### PR TITLE
Add scrollbar support with scroll event handling

### DIFF
--- a/examples/MikoApp1.Console/Program.cs
+++ b/examples/MikoApp1.Console/Program.cs
@@ -1,4 +1,4 @@
-using Miko.Core;
+﻿using Miko.Core;
 using Miko.Examples.Bootstrap;
 using Miko.Examples.Bootstrap.Examples;
 using Miko.Fonts;
@@ -7,7 +7,7 @@ using MikoApp1;
 using SkiaSharp;
 
 int width = 1024;
-int height = 768;
+int height = 700;
 
 // Register fonts from embedded resources
 using var fontStream = typeof(App).Assembly.GetManifestResourceStream("MikoApp1.Resources.Fonts.bootstrap-icons.woff2");

--- a/examples/MikoApp1.WinUI/MikoApp1.WinUI.csproj
+++ b/examples/MikoApp1.WinUI/MikoApp1.WinUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/examples/MikoApp1/App.cs
+++ b/examples/MikoApp1/App.cs
@@ -23,7 +23,11 @@ public static class App
         });
         builder.UseRouter(typeof(ButtonExample).Assembly);
         builder.UseDefaultLayout(typeof(MainLayout));
-        builder.UseLogging(logging => logging.AddConsole());
+        builder.UseLogging(logging =>
+        {
+            logging.AddConsole();
+            logging.SetMinimumLevel(LogLevel.Trace);
+        });
         return builder.Build();
     }
 }

--- a/examples/MikoApp1/MainLayout.cs
+++ b/examples/MikoApp1/MainLayout.cs
@@ -1,4 +1,4 @@
-using Miko.Common;
+﻿using Miko.Common;
 using Miko.Components;
 using Miko.Core;
 using Miko.Core.DomElements;
@@ -88,6 +88,7 @@ public class MainLayout : LayoutComponentBase
                     {
                         FlexGrow = 1,
                         Padding = Length.Px(16),
+                        OverflowY = Overflow.Scroll,
                     }
                 },
                 new()

--- a/src/Miko/Common/Enums.cs
+++ b/src/Miko/Common/Enums.cs
@@ -127,3 +127,14 @@ public enum InputType
     Radio,
     Range
 }
+
+/// <summary>
+/// 溢出处理方式
+/// </summary>
+public enum Overflow
+{
+    Visible,
+    Hidden,
+    Scroll,
+    Auto
+}

--- a/src/Miko/Core/Element.cs
+++ b/src/Miko/Core/Element.cs
@@ -39,6 +39,7 @@ public abstract class Element
     public MikoEventHandler<FocusEventArgs>? OnFocus { get; set; }
     public MikoEventHandler<FocusEventArgs>? OnBlur { get; set; }
     public MikoEventHandler<ChangeEventArgs>? OnChange { get; set; }
+    public MikoEventHandler<ScrollEventArgs>? OnScroll { get; set; }
 
     /// <summary>
     /// 添加事件监听器

--- a/src/Miko/Core/MikoEngine.cs
+++ b/src/Miko/Core/MikoEngine.cs
@@ -1,6 +1,8 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Miko.Common;
 using Miko.Core;
+using Miko.Events;
 using Miko.Layout;
 using Miko.Rendering;
 using Miko.Styling;
@@ -13,6 +15,7 @@ public class MikoEngine
     private readonly LayoutEngine _layoutEngine = new();
     private readonly RenderEngine _renderEngine = new();
     private readonly DirtyRegionManager _dirtyManager = new();
+    private readonly EventDispatcher _eventDispatcher = new();
     private List<StyleSheet> _styleSheets = new();
     private ILogger _logger = NullLogger.Instance;
 
@@ -48,7 +51,9 @@ public class MikoEngine
         {
             var dirtyRegions = _dirtyManager.GetDirtyRegions();
             _logger.LogDebug("Incremental update, {Count} dirty regions", dirtyRegions.Count);
+            var oldLayout = _currentLayout;
             _currentLayout = _layoutEngine.Layout(_root, _styleSheets, _viewportWidth, _viewportHeight);
+            RestoreScrollState(oldLayout, _currentLayout);
             _renderEngine.RenderDirty(_currentLayout, dirtyRegions);
         }
     }
@@ -58,8 +63,9 @@ public class MikoEngine
         if (_root == null) throw new InvalidOperationException("Engine not initialized. Call Initialize first.");
 
         _renderEngine.SetCanvas(canvas);
-        _logger.LogDebug("Full render pass");
+        var oldLayout = _currentLayout;
         _currentLayout = _layoutEngine.Layout(_root, _styleSheets, _viewportWidth, _viewportHeight);
+        RestoreScrollState(oldLayout, _currentLayout);
         _renderEngine.Render(_currentLayout);
         _dirtyManager.Clear();
     }
@@ -145,5 +151,165 @@ public class MikoEngine
             child.SetParent(element);
             EnsureParentReferences(child);
         }
+    }
+
+    /// <summary>
+    /// 将旧布局树的滚动状态恢复到新布局树
+    /// </summary>
+    private static void RestoreScrollState(LayoutBox? oldRoot, LayoutBox? newRoot)
+    {
+        if (oldRoot == null || newRoot == null) return;
+        RestoreScrollStateRecursive(oldRoot, newRoot);
+    }
+
+    private static void RestoreScrollStateRecursive(LayoutBox oldBox, LayoutBox newBox)
+    {
+        if (oldBox.Element == newBox.Element)
+        {
+            newBox.ScrollTop = oldBox.ScrollTop;
+            newBox.ScrollLeft = oldBox.ScrollLeft;
+        }
+
+        foreach (var newChild in newBox.Children)
+        {
+            foreach (var oldChild in oldBox.Children)
+            {
+                if (oldChild.Element == newChild.Element)
+                {
+                    RestoreScrollStateRecursive(oldChild, newChild);
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// 处理滚动事件，更新滚动位置
+    /// </summary>
+    public bool ScrollBy(float x, float y, float deltaX, float deltaY)
+    {
+        if (_currentLayout == null)
+        {
+            _logger.LogTrace("ScrollBy: no layout available");
+            return false;
+        }
+
+        var targetElement = HitTest(x, y);
+        if (targetElement == null)
+        {
+            _logger.LogTrace("ScrollBy: no element at ({X}, {Y})", x, y);
+            return false;
+        }
+
+        _logger.LogTrace("ScrollBy: hit element <{Tag} id=\"{Id}\" class=\"{Class}\"> at ({X}, {Y}), delta=({DeltaX}, {DeltaY})",
+            targetElement.TagName, targetElement.Id, targetElement.Class, x, y, deltaX, deltaY);
+
+        var scrollableBox = FindScrollableBox(targetElement, deltaX, deltaY);
+        if (scrollableBox == null)
+        {
+            _logger.LogTrace("ScrollBy: no scrollable ancestor found for <{Tag} id=\"{Id}\" class=\"{Class}\">",
+                targetElement.TagName, targetElement.Id, targetElement.Class);
+            return false;
+        }
+
+        _logger.LogTrace("ScrollBy: found scrollable <{Tag} id=\"{Id}\" class=\"{Class}\">, overflowY={OverflowY}, scrollableHeight={ScrollableH}, paddingBoxHeight={PaddingH}",
+            scrollableBox.Element.TagName, scrollableBox.Element.Id, scrollableBox.Element.Class,
+            scrollableBox.ComputedStyle.OverflowY, scrollableBox.ScrollableContentHeight, scrollableBox.BoxModel.PaddingBox.Height);
+
+        float oldScrollLeft = scrollableBox.ScrollLeft;
+        float oldScrollTop = scrollableBox.ScrollTop;
+
+        // 更新垂直滚动
+        if (Math.Abs(deltaY) > 0.01f && scrollableBox.HasVerticalScrollbar)
+        {
+            float maxScrollTop = scrollableBox.ScrollableContentHeight - scrollableBox.BoxModel.PaddingBox.Height
+                + (scrollableBox.HasHorizontalScrollbar ? LayoutBox.ScrollbarThickness : 0);
+            maxScrollTop = Math.Max(0, maxScrollTop);
+            scrollableBox.ScrollTop = Math.Clamp(scrollableBox.ScrollTop + deltaY, 0, maxScrollTop);
+            _logger.LogTrace("ScrollBy: vertical scroll {Old} -> {New} (max={Max})", oldScrollTop, scrollableBox.ScrollTop, maxScrollTop);
+        }
+
+        // 更新水平滚动
+        if (Math.Abs(deltaX) > 0.01f && scrollableBox.HasHorizontalScrollbar)
+        {
+            float maxScrollLeft = scrollableBox.ScrollableContentWidth - scrollableBox.BoxModel.PaddingBox.Width
+                + (scrollableBox.HasVerticalScrollbar ? LayoutBox.ScrollbarThickness : 0);
+            maxScrollLeft = Math.Max(0, maxScrollLeft);
+            scrollableBox.ScrollLeft = Math.Clamp(scrollableBox.ScrollLeft + deltaX, 0, maxScrollLeft);
+            _logger.LogTrace("ScrollBy: horizontal scroll {Old} -> {New} (max={Max})", oldScrollLeft, scrollableBox.ScrollLeft, maxScrollLeft);
+        }
+
+        bool scrolled = Math.Abs(scrollableBox.ScrollLeft - oldScrollLeft) > 0.01f ||
+                        Math.Abs(scrollableBox.ScrollTop - oldScrollTop) > 0.01f;
+
+        if (scrolled)
+        {
+            // 分发滚动事件
+            var scrollArgs = new ScrollEventArgs
+            {
+                Target = scrollableBox.Element,
+                DeltaX = scrollableBox.ScrollLeft - oldScrollLeft,
+                DeltaY = scrollableBox.ScrollTop - oldScrollTop,
+                ScrollLeft = scrollableBox.ScrollLeft,
+                ScrollTop = scrollableBox.ScrollTop,
+                Bubbles = true
+            };
+            _eventDispatcher.Dispatch(scrollableBox.Element, EventTypes.Scroll, scrollArgs);
+
+            InvalidateElement(scrollableBox.Element);
+            _logger.LogTrace("ScrollBy: scrolled, new position=({ScrollLeft}, {ScrollTop})", scrollableBox.ScrollLeft, scrollableBox.ScrollTop);
+        }
+        else
+        {
+            _logger.LogTrace("ScrollBy: no actual scroll change (already at boundary)");
+        }
+
+        return scrolled;
+    }
+
+    /// <summary>
+    /// 从目标元素向上查找最近的可滚动容器
+    /// </summary>
+    private LayoutBox? FindScrollableBox(Element target, float deltaX, float deltaY)
+    {
+        if (_currentLayout == null) return null;
+
+        var current = target;
+        while (current != null)
+        {
+            var box = FindLayoutBoxForElement(_currentLayout, current);
+            if (box != null)
+            {
+                bool canScrollY = Math.Abs(deltaY) > 0.01f &&
+                    (box.ComputedStyle.OverflowY == Overflow.Auto || box.ComputedStyle.OverflowY == Overflow.Scroll) &&
+                    box.ScrollableContentHeight > box.BoxModel.PaddingBox.Height;
+
+                bool canScrollX = Math.Abs(deltaX) > 0.01f &&
+                    (box.ComputedStyle.OverflowX == Overflow.Auto || box.ComputedStyle.OverflowX == Overflow.Scroll) &&
+                    box.ScrollableContentWidth > box.BoxModel.PaddingBox.Width;
+
+                if (canScrollY || canScrollX)
+                    return box;
+            }
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// 在布局树中查找对应元素的 LayoutBox
+    /// </summary>
+    private static LayoutBox? FindLayoutBoxForElement(LayoutBox box, Element element)
+    {
+        if (box.Element == element) return box;
+
+        foreach (var child in box.Children)
+        {
+            var found = FindLayoutBoxForElement(child, element);
+            if (found != null) return found;
+        }
+
+        return null;
     }
 }

--- a/src/Miko/Events/EventArgs.cs
+++ b/src/Miko/Events/EventArgs.cs
@@ -100,3 +100,29 @@ public enum MouseButton
     Middle,
     Right
 }
+
+/// <summary>
+/// 滚动事件参数
+/// </summary>
+public class ScrollEventArgs : MikoEventArgs
+{
+    /// <summary>
+    /// 水平滚动增量（像素）
+    /// </summary>
+    public float DeltaX { get; init; }
+
+    /// <summary>
+    /// 垂直滚动增量（像素）
+    /// </summary>
+    public float DeltaY { get; init; }
+
+    /// <summary>
+    /// 当前滚动位置 X
+    /// </summary>
+    public float ScrollLeft { get; init; }
+
+    /// <summary>
+    /// 当前滚动位置 Y
+    /// </summary>
+    public float ScrollTop { get; init; }
+}

--- a/src/Miko/Events/EventDispatcher.cs
+++ b/src/Miko/Events/EventDispatcher.cs
@@ -98,6 +98,9 @@ public class EventDispatcher
             case EventTypes.Change when args is ChangeEventArgs changeArgs:
                 element.OnChange?.Invoke(changeArgs);
                 break;
+            case EventTypes.Scroll when args is ScrollEventArgs scrollArgs:
+                element.OnScroll?.Invoke(scrollArgs);
+                break;
         }
     }
 }

--- a/src/Miko/Events/EventTypes.cs
+++ b/src/Miko/Events/EventTypes.cs
@@ -13,4 +13,5 @@ public static class EventTypes
     public const string Focus = "focus";
     public const string Blur = "blur";
     public const string Change = "change";
+    public const string Scroll = "scroll";
 }

--- a/src/Miko/Hosting/MikoApp.cs
+++ b/src/Miko/Hosting/MikoApp.cs
@@ -110,6 +110,7 @@ public class MikoApp
         {
             mouse.MouseDown += OnMouseDown;
             mouse.MouseUp += OnMouseUp;
+            mouse.Scroll += OnMouseScroll;
         }
 
         using var tempSurface = SKSurface.Create(new SKImageInfo(_width, _height));
@@ -186,6 +187,15 @@ public class MikoApp
         };
 
         _eventDispatcher.Dispatch(target, EventTypes.Click, args);
+    }
+
+    private void OnMouseScroll(IMouse mouse, ScrollWheel scrollWheel)
+    {
+        float deltaY = scrollWheel.Y * -40f;
+        float deltaX = scrollWheel.X * -40f;
+        _logger.LogTrace("OnMouseScroll: wheel=({WheelX}, {WheelY}), pos=({PosX}, {PosY}), delta=({DeltaX}, {DeltaY})",
+            scrollWheel.X, scrollWheel.Y, mouse.Position.X, mouse.Position.Y, deltaX, deltaY);
+        _engine.ScrollBy(mouse.Position.X, mouse.Position.Y, deltaX, deltaY);
     }
 
     private void OnClose()

--- a/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
@@ -78,6 +78,11 @@ public class BlockLayout
             contentWidth = Math.Min(contentWidth, style.MaxWidth.ToPixels(containerWidth));
         }
 
+        // 判断是否需要为滚动条预留空间（Classic 模式占用布局）
+        bool needsVerticalScrollbar = style.OverflowY == Overflow.Scroll;
+        float scrollbarReservedWidth = needsVerticalScrollbar ? LayoutBox.ScrollbarThickness : 0;
+        float childAvailableWidth = contentWidth - scrollbarReservedWidth;
+
         // 3. 计算内容区域的位置
         float contentX = x + box.BoxModel.Margin.Left + box.BoxModel.Border.Left + box.BoxModel.Padding.Left;
         float contentY = y + box.BoxModel.Margin.Top + box.BoxModel.Border.Top + box.BoxModel.Padding.Top;
@@ -116,7 +121,7 @@ public class BlockLayout
             else
             {
                 // Block 子元素垂直堆叠
-                var childConstraints = new LayoutConstraints(contentWidth, null);
+                var childConstraints = new LayoutConstraints(childAvailableWidth, null);
                 LayoutChild(child, childConstraints, contentX, currentY);
 
                 currentY = child.BoxModel.MarginBox.Bottom;
@@ -125,11 +130,24 @@ public class BlockLayout
             }
         }
 
+        // 记录子元素实际占用的总高度
+        float childrenTotalHeight = currentY - contentY;
+
         // 5. 计算 height
         float contentHeight;
         if (!style.Height.IsAuto)
         {
             contentHeight = style.Height.ToPixels(constraints.AvailableHeight ?? 0);
+        }
+        else if (constraints.AvailableHeight.HasValue &&
+                 (style.OverflowY == Overflow.Auto || style.OverflowY == Overflow.Scroll || style.OverflowY == Overflow.Hidden))
+        {
+            // 当有可用高度约束（如来自 flex 容器）且设置了 overflow 时，使用约束高度
+            contentHeight = constraints.AvailableHeight.Value
+                - box.BoxModel.Margin.Vertical
+                - box.BoxModel.Border.Vertical
+                - box.BoxModel.Padding.Vertical;
+            contentHeight = Math.Max(0, contentHeight);
         }
         else
         {
@@ -164,6 +182,62 @@ public class BlockLayout
 
         // 6. 设置内容区域
         box.BoxModel.Content = new RectF(contentX, contentY, contentWidth, contentHeight);
+
+        // 7. 记录可滚动内容尺寸
+        box.ScrollableContentWidth = maxChildWidth;
+        box.ScrollableContentHeight = childrenTotalHeight;
+
+        // 8. 如果 overflow-y 是 auto 且内容溢出，需要为滚动条预留空间并重新布局
+        if (style.OverflowY == Overflow.Auto && !needsVerticalScrollbar &&
+            childrenTotalHeight > contentHeight && contentHeight > 0)
+        {
+            scrollbarReservedWidth = LayoutBox.ScrollbarThickness;
+            childAvailableWidth = contentWidth - scrollbarReservedWidth;
+            RelayoutChildren(box, childAvailableWidth, contentX, contentY);
+        }
+    }
+
+    private void RelayoutChildren(LayoutBox box, float childAvailableWidth, float contentX, float contentY)
+    {
+        float currentY = contentY;
+        float maxChildWidth = 0;
+
+        int i = 0;
+        while (i < box.Children.Count)
+        {
+            var child = box.Children[i];
+
+            if (IsInlineOrInlineBlock(child))
+            {
+                float lineX = contentX;
+                float lineHeight = 0;
+
+                while (i < box.Children.Count && IsInlineOrInlineBlock(box.Children[i]))
+                {
+                    var inlineChild = box.Children[i];
+                    var childConstraints = new LayoutConstraints(null, null);
+                    LayoutChild(inlineChild, childConstraints, lineX, currentY);
+
+                    lineX = inlineChild.BoxModel.MarginBox.Right;
+                    lineHeight = Math.Max(lineHeight, inlineChild.BoxModel.MarginBox.Height);
+                    maxChildWidth = Math.Max(maxChildWidth, lineX - contentX);
+                    i++;
+                }
+                currentY += lineHeight;
+            }
+            else
+            {
+                var childConstraints = new LayoutConstraints(childAvailableWidth, null);
+                LayoutChild(child, childConstraints, contentX, currentY);
+
+                currentY = child.BoxModel.MarginBox.Bottom;
+                maxChildWidth = Math.Max(maxChildWidth, child.BoxModel.MarginBox.Width);
+                i++;
+            }
+        }
+
+        box.ScrollableContentWidth = maxChildWidth;
+        box.ScrollableContentHeight = currentY - contentY;
     }
 
     private void LayoutChild(LayoutBox child, LayoutConstraints constraints, float x, float y)

--- a/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
@@ -118,6 +118,28 @@ public class FlexLayout
         }
 
         box.BoxModel.Content = new RectF(contentX, contentY, contentWidth, contentHeight);
+
+        // 记录可滚动内容尺寸
+        if (isRow)
+        {
+            float totalChildWidth = 0;
+            foreach (var child in box.Children)
+            {
+                totalChildWidth += child.BoxModel.MarginBox.Width;
+            }
+            box.ScrollableContentWidth = totalChildWidth;
+            box.ScrollableContentHeight = maxCrossSize;
+        }
+        else
+        {
+            float totalChildHeight = 0;
+            foreach (var child in box.Children)
+            {
+                totalChildHeight += child.BoxModel.MarginBox.Height;
+            }
+            box.ScrollableContentWidth = maxCrossSize;
+            box.ScrollableContentHeight = totalChildHeight;
+        }
     }
 
     private void LayoutRowDirection(LayoutBox box, float contentX, float contentY,
@@ -135,14 +157,28 @@ public class FlexLayout
             float flexBasis;
             bool usedAutoSize = false;
 
-            // 确定 flex-basis
+            // 确定 flex-basis（统一转换为 outer size 以便正确计算剩余空间）
             if (!childStyle.FlexBasis.IsAuto)
             {
-                flexBasis = childStyle.FlexBasis.ToPixels(contentWidth);
+                float basisContentWidth = childStyle.FlexBasis.ToPixels(contentWidth);
+                float outerExtra = childStyle.MarginLeft.ToPixels(contentWidth)
+                    + childStyle.MarginRight.ToPixels(contentWidth)
+                    + childStyle.BorderLeftWidth.ToPixels(contentWidth)
+                    + childStyle.BorderRightWidth.ToPixels(contentWidth)
+                    + childStyle.PaddingLeft.ToPixels(contentWidth)
+                    + childStyle.PaddingRight.ToPixels(contentWidth);
+                flexBasis = basisContentWidth + outerExtra;
             }
             else if (!childStyle.Width.IsAuto)
             {
-                flexBasis = childStyle.Width.ToPixels(contentWidth);
+                float basisContentWidth = childStyle.Width.ToPixels(contentWidth);
+                float outerExtra = childStyle.MarginLeft.ToPixels(contentWidth)
+                    + childStyle.MarginRight.ToPixels(contentWidth)
+                    + childStyle.BorderLeftWidth.ToPixels(contentWidth)
+                    + childStyle.BorderRightWidth.ToPixels(contentWidth)
+                    + childStyle.PaddingLeft.ToPixels(contentWidth)
+                    + childStyle.PaddingRight.ToPixels(contentWidth);
+                flexBasis = basisContentWidth + outerExtra;
             }
             else
             {
@@ -216,19 +252,9 @@ public class FlexLayout
                 float childPaddingLeft = childStyle.PaddingLeft.ToPixels(contentWidth);
                 float childPaddingRight = childStyle.PaddingRight.ToPixels(contentWidth);
 
-                // 计算内容宽度
-                float childContentWidth;
-                if (info.UsedAutoSize)
-                {
-                    // 从 margin box 计算 content width
-                    childContentWidth = info.FinalSize - childMarginLeft - childMarginRight
-                        - childBorderLeftWidth - childBorderRightWidth - childPaddingLeft - childPaddingRight;
-                }
-                else
-                {
-                    // flex-basis/width 就是 content width
-                    childContentWidth = info.FinalSize;
-                }
+                // FinalSize 统一代表 outer (margin box) 尺寸，需要减去 margin/border/padding 得到 content width
+                float childContentWidth = info.FinalSize - childMarginLeft - childMarginRight
+                    - childBorderLeftWidth - childBorderRightWidth - childPaddingLeft - childPaddingRight;
                 childContentWidth = Math.Max(0, childContentWidth);
 
                 // 使用计算出的宽度约束重新布局
@@ -283,14 +309,28 @@ public class FlexLayout
             float flexBasis;
             bool usedAutoSize = false;
 
-            // 确定 flex-basis（列方向使用高度）
+            // 确定 flex-basis（列方向使用高度，统一转换为 outer size）
             if (!childStyle.FlexBasis.IsAuto)
             {
-                flexBasis = childStyle.FlexBasis.ToPixels(contentHeight);
+                float basisContentHeight = childStyle.FlexBasis.ToPixels(contentHeight);
+                float outerExtra = childStyle.MarginTop.ToPixels(contentWidth)
+                    + childStyle.MarginBottom.ToPixels(contentWidth)
+                    + childStyle.BorderTopWidth.ToPixels(contentWidth)
+                    + childStyle.BorderBottomWidth.ToPixels(contentWidth)
+                    + childStyle.PaddingTop.ToPixels(contentWidth)
+                    + childStyle.PaddingBottom.ToPixels(contentWidth);
+                flexBasis = basisContentHeight + outerExtra;
             }
             else if (!childStyle.Height.IsAuto)
             {
-                flexBasis = childStyle.Height.ToPixels(contentHeight);
+                float basisContentHeight = childStyle.Height.ToPixels(contentHeight);
+                float outerExtra = childStyle.MarginTop.ToPixels(contentWidth)
+                    + childStyle.MarginBottom.ToPixels(contentWidth)
+                    + childStyle.BorderTopWidth.ToPixels(contentWidth)
+                    + childStyle.BorderBottomWidth.ToPixels(contentWidth)
+                    + childStyle.PaddingTop.ToPixels(contentWidth)
+                    + childStyle.PaddingBottom.ToPixels(contentWidth);
+                flexBasis = basisContentHeight + outerExtra;
             }
             else
             {
@@ -365,19 +405,9 @@ public class FlexLayout
                 float childPaddingTop = childStyle.PaddingTop.ToPixels(contentWidth);
                 float childPaddingBottom = childStyle.PaddingBottom.ToPixels(contentWidth);
 
-                // 计算内容高度
-                float childContentHeight;
-                if (info.UsedAutoSize)
-                {
-                    // 从 margin box 计算 content height
-                    childContentHeight = info.FinalSize - childMarginTop - childMarginBottom
-                        - childBorderTopWidth - childBorderBottomWidth - childPaddingTop - childPaddingBottom;
-                }
-                else
-                {
-                    // flex-basis/height 就是 content height
-                    childContentHeight = info.FinalSize;
-                }
+                // FinalSize 统一代表 outer size，需要减去 margin/border/padding 得到 content height
+                float childContentHeight = info.FinalSize - childMarginTop - childMarginBottom
+                    - childBorderTopWidth - childBorderBottomWidth - childPaddingTop - childPaddingBottom;
                 childContentHeight = Math.Max(0, childContentHeight);
 
                 // 使用计算出的高度约束重新布局

--- a/src/Miko/Layout/LayoutBox.cs
+++ b/src/Miko/Layout/LayoutBox.cs
@@ -21,5 +21,22 @@ public class LayoutBox
     // 布局类型
     public LayoutType Type { get; set; }
 
+    // 滚动状态
+    public float ScrollTop { get; set; }
+    public float ScrollLeft { get; set; }
+
+    // 内容实际尺寸（可能超出 Content 区域）
+    public float ScrollableContentWidth { get; set; }
+    public float ScrollableContentHeight { get; set; }
+
+    // 是否需要显示滚动条
+    public bool HasVerticalScrollbar => ComputedStyle.OverflowY == Overflow.Scroll ||
+        (ComputedStyle.OverflowY == Overflow.Auto && ScrollableContentHeight > BoxModel.Content.Height);
+    public bool HasHorizontalScrollbar => ComputedStyle.OverflowX == Overflow.Scroll ||
+        (ComputedStyle.OverflowX == Overflow.Auto && ScrollableContentWidth > BoxModel.Content.Width);
+
+    // Classic 滚动条宽度（占用布局空间）
+    public const float ScrollbarThickness = 17f;
+
     public override string ToString() => $"LayoutBox({Element.TagName}, Type: {Type})";
 }

--- a/src/Miko/Rendering/Painter.cs
+++ b/src/Miko/Rendering/Painter.cs
@@ -637,4 +637,92 @@ public class Painter
         path.AddRoundRect(roundRect);
         return path;
     }
+
+    /// <summary>
+    /// 绘制垂直滚动条
+    /// </summary>
+    public void DrawVerticalScrollbar(RectF trackRect, float scrollTop, float contentHeight, float viewportHeight)
+    {
+        if (viewportHeight <= 0 || contentHeight <= viewportHeight) return;
+
+        // 绘制轨道
+        using var trackPaint = new SKPaint
+        {
+            Color = new SKColor(0xF1, 0xF1, 0xF1),
+            Style = SKPaintStyle.Fill
+        };
+        _canvas.DrawRect(trackRect.ToSKRect(), trackPaint);
+
+        // 计算滑块尺寸和位置
+        float thumbRatio = viewportHeight / contentHeight;
+        float thumbHeight = Math.Max(trackRect.Height * thumbRatio, 20f);
+        float scrollableTrack = trackRect.Height - thumbHeight;
+        float maxScroll = contentHeight - viewportHeight;
+        float thumbY = trackRect.Top + (maxScroll > 0 ? (scrollTop / maxScroll) * scrollableTrack : 0);
+
+        // 绘制滑块
+        var thumbRect = new SKRect(
+            trackRect.Left + 2,
+            thumbY + 2,
+            trackRect.Right - 2,
+            thumbY + thumbHeight - 2);
+
+        using var thumbPaint = new SKPaint
+        {
+            Color = new SKColor(0xC1, 0xC1, 0xC1),
+            Style = SKPaintStyle.Fill,
+            IsAntialias = true
+        };
+
+        float radius = (trackRect.Width - 4) / 2;
+        _canvas.DrawRoundRect(thumbRect, radius, radius, thumbPaint);
+    }
+
+    /// <summary>
+    /// 绘制水平滚动条
+    /// </summary>
+    public void DrawHorizontalScrollbar(RectF trackRect, float scrollLeft, float contentWidth, float viewportWidth)
+    {
+        if (viewportWidth <= 0 || contentWidth <= viewportWidth) return;
+
+        // 绘制轨道
+        using var trackPaint = new SKPaint
+        {
+            Color = new SKColor(0xF1, 0xF1, 0xF1),
+            Style = SKPaintStyle.Fill
+        };
+        _canvas.DrawRect(trackRect.ToSKRect(), trackPaint);
+
+        // 计算滑块尺寸和位置
+        float thumbRatio = viewportWidth / contentWidth;
+        float thumbWidth = Math.Max(trackRect.Width * thumbRatio, 20f);
+        float scrollableTrack = trackRect.Width - thumbWidth;
+        float maxScroll = contentWidth - viewportWidth;
+        float thumbX = trackRect.Left + (maxScroll > 0 ? (scrollLeft / maxScroll) * scrollableTrack : 0);
+
+        // 绘制滑块
+        var thumbRect = new SKRect(
+            thumbX + 2,
+            trackRect.Top + 2,
+            thumbX + thumbWidth - 2,
+            trackRect.Bottom - 2);
+
+        using var thumbPaint = new SKPaint
+        {
+            Color = new SKColor(0xC1, 0xC1, 0xC1),
+            Style = SKPaintStyle.Fill,
+            IsAntialias = true
+        };
+
+        float radius = (trackRect.Height - 4) / 2;
+        _canvas.DrawRoundRect(thumbRect, radius, radius, thumbPaint);
+    }
+
+    /// <summary>
+    /// 平移画布
+    /// </summary>
+    public void Translate(float dx, float dy)
+    {
+        _canvas.Translate(dx, dy);
+    }
 }

--- a/src/Miko/Rendering/RenderEngine.cs
+++ b/src/Miko/Rendering/RenderEngine.cs
@@ -83,13 +83,99 @@ public class RenderEngine
         // 特殊处理：SelectElement 在未展开时不渲染子元素（与浏览器行为一致）
         if (box.Element is SelectElement selectElement && !selectElement.IsOpen)
         {
-            // 下拉框关闭时，不渲染 OptionElement 子元素
             return;
         }
+
+        // 处理 overflow 裁剪和滚动
+        bool hasOverflow = box.ComputedStyle.OverflowX != Overflow.Visible ||
+                           box.ComputedStyle.OverflowY != Overflow.Visible;
+
+        if (hasOverflow && box.Children.Count > 0)
+        {
+            RenderChildrenWithOverflow(box);
+        }
+        else
+        {
+            foreach (var child in box.Children)
+            {
+                RenderBox(child);
+            }
+        }
+
+        // 5. 绘制滚动条（在裁剪区域之外）
+        RenderScrollbars(box);
+    }
+
+    /// <summary>
+    /// 带溢出裁剪的子元素渲染
+    /// </summary>
+    private void RenderChildrenWithOverflow(LayoutBox box)
+    {
+        if (_painter == null) return;
+
+        var paddingBox = box.BoxModel.PaddingBox;
+        float clipWidth = paddingBox.Width;
+        float clipHeight = paddingBox.Height;
+
+        // Classic 模式下，滚动条占用 padding box 空间
+        if (box.HasVerticalScrollbar)
+        {
+            clipWidth -= LayoutBox.ScrollbarThickness;
+        }
+        if (box.HasHorizontalScrollbar)
+        {
+            clipHeight -= LayoutBox.ScrollbarThickness;
+        }
+
+        var clipRect = new RectF(paddingBox.X, paddingBox.Y, clipWidth, clipHeight);
+
+        _painter.Save();
+        _painter.ClipRect(clipRect);
+        _painter.Translate(-box.ScrollLeft, -box.ScrollTop);
 
         foreach (var child in box.Children)
         {
             RenderBox(child);
+        }
+
+        _painter.Restore();
+    }
+
+    /// <summary>
+    /// 渲染滚动条
+    /// </summary>
+    private void RenderScrollbars(LayoutBox box)
+    {
+        if (_painter == null) return;
+
+        var paddingBox = box.BoxModel.PaddingBox;
+        bool hasVScrollbar = box.HasVerticalScrollbar;
+        bool hasHScrollbar = box.HasHorizontalScrollbar;
+
+        if (hasVScrollbar)
+        {
+            float trackX = paddingBox.Right - LayoutBox.ScrollbarThickness;
+            float trackHeight = paddingBox.Height - (hasHScrollbar ? LayoutBox.ScrollbarThickness : 0);
+            var trackRect = new RectF(trackX, paddingBox.Y, LayoutBox.ScrollbarThickness, trackHeight);
+
+            _painter.DrawVerticalScrollbar(
+                trackRect,
+                box.ScrollTop,
+                box.ScrollableContentHeight,
+                trackHeight);
+        }
+
+        if (hasHScrollbar)
+        {
+            float trackY = paddingBox.Bottom - LayoutBox.ScrollbarThickness;
+            float trackWidth = paddingBox.Width - (hasVScrollbar ? LayoutBox.ScrollbarThickness : 0);
+            var trackRect = new RectF(paddingBox.X, trackY, trackWidth, LayoutBox.ScrollbarThickness);
+
+            _painter.DrawHorizontalScrollbar(
+                trackRect,
+                box.ScrollLeft,
+                box.ScrollableContentWidth,
+                trackWidth);
         }
     }
 
@@ -137,7 +223,6 @@ public class RenderEngine
 
         var style = box.ComputedStyle;
 
-        // 检查是否有任何可见边框
         bool hasVisibleBorder =
             style.ComputedBorderTop.IsVisible ||
             style.ComputedBorderRight.IsVisible ||
@@ -249,7 +334,6 @@ public class RenderEngine
                 break;
 
             case InputType.Password:
-                // 绘制密码圆点
                 if (!string.IsNullOrEmpty(inputElement.Value))
                 {
                     _painter.DrawPasswordText(
@@ -261,7 +345,6 @@ public class RenderEngine
                 }
                 else if (!string.IsNullOrEmpty(inputElement.Placeholder))
                 {
-                    // 绘制占位符
                     _painter.DrawText(
                         inputElement.Placeholder,
                         contentRect,
@@ -276,7 +359,6 @@ public class RenderEngine
 
             case InputType.Text:
             default:
-                // 绘制文本或占位符
                 if (!string.IsNullOrEmpty(inputElement.Value))
                 {
                     _painter.DrawText(
@@ -315,7 +397,6 @@ public class RenderEngine
         var style = box.ComputedStyle;
         var borderBox = box.BoxModel.BorderBox;
 
-        // 绘制select控件（不绘制背景和边框，因为RenderBackground和RenderBorder已经处理）
         _painter.DrawSelect(
             borderBox,
             selectElement.GetDisplayText(),
@@ -323,11 +404,10 @@ public class RenderEngine
             style.BorderTopColor,
             style.BackgroundColor,
             style.Color,
-            Color.Gray,  // Arrow color
+            Color.Gray,
             style.FontSize.Value
         );
 
-        // 如果下拉框展开，绘制选项列表
         if (selectElement.IsOpen)
         {
             RenderSelectDropdown(box, selectElement);
@@ -344,7 +424,6 @@ public class RenderEngine
         var style = box.ComputedStyle;
         var borderBox = box.BoxModel.BorderBox;
 
-        // 构建选项列表
         var options = new List<(string text, bool isSelected, bool isDisabled, bool isGroupLabel)>();
         var allOptions = selectElement.GetAllOptions();
         int optionIndex = 0;
@@ -353,10 +432,8 @@ public class RenderEngine
         {
             if (child is OptGroupElement optGroup)
             {
-                // 添加分组标签
                 options.Add((optGroup.Label ?? string.Empty, false, false, true));
 
-                // 添加分组中的选项
                 foreach (var groupChild in optGroup.Children)
                 {
                     if (groupChild is OptionElement option)
@@ -377,7 +454,6 @@ public class RenderEngine
             }
         }
 
-        // 计算下拉列表位置和大小
         float optionHeight = style.FontSize.Value + 8;
         float dropdownHeight = options.Count * optionHeight;
         var dropdownRect = new RectF(
@@ -387,17 +463,16 @@ public class RenderEngine
             dropdownHeight
         );
 
-        // 绘制下拉列表
         _painter.DrawSelectDropdown(
             dropdownRect,
             options,
-            Color.White,           // Background
-            style.BorderTopColor,  // Border
-            style.Color,           // Text
-            new Color(0, 120, 215),  // Selected background (blue)
-            Color.White,           // Selected text
-            Color.Gray,            // Disabled text
-            Color.Gray,            // Group label color
+            Color.White,
+            style.BorderTopColor,
+            style.Color,
+            new Color(0, 120, 215),
+            Color.White,
+            Color.Gray,
+            Color.Gray,
             style.FontSize.Value
         );
     }

--- a/src/Miko/Routing/RouteView.cs
+++ b/src/Miko/Routing/RouteView.cs
@@ -1,4 +1,4 @@
-using Miko.Components;
+﻿using Miko.Components;
 using Miko.Core;
 
 namespace Miko.Routing;
@@ -32,7 +32,8 @@ public class RouteView
             var layout = (LayoutComponentBase)Activator.CreateInstance(_defaultLayout)!;
             layout.NavigationManager = _navigationManager;
             layout.Body = content;
-            return layout.Build();
+            var s = layout.Build();
+            return s;
         }
 
         return content;

--- a/src/Miko/Styling/ComputedStyle.cs
+++ b/src/Miko/Styling/ComputedStyle.cs
@@ -81,6 +81,9 @@ public class ComputedStyle : Style
     public new float Opacity { get; set; } = 1.0f;
     public new int ZIndex { get; set; } = 0;
 
+    public new Overflow OverflowX { get; set; } = Overflow.Visible;
+    public new Overflow OverflowY { get; set; } = Overflow.Visible;
+
     /// <summary>
     /// 从样式对象创建计算样式
     /// </summary>
@@ -200,6 +203,9 @@ public class ComputedStyle : Style
 
             if (style.Opacity.HasValue) computed.Opacity = style.Opacity.Value;
             if (style.ZIndex.HasValue) computed.ZIndex = style.ZIndex.Value;
+
+            if (style.OverflowX.HasValue) computed.OverflowX = style.OverflowX.Value;
+            if (style.OverflowY.HasValue) computed.OverflowY = style.OverflowY.Value;
         }
 
         return computed;

--- a/src/Miko/Styling/Style.cs
+++ b/src/Miko/Styling/Style.cs
@@ -229,6 +229,22 @@ public class Style
     public float? Opacity { get; set; }
     public int? ZIndex { get; set; }
 
+    // 溢出
+    public Overflow? OverflowX { get; set; }
+    public Overflow? OverflowY { get; set; }
+
+    /// <summary>
+    /// 溢出简写属性（同时设置 X 和 Y）
+    /// </summary>
+    public Overflow Overflow
+    {
+        set
+        {
+            OverflowX = value;
+            OverflowY = value;
+        }
+    }
+
     /// <summary>
     /// 合并样式（用于级联）
     /// </summary>
@@ -300,6 +316,9 @@ public class Style
 
         Opacity ??= other.Opacity;
         ZIndex ??= other.ZIndex;
+
+        OverflowX ??= other.OverflowX;
+        OverflowY ??= other.OverflowY;
     }
 
     /// <summary>

--- a/tests/Miko.Tests/Layout/OverflowTests.cs
+++ b/tests/Miko.Tests/Layout/OverflowTests.cs
@@ -1,0 +1,312 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Layout;
+
+public class OverflowTests
+{
+    private readonly LayoutEngine _layoutEngine = new();
+
+    [Fact]
+    public void OverflowVisible_ShouldNotClipContent()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(200),
+                Height = Length.Px(100),
+                Overflow = Overflow.Visible
+            },
+            Children =
+            {
+                new DivElement
+                {
+                    Style = new Style { Height = Length.Px(300) }
+                }
+            }
+        };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet>(), 800, 600);
+
+        layout.BoxModel.Content.Height.ShouldBe(100);
+        layout.HasVerticalScrollbar.ShouldBeFalse();
+        layout.HasHorizontalScrollbar.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void OverflowScroll_ShouldAlwaysShowScrollbar()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(200),
+                Height = Length.Px(100),
+                OverflowY = Overflow.Scroll
+            },
+            Children =
+            {
+                new DivElement
+                {
+                    Style = new Style { Height = Length.Px(50) }
+                }
+            }
+        };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet>(), 800, 600);
+
+        // overflow: scroll 始终显示滚动条，即使内容没有溢出
+        layout.HasVerticalScrollbar.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OverflowAuto_ShouldShowScrollbarOnlyWhenContentOverflows()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(200),
+                Height = Length.Px(100),
+                OverflowY = Overflow.Auto
+            },
+            Children =
+            {
+                new DivElement
+                {
+                    Style = new Style { Height = Length.Px(50) }
+                }
+            }
+        };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet>(), 800, 600);
+
+        // 内容没有溢出，不显示滚动条
+        layout.HasVerticalScrollbar.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void OverflowAuto_ShouldShowScrollbarWhenContentOverflows()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(200),
+                Height = Length.Px(100),
+                OverflowY = Overflow.Auto
+            },
+            Children =
+            {
+                new DivElement
+                {
+                    Style = new Style { Height = Length.Px(300) }
+                }
+            }
+        };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet>(), 800, 600);
+
+        // 内容溢出，显示滚动条
+        layout.HasVerticalScrollbar.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OverflowScroll_ShouldReserveScrollbarWidth()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(200),
+                Height = Length.Px(100),
+                OverflowY = Overflow.Scroll
+            },
+            Children =
+            {
+                new DivElement { Id = "child" }
+            }
+        };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet>(), 800, 600);
+
+        // Classic 模式下，滚动条占用 17px 宽度
+        var child = layout.Children[0];
+        child.BoxModel.Content.Width.ShouldBe(200 - LayoutBox.ScrollbarThickness);
+    }
+
+    [Fact]
+    public void OverflowHidden_ShouldNotShowScrollbar()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(200),
+                Height = Length.Px(100),
+                OverflowY = Overflow.Hidden
+            },
+            Children =
+            {
+                new DivElement
+                {
+                    Style = new Style { Height = Length.Px(300) }
+                }
+            }
+        };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet>(), 800, 600);
+
+        // overflow: hidden 不显示滚动条
+        layout.HasVerticalScrollbar.ShouldBeFalse();
+        layout.BoxModel.Content.Height.ShouldBe(100);
+    }
+
+    [Fact]
+    public void ScrollableContentHeight_ShouldTrackActualContentSize()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(200),
+                Height = Length.Px(100),
+                OverflowY = Overflow.Auto
+            },
+            Children =
+            {
+                new DivElement { Style = new Style { Height = Length.Px(150) } },
+                new DivElement { Style = new Style { Height = Length.Px(100) } }
+            }
+        };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet>(), 800, 600);
+
+        layout.ScrollableContentHeight.ShouldBe(250);
+    }
+
+    [Fact]
+    public void OverflowX_Scroll_ShouldShowHorizontalScrollbar()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(200),
+                Height = Length.Px(100),
+                OverflowX = Overflow.Scroll
+            }
+        };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet>(), 800, 600);
+
+        layout.HasHorizontalScrollbar.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OverflowShorthand_ShouldSetBothAxes()
+    {
+        var style = new Style { Overflow = Overflow.Auto };
+
+        style.OverflowX.ShouldBe(Overflow.Auto);
+        style.OverflowY.ShouldBe(Overflow.Auto);
+    }
+
+    [Fact]
+    public void ComputedStyle_OverflowDefault_ShouldBeVisible()
+    {
+        var computed = ComputedStyle.FromStyle(null);
+
+        computed.OverflowX.ShouldBe(Overflow.Visible);
+        computed.OverflowY.ShouldBe(Overflow.Visible);
+    }
+
+    [Fact]
+    public void ComputedStyle_OverflowFromStyle_ShouldResolve()
+    {
+        var style = new Style { OverflowY = Overflow.Scroll };
+        var computed = ComputedStyle.FromStyle(style);
+
+        computed.OverflowX.ShouldBe(Overflow.Visible);
+        computed.OverflowY.ShouldBe(Overflow.Scroll);
+    }
+
+    [Fact]
+    public void StyleMerge_ShouldCascadeOverflow()
+    {
+        var style1 = new Style { OverflowY = Overflow.Auto };
+        var style2 = new Style { OverflowX = Overflow.Hidden };
+
+        style1.Merge(style2);
+
+        style1.OverflowY.ShouldBe(Overflow.Auto);
+        style1.OverflowX.ShouldBe(Overflow.Hidden);
+    }
+
+    [Fact]
+    public void ScrollbarThickness_ShouldBe17px()
+    {
+        LayoutBox.ScrollbarThickness.ShouldBe(17f);
+    }
+
+    [Fact]
+    public void FlexChild_WithOverflowAuto_ShouldShowScrollbarWhenContentOverflows()
+    {
+        // 模拟 MikoApp1 的布局结构：flex 容器 + flex-grow 子元素 + overflow-y: auto
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Flex,
+                Width = Length.Px(800),
+                Height = Length.Px(600),
+            },
+            Children =
+            {
+                new DivElement
+                {
+                    Style = new Style
+                    {
+                        Width = Length.Px(200),
+                        Height = Length.Percent(100),
+                    }
+                },
+                new DivElement
+                {
+                    Id = "main-content",
+                    Style = new Style
+                    {
+                        FlexGrow = 1,
+                        OverflowY = Overflow.Auto,
+                    },
+                    Children =
+                    {
+                        new DivElement { Style = new Style { Height = Length.Px(300) } },
+                        new DivElement { Style = new Style { Height = Length.Px(300) } },
+                        new DivElement { Style = new Style { Height = Length.Px(300) } },
+                    }
+                }
+            }
+        };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet>(), 800, 600);
+
+        var mainContent = layout.Children[1];
+        mainContent.BoxModel.Content.Height.ShouldBe(600);
+        mainContent.ScrollableContentHeight.ShouldBe(900);
+        mainContent.HasVerticalScrollbar.ShouldBeTrue();
+    }
+}

--- a/tests/Miko.Tests/Layout/PercentHeightTests.cs
+++ b/tests/Miko.Tests/Layout/PercentHeightTests.cs
@@ -1,0 +1,78 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Layout;
+
+public class PercentHeightTests
+{
+    private readonly LayoutEngine _layoutEngine = new();
+
+    [Fact]
+    public void FlexContainer_WithPercentHeight_ShouldResolveToViewportHeight()
+    {
+        var root = new DivElement
+        {
+            Class = "layout",
+            Children =
+            {
+                new DivElement { Class = "sidebar" },
+                new DivElement { Class = "main-content" }
+            }
+        };
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new()
+                    {
+                        Selector = new ClassSelector("layout"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            Width = Length.Percent(100),
+                            Height = Length.Percent(100),
+                        }
+                    },
+                    new()
+                    {
+                        Selector = new ClassSelector("sidebar"),
+                        Style = new Style
+                        {
+                            Width = Length.Px(200),
+                            Height = Length.Percent(100),
+                        }
+                    },
+                    new()
+                    {
+                        Selector = new ClassSelector("main-content"),
+                        Style = new Style
+                        {
+                            FlexGrow = 1,
+                            OverflowY = Overflow.Auto,
+                        }
+                    },
+                }
+            }
+        };
+
+        var layout = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        // 根容器的 height: 100% 应该解析为 viewport height (600px)
+        layout.BoxModel.Content.Height.ShouldBe(600);
+
+        // sidebar 的 height: 100% 应该解析为父容器的 content height (600px)
+        var sidebar = layout.Children[0];
+        sidebar.BoxModel.Content.Height.ShouldBe(600);
+
+        // main-content 应该从 flex 容器获得 600px 的高度约束
+        var mainContent = layout.Children[1];
+        mainContent.BoxModel.Content.Height.ShouldBe(600);
+    }
+}

--- a/tests/Miko.Tests/Layout/PercentWidthScrollbarTests.cs
+++ b/tests/Miko.Tests/Layout/PercentWidthScrollbarTests.cs
@@ -1,0 +1,262 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Layout;
+
+public class PercentWidthScrollbarTests
+{
+    private readonly LayoutEngine _layoutEngine = new();
+
+    [Fact]
+    public void FlexContainer_PercentWidth_ScrollbarShouldBeWithinCanvas()
+    {
+        // 模拟 MikoApp1 的布局：layout 宽度 100%，viewport 1017px
+        var root = new DivElement
+        {
+            Class = "layout",
+            Children =
+            {
+                new DivElement { Class = "sidebar" },
+                new DivElement
+                {
+                    Class = "main-content",
+                    Children =
+                    {
+                        new DivElement { Style = new Style { Height = Length.Px(300) } },
+                        new DivElement { Style = new Style { Height = Length.Px(300) } },
+                        new DivElement { Style = new Style { Height = Length.Px(300) } },
+                    }
+                }
+            }
+        };
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new()
+                    {
+                        Selector = new ClassSelector("layout"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            Width = Length.Percent(100),
+                            Height = Length.Percent(100),
+                        }
+                    },
+                    new()
+                    {
+                        Selector = new ClassSelector("sidebar"),
+                        Style = new Style
+                        {
+                            Width = Length.Px(200),
+                            Height = Length.Percent(100),
+                            Padding = Length.Px(16),
+                        }
+                    },
+                    new()
+                    {
+                        Selector = new ClassSelector("main-content"),
+                        Style = new Style
+                        {
+                            FlexGrow = 1,
+                            Padding = Length.Px(16),
+                            OverflowY = Overflow.Scroll,
+                        }
+                    },
+                }
+            }
+        };
+
+        float viewportWidth = 1017;
+        float viewportHeight = 700;
+
+        var layout = _layoutEngine.Layout(root, styleSheets, viewportWidth, viewportHeight);
+
+        // 根容器宽度应该等于 viewport 宽度
+        layout.BoxModel.Content.Width.ShouldBe(viewportWidth);
+
+        var sidebar = layout.Children[0];
+        var mainContent = layout.Children[1];
+
+        // main-content 应该有滚动条
+        mainContent.HasVerticalScrollbar.ShouldBeTrue();
+
+        // 滚动条右边界应该紧贴 padding box 右边缘（即 border box 右边缘 - border width）
+        var paddingBox = mainContent.BoxModel.PaddingBox;
+        paddingBox.Right.ShouldBe(viewportWidth,
+            $"Scrollbar right edge (paddingBox.Right={paddingBox.Right}) should align with canvas right ({viewportWidth})");
+
+        // main-content 的 border box 右边界不应超出画布
+        mainContent.BoxModel.BorderBox.Right.ShouldBeLessThanOrEqualTo(viewportWidth,
+            $"MainContent border box right ({mainContent.BoxModel.BorderBox.Right}) exceeds canvas width ({viewportWidth})");
+    }
+
+    [Fact]
+    public void Diagnostic_FlexContainer_PercentWidth_LayoutValues()
+    {
+        var root = new DivElement
+        {
+            Class = "layout",
+            Children =
+            {
+                new DivElement { Class = "sidebar" },
+                new DivElement
+                {
+                    Class = "main-content",
+                    Children =
+                    {
+                        new DivElement { Style = new Style { Height = Length.Px(300) } },
+                        new DivElement { Style = new Style { Height = Length.Px(300) } },
+                        new DivElement { Style = new Style { Height = Length.Px(300) } },
+                    }
+                }
+            }
+        };
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new()
+                    {
+                        Selector = new ClassSelector("layout"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            Width = Length.Percent(100),
+                            Height = Length.Percent(100),
+                        }
+                    },
+                    new()
+                    {
+                        Selector = new ClassSelector("sidebar"),
+                        Style = new Style
+                        {
+                            Width = Length.Px(200),
+                            Height = Length.Percent(100),
+                            Padding = Length.Px(16),
+                        }
+                    },
+                    new()
+                    {
+                        Selector = new ClassSelector("main-content"),
+                        Style = new Style
+                        {
+                            FlexGrow = 1,
+                            Padding = Length.Px(16),
+                            OverflowY = Overflow.Scroll,
+                        }
+                    },
+                }
+            }
+        };
+
+        float viewportWidth = 1017;
+        float viewportHeight = 700;
+
+        var layout = _layoutEngine.Layout(root, styleSheets, viewportWidth, viewportHeight);
+
+        var sidebarBox = layout.Children[0];
+        var mainContentBox = layout.Children[1];
+
+        // 输出所有关键值
+        var msg = $"\nRoot content: {layout.BoxModel.Content}" +
+                  $"\nSidebar content: {sidebarBox.BoxModel.Content}" +
+                  $"\nSidebar margin box: {sidebarBox.BoxModel.MarginBox}" +
+                  $"\nMainContent content: {mainContentBox.BoxModel.Content}" +
+                  $"\nMainContent padding: {mainContentBox.BoxModel.Padding}" +
+                  $"\nMainContent border box: {mainContentBox.BoxModel.BorderBox}" +
+                  $"\nMainContent margin box: {mainContentBox.BoxModel.MarginBox}";
+
+        // flex-grow 子元素的 content width 应该 = 容器宽度 - sidebar 占用宽度 - 自身 padding
+        float expectedMainContentWidth = viewportWidth - sidebarBox.BoxModel.MarginBox.Width - 32; // 32 = padding left + right
+        mainContentBox.BoxModel.Content.Width.ShouldBe(expectedMainContentWidth, msg);
+    }
+
+    [Fact]
+    public void FlexContainer_FixedWidth_ScrollbarShouldBeWithinCanvas()
+    {
+        // 对比：使用固定宽度 1000px
+        var root = new DivElement
+        {
+            Class = "layout",
+            Children =
+            {
+                new DivElement { Class = "sidebar" },
+                new DivElement
+                {
+                    Class = "main-content",
+                    Children =
+                    {
+                        new DivElement { Style = new Style { Height = Length.Px(300) } },
+                        new DivElement { Style = new Style { Height = Length.Px(300) } },
+                        new DivElement { Style = new Style { Height = Length.Px(300) } },
+                    }
+                }
+            }
+        };
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new()
+                    {
+                        Selector = new ClassSelector("layout"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            Width = Length.Px(1000),
+                            Height = Length.Px(700),
+                        }
+                    },
+                    new()
+                    {
+                        Selector = new ClassSelector("sidebar"),
+                        Style = new Style
+                        {
+                            Width = Length.Px(200),
+                            Height = Length.Percent(100),
+                            Padding = Length.Px(16),
+                        }
+                    },
+                    new()
+                    {
+                        Selector = new ClassSelector("main-content"),
+                        Style = new Style
+                        {
+                            FlexGrow = 1,
+                            Padding = Length.Px(16),
+                            OverflowY = Overflow.Scroll,
+                        }
+                    },
+                }
+            }
+        };
+
+        float viewportWidth = 1017;
+        float viewportHeight = 700;
+
+        var layout = _layoutEngine.Layout(root, styleSheets, viewportWidth, viewportHeight);
+
+        var mainContent = layout.Children[1];
+
+        // 固定宽度时滚动条应该正常显示
+        mainContent.HasVerticalScrollbar.ShouldBeTrue();
+
+        // 滚动条右边界不应超出容器
+        float scrollbarRight = mainContent.BoxModel.Content.Right;
+        scrollbarRight.ShouldBeLessThanOrEqualTo(1000f);
+    }
+}

--- a/tests/Miko.Tests/Layout/ScrollEventTests.cs
+++ b/tests/Miko.Tests/Layout/ScrollEventTests.cs
@@ -1,0 +1,318 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Events;
+using Miko.Layout;
+using Miko.Styling;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Layout;
+
+public class ScrollEventTests
+{
+    private MikoEngine CreateEngine(Element root, float width = 400, float height = 300)
+    {
+        var engine = new MikoEngine();
+        using var surface = SKSurface.Create(new SKImageInfo((int)width, (int)height));
+        engine.Initialize(root, new List<StyleSheet>(), surface.Canvas, width, height);
+        return engine;
+    }
+
+    [Fact]
+    public void ScrollBy_ShouldUpdateScrollTop()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(400),
+                Height = Length.Px(300),
+                OverflowY = Overflow.Auto,
+            },
+            Children =
+            {
+                new DivElement { Style = new Style { Height = Length.Px(800) } }
+            }
+        };
+
+        var engine = CreateEngine(root);
+
+        // 在容器中心滚动
+        bool scrolled = engine.ScrollBy(200, 150, 0, 100);
+
+        scrolled.ShouldBeTrue();
+        var layout = engine.GetCurrentLayout()!;
+        layout.ScrollTop.ShouldBe(100);
+    }
+
+    [Fact]
+    public void ScrollBy_ShouldClampToZero()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(400),
+                Height = Length.Px(300),
+                OverflowY = Overflow.Auto,
+            },
+            Children =
+            {
+                new DivElement { Style = new Style { Height = Length.Px(800) } }
+            }
+        };
+
+        var engine = CreateEngine(root);
+
+        // 向上滚动（负值），应该被 clamp 到 0
+        bool scrolled = engine.ScrollBy(200, 150, 0, -100);
+
+        scrolled.ShouldBeFalse();
+        var layout = engine.GetCurrentLayout()!;
+        layout.ScrollTop.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ScrollBy_ShouldClampToMaxScroll()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(400),
+                Height = Length.Px(300),
+                OverflowY = Overflow.Auto,
+            },
+            Children =
+            {
+                new DivElement { Style = new Style { Height = Length.Px(800) } }
+            }
+        };
+
+        var engine = CreateEngine(root);
+
+        // 滚动超过最大值
+        bool scrolled = engine.ScrollBy(200, 150, 0, 9999);
+
+        scrolled.ShouldBeTrue();
+        var layout = engine.GetCurrentLayout()!;
+        // maxScroll = contentHeight(800) - paddingBoxHeight(300) = 500
+        layout.ScrollTop.ShouldBe(500);
+    }
+
+    [Fact]
+    public void ScrollBy_ShouldFindScrollableAncestor()
+    {
+        // 子元素不可滚动，父元素可滚动
+        var child = new DivElement
+        {
+            Id = "child",
+            Style = new Style { Height = Length.Px(200) }
+        };
+
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(400),
+                Height = Length.Px(300),
+                OverflowY = Overflow.Auto,
+            },
+            Children =
+            {
+                child,
+                new DivElement { Style = new Style { Height = Length.Px(600) } }
+            }
+        };
+
+        var engine = CreateEngine(root);
+
+        // 在子元素上滚动，应该找到父容器进行滚动
+        bool scrolled = engine.ScrollBy(200, 100, 0, 50);
+
+        scrolled.ShouldBeTrue();
+        var layout = engine.GetCurrentLayout()!;
+        layout.ScrollTop.ShouldBe(50);
+    }
+
+    [Fact]
+    public void ScrollBy_ShouldNotScrollNonOverflowElement()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(400),
+                Height = Length.Px(300),
+            },
+            Children =
+            {
+                new DivElement { Style = new Style { Height = Length.Px(800) } }
+            }
+        };
+
+        var engine = CreateEngine(root);
+
+        // 没有 overflow 设置，不应该滚动
+        bool scrolled = engine.ScrollBy(200, 150, 0, 100);
+
+        scrolled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ScrollBy_ShouldDispatchScrollEvent()
+    {
+        ScrollEventArgs? receivedArgs = null;
+
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(400),
+                Height = Length.Px(300),
+                OverflowY = Overflow.Auto,
+            },
+            Children =
+            {
+                new DivElement { Style = new Style { Height = Length.Px(800) } }
+            }
+        };
+
+        root.OnScroll = args => receivedArgs = args;
+
+        var engine = CreateEngine(root);
+        engine.ScrollBy(200, 150, 0, 75);
+
+        receivedArgs.ShouldNotBeNull();
+        receivedArgs.DeltaY.ShouldBe(75);
+        receivedArgs.ScrollTop.ShouldBe(75);
+        receivedArgs.Target.ShouldBe(root);
+    }
+
+    [Fact]
+    public void ScrollBy_HorizontalScroll_ShouldUpdateScrollLeft()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(300),
+                Height = Length.Px(300),
+                OverflowX = Overflow.Scroll,
+            },
+            Children =
+            {
+                new DivElement
+                {
+                    Style = new Style
+                    {
+                        Display = Display.InlineBlock,
+                        Width = Length.Px(800),
+                        Height = Length.Px(100),
+                    }
+                }
+            }
+        };
+
+        var engine = CreateEngine(root);
+
+        bool scrolled = engine.ScrollBy(150, 150, 100, 0);
+
+        scrolled.ShouldBeTrue();
+        var layout = engine.GetCurrentLayout()!;
+        layout.ScrollLeft.ShouldBe(100);
+    }
+
+    [Fact]
+    public void ScrollBy_MultipleScrolls_ShouldAccumulate()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(400),
+                Height = Length.Px(300),
+                OverflowY = Overflow.Auto,
+            },
+            Children =
+            {
+                new DivElement { Style = new Style { Height = Length.Px(800) } }
+            }
+        };
+
+        var engine = CreateEngine(root);
+
+        engine.ScrollBy(200, 150, 0, 50);
+        engine.ScrollBy(200, 150, 0, 30);
+
+        var layout = engine.GetCurrentLayout()!;
+        layout.ScrollTop.ShouldBe(80);
+    }
+
+    [Fact]
+    public void ScrollBy_OverflowHidden_ShouldNotScroll()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(400),
+                Height = Length.Px(300),
+                OverflowY = Overflow.Hidden,
+            },
+            Children =
+            {
+                new DivElement { Style = new Style { Height = Length.Px(800) } }
+            }
+        };
+
+        var engine = CreateEngine(root);
+
+        // overflow: hidden 裁剪内容但不允许滚动
+        bool scrolled = engine.ScrollBy(200, 150, 0, 100);
+
+        scrolled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ScrollBy_ShouldPreserveScrollStateAfterReRender()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(400),
+                Height = Length.Px(300),
+                OverflowY = Overflow.Auto,
+            },
+            Children =
+            {
+                new DivElement { Style = new Style { Height = Length.Px(800) } }
+            }
+        };
+
+        var engine = CreateEngine(root);
+
+        // 滚动
+        engine.ScrollBy(200, 150, 0, 100);
+        engine.GetCurrentLayout()!.ScrollTop.ShouldBe(100);
+
+        // 重新渲染（模拟 WinUI 每帧调用 Render）
+        using var surface = SKSurface.Create(new SKImageInfo(400, 300));
+        engine.Render(surface.Canvas);
+
+        // 滚动状态应该被保留
+        engine.GetCurrentLayout()!.ScrollTop.ShouldBe(100);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Overflow` enum (`Visible`, `Hidden`, `Scroll`, `Auto`) with `OverflowX`/`OverflowY` style properties
- Implement Classic scrollbar layout: reserves 17px in block/flex layout, positioned at padding box right edge
- Render scrollbars with Chrome-style colors (`#f1f1f1` track, `#c1c1c1` thumb)
- Clip overflowing content to padding box with scroll offset translation
- Fix flex-grow space calculation: use outer (margin box) size for flex-basis to prevent child overflow
- Fix block layout: respect `AvailableHeight` constraint when `overflow` is set and `height` is auto
- Add `ScrollBy()` to `MikoEngine`: hit test → find scrollable ancestor → clamp scroll position → dispatch scroll event
- Preserve scroll state across re-layouts (`RestoreScrollState` after each `Layout` call)
- Wire mouse wheel to `ScrollBy` in `MikoApp` hosting layer (40px per wheel tick)
- Add `ScrollEventArgs`, `EventTypes.Scroll`, `Element.OnScroll` convenience handler

## Test Plan

- [x] `OverflowTests` — overflow style, scrollbar visibility, scrollbar thickness
- [x] `PercentHeightTests` — percent height resolves correctly in flex containers
- [x] `PercentWidthScrollbarTests` — scrollbar stays within canvas bounds with percent width
- [x] `ScrollEventTests` — scroll position update, clamping, ancestor lookup, event dispatch, state preservation after re-render
- All 400 tests pass: `dotnet test tests/Miko.Tests/Miko.Tests.csproj`