### PR TITLE
Fix scrollbar drag/click: always operate on current layout box

### DIFF
--- a/src/Miko/Core/MikoEngine.cs
+++ b/src/Miko/Core/MikoEngine.cs
@@ -335,4 +335,186 @@ public class MikoEngine
 
         return null;
     }
+
+    public enum ScrollbarHitType { None, VerticalThumb, VerticalTrack, HorizontalThumb, HorizontalTrack }
+
+    public record ScrollbarHitResult(LayoutBox Box, ScrollbarHitType HitType, float ThumbOffset);
+
+    /// <summary>
+    /// 检测鼠标是否点击在某个滚动条上
+    /// </summary>
+    public ScrollbarHitResult? HitTestScrollbar(float x, float y)
+    {
+        if (_currentLayout == null) return null;
+        return HitTestScrollbarBox(_currentLayout, x, y, 0, 0);
+    }
+
+    private static ScrollbarHitResult? HitTestScrollbarBox(LayoutBox box, float x, float y, float scrollOffsetX, float scrollOffsetY)
+    {
+        var borderBox = box.BoxModel.BorderBox;
+        float adjustedLeft = borderBox.Left - scrollOffsetX;
+        float adjustedRight = borderBox.Right - scrollOffsetX;
+        float adjustedTop = borderBox.Top - scrollOffsetY;
+        float adjustedBottom = borderBox.Bottom - scrollOffsetY;
+
+        if (x < adjustedLeft || x > adjustedRight || y < adjustedTop || y > adjustedBottom)
+            return null;
+
+        var paddingBox = box.BoxModel.PaddingBox;
+        float pLeft = paddingBox.X - scrollOffsetX;
+        float pTop = paddingBox.Y - scrollOffsetY;
+        float pRight = pLeft + paddingBox.Width;
+        float pBottom = pTop + paddingBox.Height;
+
+        if (box.HasVerticalScrollbar)
+        {
+            float trackX = pRight - LayoutBox.ScrollbarThickness;
+            float trackHeight = paddingBox.Height - (box.HasHorizontalScrollbar ? LayoutBox.ScrollbarThickness : 0);
+
+            if (x >= trackX && x <= pRight && y >= pTop && y <= pTop + trackHeight)
+            {
+                var (thumbTop, thumbHeight) = GetVerticalThumbGeometry(box, trackHeight);
+                float screenThumbTop = thumbTop - scrollOffsetY;
+                float screenThumbBottom = screenThumbTop + thumbHeight;
+                if (y >= screenThumbTop && y <= screenThumbBottom)
+                    return new ScrollbarHitResult(box, ScrollbarHitType.VerticalThumb, y - screenThumbTop);
+                return new ScrollbarHitResult(box, ScrollbarHitType.VerticalTrack, 0);
+            }
+        }
+
+        if (box.HasHorizontalScrollbar)
+        {
+            float trackY = pBottom - LayoutBox.ScrollbarThickness;
+            float trackWidth = paddingBox.Width - (box.HasVerticalScrollbar ? LayoutBox.ScrollbarThickness : 0);
+
+            if (x >= pLeft && x <= pLeft + trackWidth && y >= trackY && y <= pBottom)
+            {
+                var (thumbLeft, thumbWidth) = GetHorizontalThumbGeometry(box, trackWidth);
+                float screenThumbLeft = thumbLeft - scrollOffsetX;
+                float screenThumbRight = screenThumbLeft + thumbWidth;
+                if (x >= screenThumbLeft && x <= screenThumbRight)
+                    return new ScrollbarHitResult(box, ScrollbarHitType.HorizontalThumb, x - screenThumbLeft);
+                return new ScrollbarHitResult(box, ScrollbarHitType.HorizontalTrack, 0);
+            }
+        }
+
+        float childScrollOffsetX = scrollOffsetX + box.ScrollLeft;
+        float childScrollOffsetY = scrollOffsetY + box.ScrollTop;
+
+        foreach (var child in box.Children)
+        {
+            var hit = HitTestScrollbarBox(child, x, y, childScrollOffsetX, childScrollOffsetY);
+            if (hit != null) return hit;
+        }
+
+        return null;
+    }
+
+    private static (float thumbTop, float thumbHeight) GetVerticalThumbGeometry(LayoutBox box, float trackHeight)
+    {
+        float viewportH = box.BoxModel.PaddingBox.Height;
+        float contentH = box.ScrollableContentHeight;
+        float thumbHeight = Math.Max(trackHeight * (viewportH / contentH), 20f);
+        float scrollableTrack = trackHeight - thumbHeight;
+        float maxScroll = contentH - viewportH;
+        float thumbTop = box.BoxModel.PaddingBox.Y + (maxScroll > 0 ? (box.ScrollTop / maxScroll) * scrollableTrack : 0);
+        return (thumbTop, thumbHeight);
+    }
+
+    private static (float thumbLeft, float thumbWidth) GetHorizontalThumbGeometry(LayoutBox box, float trackWidth)
+    {
+        float viewportW = box.BoxModel.PaddingBox.Width;
+        float contentW = box.ScrollableContentWidth;
+        float thumbWidth = Math.Max(trackWidth * (viewportW / contentW), 20f);
+        float scrollableTrack = trackWidth - thumbWidth;
+        float maxScroll = contentW - viewportW;
+        float thumbLeft = box.BoxModel.PaddingBox.X + (maxScroll > 0 ? (box.ScrollLeft / maxScroll) * scrollableTrack : 0);
+        return (thumbLeft, thumbWidth);
+    }
+
+    /// <summary>
+    /// 拖拽垂直滑块到指定鼠标Y位置
+    /// </summary>
+    public bool DragVerticalThumb(LayoutBox box, float mouseY, float thumbOffset)
+    {
+        float trackHeight = box.BoxModel.PaddingBox.Height - (box.HasHorizontalScrollbar ? LayoutBox.ScrollbarThickness : 0);
+        var (_, thumbHeight) = GetVerticalThumbGeometry(box, trackHeight);
+        float scrollableTrack = trackHeight - thumbHeight;
+        if (scrollableTrack <= 0) return false;
+
+        float thumbTop = mouseY - thumbOffset - box.BoxModel.PaddingBox.Y;
+        float ratio = Math.Clamp(thumbTop / scrollableTrack, 0f, 1f);
+
+        float viewportH = box.BoxModel.PaddingBox.Height;
+        float maxScroll = Math.Max(0, box.ScrollableContentHeight - viewportH);
+        float newScrollTop = ratio * maxScroll;
+
+        if (Math.Abs(box.ScrollTop - newScrollTop) < 0.01f) return false;
+        box.ScrollTop = newScrollTop;
+        InvalidateElement(box.Element);
+        return true;
+    }
+
+    /// <summary>
+    /// 拖拽水平滑块到指定鼠标X位置
+    /// </summary>
+    public bool DragHorizontalThumb(LayoutBox box, float mouseX, float thumbOffset)
+    {
+        float trackWidth = box.BoxModel.PaddingBox.Width - (box.HasVerticalScrollbar ? LayoutBox.ScrollbarThickness : 0);
+        var (_, thumbWidth) = GetHorizontalThumbGeometry(box, trackWidth);
+        float scrollableTrack = trackWidth - thumbWidth;
+        if (scrollableTrack <= 0) return false;
+
+        float thumbLeft = mouseX - thumbOffset - box.BoxModel.PaddingBox.X;
+        float ratio = Math.Clamp(thumbLeft / scrollableTrack, 0f, 1f);
+
+        float viewportW = box.BoxModel.PaddingBox.Width;
+        float maxScroll = Math.Max(0, box.ScrollableContentWidth - viewportW);
+        float newScrollLeft = ratio * maxScroll;
+
+        if (Math.Abs(box.ScrollLeft - newScrollLeft) < 0.01f) return false;
+        box.ScrollLeft = newScrollLeft;
+        InvalidateElement(box.Element);
+        return true;
+    }
+
+    /// <summary>
+    /// 点击滑轨，按页滚动（≈ clientSize * 0.875）
+    /// </summary>
+    public bool ScrollTrackClick(LayoutBox box, ScrollbarHitType hitType, float mouseX, float mouseY)
+    {
+        if (hitType == ScrollbarHitType.VerticalTrack)
+        {
+            float viewportH = box.BoxModel.PaddingBox.Height;
+            float pageSize = viewportH * 0.875f;
+            float trackHeight = viewportH - (box.HasHorizontalScrollbar ? LayoutBox.ScrollbarThickness : 0);
+            var (thumbTop, thumbHeight) = GetVerticalThumbGeometry(box, trackHeight);
+            float delta = mouseY < thumbTop ? -pageSize : pageSize;
+
+            float maxScroll = Math.Max(0, box.ScrollableContentHeight - viewportH);
+            float newScrollTop = Math.Clamp(box.ScrollTop + delta, 0, maxScroll);
+            if (Math.Abs(box.ScrollTop - newScrollTop) < 0.01f) return false;
+            box.ScrollTop = newScrollTop;
+            InvalidateElement(box.Element);
+            return true;
+        }
+
+        if (hitType == ScrollbarHitType.HorizontalTrack)
+        {
+            float viewportW = box.BoxModel.PaddingBox.Width;
+            float pageSize = viewportW * 0.875f;
+            float trackWidth = viewportW - (box.HasVerticalScrollbar ? LayoutBox.ScrollbarThickness : 0);
+            var (thumbLeft, thumbWidth) = GetHorizontalThumbGeometry(box, trackWidth);
+            float delta = mouseX < thumbLeft ? -pageSize : pageSize;
+
+            float maxScroll = Math.Max(0, box.ScrollableContentWidth - viewportW);
+            float newScrollLeft = Math.Clamp(box.ScrollLeft + delta, 0, maxScroll);
+            if (Math.Abs(box.ScrollLeft - newScrollLeft) < 0.01f) return false;
+            box.ScrollLeft = newScrollLeft;
+            InvalidateElement(box.Element);
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Miko/Core/MikoEngine.cs
+++ b/src/Miko/Core/MikoEngine.cs
@@ -437,44 +437,47 @@ public class MikoEngine
     /// </summary>
     public bool DragVerticalThumb(LayoutBox box, float mouseY, float thumbOffset)
     {
-        float trackHeight = box.BoxModel.PaddingBox.Height - (box.HasHorizontalScrollbar ? LayoutBox.ScrollbarThickness : 0);
-        var (_, thumbHeight) = GetVerticalThumbGeometry(box, trackHeight);
+        var current = FindLayoutBoxForElement(_currentLayout!, box.Element);
+        if (current == null) return false;
+
+        float trackHeight = current.BoxModel.PaddingBox.Height - (current.HasHorizontalScrollbar ? LayoutBox.ScrollbarThickness : 0);
+        var (_, thumbHeight) = GetVerticalThumbGeometry(current, trackHeight);
         float scrollableTrack = trackHeight - thumbHeight;
         if (scrollableTrack <= 0) return false;
 
-        float thumbTop = mouseY - thumbOffset - box.BoxModel.PaddingBox.Y;
+        float thumbTop = mouseY - thumbOffset - current.BoxModel.PaddingBox.Y;
         float ratio = Math.Clamp(thumbTop / scrollableTrack, 0f, 1f);
 
-        float viewportH = box.BoxModel.PaddingBox.Height;
-        float maxScroll = Math.Max(0, box.ScrollableContentHeight - viewportH);
+        float viewportH = current.BoxModel.PaddingBox.Height;
+        float maxScroll = Math.Max(0, current.ScrollableContentHeight - viewportH);
         float newScrollTop = ratio * maxScroll;
 
-        if (Math.Abs(box.ScrollTop - newScrollTop) < 0.01f) return false;
-        box.ScrollTop = newScrollTop;
-        InvalidateElement(box.Element);
+        if (Math.Abs(current.ScrollTop - newScrollTop) < 0.01f) return false;
+        current.ScrollTop = newScrollTop;
+        InvalidateElement(current.Element);
         return true;
     }
 
-    /// <summary>
-    /// 拖拽水平滑块到指定鼠标X位置
-    /// </summary>
     public bool DragHorizontalThumb(LayoutBox box, float mouseX, float thumbOffset)
     {
-        float trackWidth = box.BoxModel.PaddingBox.Width - (box.HasVerticalScrollbar ? LayoutBox.ScrollbarThickness : 0);
-        var (_, thumbWidth) = GetHorizontalThumbGeometry(box, trackWidth);
+        var current = FindLayoutBoxForElement(_currentLayout!, box.Element);
+        if (current == null) return false;
+
+        float trackWidth = current.BoxModel.PaddingBox.Width - (current.HasVerticalScrollbar ? LayoutBox.ScrollbarThickness : 0);
+        var (_, thumbWidth) = GetHorizontalThumbGeometry(current, trackWidth);
         float scrollableTrack = trackWidth - thumbWidth;
         if (scrollableTrack <= 0) return false;
 
-        float thumbLeft = mouseX - thumbOffset - box.BoxModel.PaddingBox.X;
+        float thumbLeft = mouseX - thumbOffset - current.BoxModel.PaddingBox.X;
         float ratio = Math.Clamp(thumbLeft / scrollableTrack, 0f, 1f);
 
-        float viewportW = box.BoxModel.PaddingBox.Width;
-        float maxScroll = Math.Max(0, box.ScrollableContentWidth - viewportW);
+        float viewportW = current.BoxModel.PaddingBox.Width;
+        float maxScroll = Math.Max(0, current.ScrollableContentWidth - viewportW);
         float newScrollLeft = ratio * maxScroll;
 
-        if (Math.Abs(box.ScrollLeft - newScrollLeft) < 0.01f) return false;
-        box.ScrollLeft = newScrollLeft;
-        InvalidateElement(box.Element);
+        if (Math.Abs(current.ScrollLeft - newScrollLeft) < 0.01f) return false;
+        current.ScrollLeft = newScrollLeft;
+        InvalidateElement(current.Element);
         return true;
     }
 
@@ -483,35 +486,38 @@ public class MikoEngine
     /// </summary>
     public bool ScrollTrackClick(LayoutBox box, ScrollbarHitType hitType, float mouseX, float mouseY)
     {
+        var current = FindLayoutBoxForElement(_currentLayout!, box.Element);
+        if (current == null) return false;
+
         if (hitType == ScrollbarHitType.VerticalTrack)
         {
-            float viewportH = box.BoxModel.PaddingBox.Height;
+            float viewportH = current.BoxModel.PaddingBox.Height;
             float pageSize = viewportH * 0.875f;
-            float trackHeight = viewportH - (box.HasHorizontalScrollbar ? LayoutBox.ScrollbarThickness : 0);
-            var (thumbTop, thumbHeight) = GetVerticalThumbGeometry(box, trackHeight);
+            float trackHeight = viewportH - (current.HasHorizontalScrollbar ? LayoutBox.ScrollbarThickness : 0);
+            var (thumbTop, _) = GetVerticalThumbGeometry(current, trackHeight);
             float delta = mouseY < thumbTop ? -pageSize : pageSize;
 
-            float maxScroll = Math.Max(0, box.ScrollableContentHeight - viewportH);
-            float newScrollTop = Math.Clamp(box.ScrollTop + delta, 0, maxScroll);
-            if (Math.Abs(box.ScrollTop - newScrollTop) < 0.01f) return false;
-            box.ScrollTop = newScrollTop;
-            InvalidateElement(box.Element);
+            float maxScroll = Math.Max(0, current.ScrollableContentHeight - viewportH);
+            float newScrollTop = Math.Clamp(current.ScrollTop + delta, 0, maxScroll);
+            if (Math.Abs(current.ScrollTop - newScrollTop) < 0.01f) return false;
+            current.ScrollTop = newScrollTop;
+            InvalidateElement(current.Element);
             return true;
         }
 
         if (hitType == ScrollbarHitType.HorizontalTrack)
         {
-            float viewportW = box.BoxModel.PaddingBox.Width;
+            float viewportW = current.BoxModel.PaddingBox.Width;
             float pageSize = viewportW * 0.875f;
-            float trackWidth = viewportW - (box.HasVerticalScrollbar ? LayoutBox.ScrollbarThickness : 0);
-            var (thumbLeft, thumbWidth) = GetHorizontalThumbGeometry(box, trackWidth);
+            float trackWidth = viewportW - (current.HasVerticalScrollbar ? LayoutBox.ScrollbarThickness : 0);
+            var (thumbLeft, _) = GetHorizontalThumbGeometry(current, trackWidth);
             float delta = mouseX < thumbLeft ? -pageSize : pageSize;
 
-            float maxScroll = Math.Max(0, box.ScrollableContentWidth - viewportW);
-            float newScrollLeft = Math.Clamp(box.ScrollLeft + delta, 0, maxScroll);
-            if (Math.Abs(box.ScrollLeft - newScrollLeft) < 0.01f) return false;
-            box.ScrollLeft = newScrollLeft;
-            InvalidateElement(box.Element);
+            float maxScroll = Math.Max(0, current.ScrollableContentWidth - viewportW);
+            float newScrollLeft = Math.Clamp(current.ScrollLeft + delta, 0, maxScroll);
+            if (Math.Abs(current.ScrollLeft - newScrollLeft) < 0.01f) return false;
+            current.ScrollLeft = newScrollLeft;
+            InvalidateElement(current.Element);
             return true;
         }
 

--- a/src/Miko/Hosting/MikoApp.cs
+++ b/src/Miko/Hosting/MikoApp.cs
@@ -183,6 +183,9 @@ public class MikoApp
         var scrollbarHit = _engine.HitTestScrollbar(mouse.Position.X, mouse.Position.Y);
         if (scrollbarHit != null)
         {
+            _logger.LogTrace("Scrollbar hit: type={HitType}, element={Tag}#{Id}, thumbOffset={Offset}, pos=({X}, {Y})",
+                scrollbarHit.HitType, scrollbarHit.Box.Element.TagName, scrollbarHit.Box.Element.Id ?? "",
+                scrollbarHit.ThumbOffset, mouse.Position.X, mouse.Position.Y);
             _draggingScrollbar = scrollbarHit;
             _isDragging = true;
             if (scrollbarHit.HitType == MikoEngine.ScrollbarHitType.VerticalThumb ||
@@ -218,6 +221,9 @@ public class MikoApp
                 if (hit.HitType == MikoEngine.ScrollbarHitType.VerticalTrack ||
                     hit.HitType == MikoEngine.ScrollbarHitType.HorizontalTrack)
                 {
+                    _logger.LogTrace("Scrollbar track click: type={HitType}, element={Tag}#{Id}, pos=({X}, {Y})",
+                        hit.HitType, hit.Box.Element.TagName, hit.Box.Element.Id ?? "",
+                        mouse.Position.X, mouse.Position.Y);
                     _engine.ScrollTrackClick(hit.Box, hit.HitType, mouse.Position.X, mouse.Position.Y);
                 }
             }
@@ -248,9 +254,17 @@ public class MikoApp
         {
             var hit = _draggingScrollbar;
             if (hit.HitType == MikoEngine.ScrollbarHitType.VerticalThumb)
+            {
+                _logger.LogTrace("Scrollbar thumb drag: vertical, element={Tag}#{Id}, mouseY={Y}",
+                    hit.Box.Element.TagName, hit.Box.Element.Id ?? "", position.Y);
                 _engine.DragVerticalThumb(hit.Box, position.Y, hit.ThumbOffset);
+            }
             else if (hit.HitType == MikoEngine.ScrollbarHitType.HorizontalThumb)
+            {
+                _logger.LogTrace("Scrollbar thumb drag: horizontal, element={Tag}#{Id}, mouseX={X}",
+                    hit.Box.Element.TagName, hit.Box.Element.Id ?? "", position.X);
                 _engine.DragHorizontalThumb(hit.Box, position.X, hit.ThumbOffset);
+            }
             return;
         }
 

--- a/src/Miko/Hosting/MikoApp.cs
+++ b/src/Miko/Hosting/MikoApp.cs
@@ -37,6 +37,7 @@ public class MikoApp
     private Element? _focusedElement;
     private InputElement? _draggingRange;
     private bool _isDragging;
+    private MikoEngine.ScrollbarHitResult? _draggingScrollbar;
 
     internal MikoApp(MikoAppConfiguration config)
     {
@@ -178,6 +179,20 @@ public class MikoApp
         if (button != Silk.NET.Input.MouseButton.Left) return;
         _mouseDownPosition = mouse.Position;
 
+        // Check scrollbar hit first
+        var scrollbarHit = _engine.HitTestScrollbar(mouse.Position.X, mouse.Position.Y);
+        if (scrollbarHit != null)
+        {
+            _draggingScrollbar = scrollbarHit;
+            _isDragging = true;
+            if (scrollbarHit.HitType == MikoEngine.ScrollbarHitType.VerticalThumb ||
+                scrollbarHit.HitType == MikoEngine.ScrollbarHitType.HorizontalThumb)
+            {
+                _mouseDownPosition = null; // suppress click handling
+            }
+            return;
+        }
+
         var target = _engine.HitTest(mouse.Position.X, mouse.Position.Y);
         if (target is InputElement { Type: InputType.Range } rangeInput)
         {
@@ -194,6 +209,19 @@ public class MikoApp
         if (_isDragging)
         {
             _isDragging = false;
+
+            // Handle scrollbar track click (not thumb drag)
+            if (_draggingScrollbar != null)
+            {
+                var hit = _draggingScrollbar;
+                _draggingScrollbar = null;
+                if (hit.HitType == MikoEngine.ScrollbarHitType.VerticalTrack ||
+                    hit.HitType == MikoEngine.ScrollbarHitType.HorizontalTrack)
+                {
+                    _engine.ScrollTrackClick(hit.Box, hit.HitType, mouse.Position.X, mouse.Position.Y);
+                }
+            }
+
             _draggingRange = null;
             _mouseDownPosition = null;
             return;
@@ -216,6 +244,16 @@ public class MikoApp
 
     private void OnMouseMove(IMouse mouse, System.Numerics.Vector2 position)
     {
+        if (_isDragging && _draggingScrollbar != null)
+        {
+            var hit = _draggingScrollbar;
+            if (hit.HitType == MikoEngine.ScrollbarHitType.VerticalThumb)
+                _engine.DragVerticalThumb(hit.Box, position.Y, hit.ThumbOffset);
+            else if (hit.HitType == MikoEngine.ScrollbarHitType.HorizontalThumb)
+                _engine.DragHorizontalThumb(hit.Box, position.X, hit.ThumbOffset);
+            return;
+        }
+
         if (_isDragging && _draggingRange != null)
         {
             UpdateRangeValue(_draggingRange, position.X);

--- a/tests/Miko.Tests/Layout/ScrollbarInteractionTests.cs
+++ b/tests/Miko.Tests/Layout/ScrollbarInteractionTests.cs
@@ -1,0 +1,273 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Layout;
+
+public class ScrollbarInteractionTests
+{
+    private MikoEngine CreateEngine(Element root, float width = 400, float height = 300)
+    {
+        var engine = new MikoEngine();
+        using var surface = SKSurface.Create(new SKImageInfo((int)width, (int)height));
+        engine.Initialize(root, new List<StyleSheet>(), surface.Canvas, width, height);
+        return engine;
+    }
+
+    private DivElement CreateScrollableRoot(float contentHeight = 800, float viewportHeight = 300)
+    {
+        return new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(400),
+                Height = Length.Px(viewportHeight),
+                OverflowY = Overflow.Auto,
+            },
+            Children =
+            {
+                new DivElement { Style = new Style { Height = Length.Px(contentHeight) } }
+            }
+        };
+    }
+
+    [Fact]
+    public void HitTestScrollbar_OnVerticalTrack_ReturnsVerticalTrackHit()
+    {
+        var root = CreateScrollableRoot();
+        var engine = CreateEngine(root);
+
+        // Vertical scrollbar is at x = paddingBox.Right - 17 = 400 - 17 = 383
+        // Click in the track area (not on thumb)
+        var hit = engine.HitTestScrollbar(390, 250);
+
+        hit.ShouldNotBeNull();
+        hit!.HitType.ShouldBe(MikoEngine.ScrollbarHitType.VerticalTrack);
+    }
+
+    [Fact]
+    public void HitTestScrollbar_OnVerticalThumb_ReturnsVerticalThumbHit()
+    {
+        var root = CreateScrollableRoot();
+        var engine = CreateEngine(root);
+
+        // Thumb starts at top of track (scrollTop=0), click near top of scrollbar
+        var hit = engine.HitTestScrollbar(390, 10);
+
+        hit.ShouldNotBeNull();
+        hit!.HitType.ShouldBe(MikoEngine.ScrollbarHitType.VerticalThumb);
+    }
+
+    [Fact]
+    public void HitTestScrollbar_OutsideScrollbar_ReturnsNull()
+    {
+        var root = CreateScrollableRoot();
+        var engine = CreateEngine(root);
+
+        // Click in content area, not on scrollbar
+        var hit = engine.HitTestScrollbar(200, 150);
+
+        hit.ShouldBeNull();
+    }
+
+    [Fact]
+    public void HitTestScrollbar_NoScrollbar_ReturnsNull()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(400),
+                Height = Length.Px(300),
+            },
+            Children =
+            {
+                new DivElement { Style = new Style { Height = Length.Px(100) } }
+            }
+        };
+        var engine = CreateEngine(root);
+
+        var hit = engine.HitTestScrollbar(390, 150);
+
+        hit.ShouldBeNull();
+    }
+
+    [Fact]
+    public void DragVerticalThumb_MovesScrollTop()
+    {
+        var root = CreateScrollableRoot();
+        var engine = CreateEngine(root);
+
+        var layout = engine.GetCurrentLayout()!;
+
+        // Drag thumb to middle of track
+        // trackHeight = 300, thumbHeight = max(300 * 300/800, 20) ≈ 112.5
+        // scrollableTrack ≈ 187.5, drag to y=150 with thumbOffset=0
+        engine.DragVerticalThumb(layout, 150, 0);
+
+        layout.ScrollTop.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void DragVerticalThumb_ToTop_SetsScrollTopToZero()
+    {
+        var root = CreateScrollableRoot();
+        var engine = CreateEngine(root);
+
+        var layout = engine.GetCurrentLayout()!;
+        layout.ScrollTop = 200;
+
+        engine.DragVerticalThumb(layout, 0, 0);
+
+        layout.ScrollTop.ShouldBe(0);
+    }
+
+    [Fact]
+    public void DragVerticalThumb_ToBottom_SetsScrollTopToMax()
+    {
+        var root = CreateScrollableRoot();
+        var engine = CreateEngine(root);
+
+        var layout = engine.GetCurrentLayout()!;
+
+        // Drag to bottom of track
+        engine.DragVerticalThumb(layout, 300, 0);
+
+        float maxScroll = layout.ScrollableContentHeight - layout.BoxModel.PaddingBox.Height;
+        layout.ScrollTop.ShouldBe(maxScroll, tolerance: 1f);
+    }
+
+    [Fact]
+    public void ScrollTrackClick_BelowThumb_ScrollsDownByPage()
+    {
+        var root = CreateScrollableRoot();
+        var engine = CreateEngine(root);
+
+        var layout = engine.GetCurrentLayout()!;
+        float initialScrollTop = layout.ScrollTop; // 0
+
+        // Click below the thumb (thumb is at top when scrollTop=0)
+        engine.ScrollTrackClick(layout, MikoEngine.ScrollbarHitType.VerticalTrack, 390, 250);
+
+        float expectedDelta = layout.BoxModel.PaddingBox.Height * 0.875f;
+        layout.ScrollTop.ShouldBeGreaterThan(initialScrollTop);
+        layout.ScrollTop.ShouldBe(expectedDelta, tolerance: 1f);
+    }
+
+    [Fact]
+    public void ScrollTrackClick_AboveThumb_ScrollsUpByPage()
+    {
+        var root = CreateScrollableRoot();
+        var engine = CreateEngine(root);
+
+        var layout = engine.GetCurrentLayout()!;
+        layout.ScrollTop = 400; // scroll to middle
+
+        float initialScrollTop = layout.ScrollTop;
+        float expectedDelta = layout.BoxModel.PaddingBox.Height * 0.875f;
+
+        // Click above the thumb (thumb is near bottom when scrollTop=400)
+        engine.ScrollTrackClick(layout, MikoEngine.ScrollbarHitType.VerticalTrack, 390, 10);
+
+        layout.ScrollTop.ShouldBeLessThan(initialScrollTop);
+        layout.ScrollTop.ShouldBe(initialScrollTop - expectedDelta, tolerance: 1f);
+    }
+
+    [Fact]
+    public void ScrollTrackClick_ClampsToMaxScroll()
+    {
+        var root = CreateScrollableRoot();
+        var engine = CreateEngine(root);
+
+        var layout = engine.GetCurrentLayout()!;
+        float maxScroll = layout.ScrollableContentHeight - layout.BoxModel.PaddingBox.Height;
+        layout.ScrollTop = maxScroll - 10; // near bottom
+
+        engine.ScrollTrackClick(layout, MikoEngine.ScrollbarHitType.VerticalTrack, 390, 290);
+
+        layout.ScrollTop.ShouldBe(maxScroll, tolerance: 0.1f);
+    }
+
+    [Fact]
+    public void ScrollTrackClick_ClampsToZero()
+    {
+        var root = CreateScrollableRoot();
+        var engine = CreateEngine(root);
+
+        var layout = engine.GetCurrentLayout()!;
+        float pageSize = layout.BoxModel.PaddingBox.Height * 0.875f;
+        layout.ScrollTop = pageSize / 2; // less than one page from top
+
+        // Click above the thumb — should scroll up but clamp to 0
+        engine.ScrollTrackClick(layout, MikoEngine.ScrollbarHitType.VerticalTrack, 390, 1);
+
+        layout.ScrollTop.ShouldBe(0);
+    }
+
+    [Fact]
+    public void HitTestScrollbar_VerticalThumb_ReturnsCorrectThumbOffset()
+    {
+        var root = CreateScrollableRoot();
+        var engine = CreateEngine(root);
+
+        // Thumb is at top (scrollTop=0), click 5px into the thumb
+        var hit = engine.HitTestScrollbar(390, 5);
+
+        hit.ShouldNotBeNull();
+        hit!.HitType.ShouldBe(MikoEngine.ScrollbarHitType.VerticalThumb);
+        hit.ThumbOffset.ShouldBe(5f, tolerance: 1f);
+    }
+
+    [Fact]
+    public void DragVerticalThumb_InvalidatesElement()
+    {
+        var root = CreateScrollableRoot();
+        var engine = CreateEngine(root);
+
+        var layout = engine.GetCurrentLayout()!;
+        bool invalidated = engine.DragVerticalThumb(layout, 150, 0);
+
+        invalidated.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HorizontalScrollbar_HitTest_ReturnsHorizontalHit()
+    {
+        var root = new DivElement
+        {
+            Style = new Style
+            {
+                Display = Display.Block,
+                Width = Length.Px(300),
+                Height = Length.Px(300),
+                OverflowX = Overflow.Scroll,
+            },
+            Children =
+            {
+                new DivElement
+                {
+                    Style = new Style
+                    {
+                        Display = Display.InlineBlock,
+                        Width = Length.Px(800),
+                        Height = Length.Px(100),
+                    }
+                }
+            }
+        };
+        var engine = CreateEngine(root, 300, 300);
+
+        // Horizontal scrollbar is at y = paddingBox.Bottom - 17 = 300 - 17 = 283
+        var hit = engine.HitTestScrollbar(50, 290);
+
+        hit.ShouldNotBeNull();
+        (hit!.HitType == MikoEngine.ScrollbarHitType.HorizontalThumb ||
+         hit.HitType == MikoEngine.ScrollbarHitType.HorizontalTrack).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Fix scrollbar thumb drag and track click to always operate on the current layout box
- Add trace logging for scrollbar interactions
- Add scrollbar thumb drag and track click support

## Test Plan
- [x] Scrollbar thumb drag works correctly
- [x] Scrollbar track click works correctly
- [x] No regressions in existing scrollbar behavior