### PR TITLE
Add @media query support with Expression-based conditions

### DIFF
--- a/src/Miko/Layout/LayoutEngine.cs
+++ b/src/Miko/Layout/LayoutEngine.cs
@@ -21,7 +21,8 @@ public class LayoutEngine
     public LayoutBox Layout(Element root, List<StyleSheet> styleSheets, float viewportWidth, float viewportHeight)
     {
         // 1. 样式计算：为每个元素计算最终样式
-        ComputeStyles(root, styleSheets);
+        var viewport = new ViewportInfo(viewportWidth, viewportHeight);
+        ComputeStyles(root, styleSheets, viewport);
 
         // 2. 构建布局树：根据 display 属性过滤和组织
         var layoutRoot = BuildLayoutTree(root);
@@ -41,9 +42,9 @@ public class LayoutEngine
     /// <summary>
     /// 计算所有元素的样式
     /// </summary>
-    private void ComputeStyles(Element element, List<StyleSheet> styleSheets)
+    private void ComputeStyles(Element element, List<StyleSheet> styleSheets, ViewportInfo viewport)
     {
-        var computedStyle = _styleResolver.Resolve(element, styleSheets);
+        var computedStyle = _styleResolver.Resolve(element, styleSheets, viewport);
 
         // 创建布局盒子并关联
         element.LayoutBox = new LayoutBox
@@ -55,7 +56,7 @@ public class LayoutEngine
         // 递归处理子元素
         foreach (var child in element.Children)
         {
-            ComputeStyles(child, styleSheets);
+            ComputeStyles(child, styleSheets, viewport);
         }
     }
 

--- a/src/Miko/Styling/MediaCondition.cs
+++ b/src/Miko/Styling/MediaCondition.cs
@@ -1,18 +1,30 @@
+using System.Linq.Expressions;
+
 namespace Miko.Styling;
 
 public class MediaCondition
 {
-    public float? MinWidth { get; set; }
-    public float? MaxWidth { get; set; }
-    public float? MinHeight { get; set; }
-    public float? MaxHeight { get; set; }
+    private readonly Func<ViewportInfo, bool> _compiled;
 
-    public bool Matches(ViewportInfo viewport)
+    public Expression<Func<ViewportInfo, bool>> Expression { get; }
+
+    public MediaCondition(Expression<Func<ViewportInfo, bool>> expression)
     {
-        if (MinWidth.HasValue && viewport.Width < MinWidth.Value) return false;
-        if (MaxWidth.HasValue && viewport.Width > MaxWidth.Value) return false;
-        if (MinHeight.HasValue && viewport.Height < MinHeight.Value) return false;
-        if (MaxHeight.HasValue && viewport.Height > MaxHeight.Value) return false;
-        return true;
+        Expression = expression;
+        _compiled = expression.Compile();
     }
+
+    public bool Matches(ViewportInfo viewport) => _compiled(viewport);
+
+    public static MediaCondition MinWidth(float value) =>
+        new(v => v.Width >= value);
+
+    public static MediaCondition MaxWidth(float value) =>
+        new(v => v.Width <= value);
+
+    public static MediaCondition MinHeight(float value) =>
+        new(v => v.Height >= value);
+
+    public static MediaCondition MaxHeight(float value) =>
+        new(v => v.Height <= value);
 }

--- a/src/Miko/Styling/MediaCondition.cs
+++ b/src/Miko/Styling/MediaCondition.cs
@@ -1,0 +1,18 @@
+namespace Miko.Styling;
+
+public class MediaCondition
+{
+    public float? MinWidth { get; set; }
+    public float? MaxWidth { get; set; }
+    public float? MinHeight { get; set; }
+    public float? MaxHeight { get; set; }
+
+    public bool Matches(ViewportInfo viewport)
+    {
+        if (MinWidth.HasValue && viewport.Width < MinWidth.Value) return false;
+        if (MaxWidth.HasValue && viewport.Width > MaxWidth.Value) return false;
+        if (MinHeight.HasValue && viewport.Height < MinHeight.Value) return false;
+        if (MaxHeight.HasValue && viewport.Height > MaxHeight.Value) return false;
+        return true;
+    }
+}

--- a/src/Miko/Styling/MediaRule.cs
+++ b/src/Miko/Styling/MediaRule.cs
@@ -1,0 +1,7 @@
+namespace Miko.Styling;
+
+public class MediaRule
+{
+    public MediaCondition Condition { get; set; } = null!;
+    public List<StyleRule> Rules { get; set; } = new();
+}

--- a/src/Miko/Styling/StyleResolver.cs
+++ b/src/Miko/Styling/StyleResolver.cs
@@ -12,7 +12,7 @@ public class StyleResolver
     /// <summary>
     /// 解析元素的最终样式
     /// </summary>
-    public ComputedStyle Resolve(Element element, List<StyleSheet> styleSheets)
+    public ComputedStyle Resolve(Element element, List<StyleSheet> styleSheets, ViewportInfo? viewport = null)
     {
         // 1. 收集所有匹配的规则（带有定义顺序索引）
         var matchedRules = new List<(StyleRule rule, int specificity, int index)>();
@@ -27,6 +27,24 @@ public class StyleResolver
                     matchedRules.Add((rule, rule.Selector.Specificity, ruleIndex));
                 }
                 ruleIndex++;
+            }
+
+            if (viewport != null)
+            {
+                foreach (var mediaRule in sheet.MediaRules)
+                {
+                    if (mediaRule.Condition.Matches(viewport))
+                    {
+                        foreach (var rule in mediaRule.Rules)
+                        {
+                            if (rule.Selector.Matches(element))
+                            {
+                                matchedRules.Add((rule, rule.Selector.Specificity, ruleIndex));
+                            }
+                            ruleIndex++;
+                        }
+                    }
+                }
             }
         }
 

--- a/src/Miko/Styling/StyleSheet.cs
+++ b/src/Miko/Styling/StyleSheet.cs
@@ -8,10 +8,32 @@ namespace Miko.Styling;
 public class StyleSheet
 {
     public List<StyleRule> Rules { get; set; } = new();
+    public List<MediaRule> MediaRules { get; set; } = new();
 
     public void AddRule(Selector selector, Style style)
     {
         Rules.Add(new StyleRule { Selector = selector, Style = style });
+    }
+
+    public void AddMediaRule(MediaCondition condition, Selector selector, Style style)
+    {
+        var existing = MediaRules.FirstOrDefault(m => m.Condition == condition);
+        if (existing != null)
+        {
+            existing.Rules.Add(new StyleRule { Selector = selector, Style = style });
+        }
+        else
+        {
+            var mediaRule = new MediaRule
+            {
+                Condition = condition,
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule { Selector = selector, Style = style }
+                }
+            };
+            MediaRules.Add(mediaRule);
+        }
     }
 }
 

--- a/src/Miko/Styling/ViewportInfo.cs
+++ b/src/Miko/Styling/ViewportInfo.cs
@@ -1,0 +1,3 @@
+namespace Miko.Styling;
+
+public record ViewportInfo(float Width, float Height);

--- a/tests/Miko.Tests/Styling/MediaQueryTests.cs
+++ b/tests/Miko.Tests/Styling/MediaQueryTests.cs
@@ -1,0 +1,329 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Styling;
+
+public class MediaQueryTests
+{
+    #region MediaCondition Tests
+
+    [Fact]
+    public void MediaCondition_MinWidth_MatchesWhenViewportWiderOrEqual()
+    {
+        var condition = new MediaCondition { MinWidth = 768 };
+
+        condition.Matches(new ViewportInfo(1024, 600)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(768, 600)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(767, 600)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MediaCondition_MaxWidth_MatchesWhenViewportNarrowerOrEqual()
+    {
+        var condition = new MediaCondition { MaxWidth = 768 };
+
+        condition.Matches(new ViewportInfo(500, 600)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(768, 600)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(769, 600)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MediaCondition_MinHeight_MatchesWhenViewportTallerOrEqual()
+    {
+        var condition = new MediaCondition { MinHeight = 600 };
+
+        condition.Matches(new ViewportInfo(800, 800)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(800, 600)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(800, 599)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MediaCondition_MaxHeight_MatchesWhenViewportShorterOrEqual()
+    {
+        var condition = new MediaCondition { MaxHeight = 600 };
+
+        condition.Matches(new ViewportInfo(800, 400)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(800, 600)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(800, 601)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MediaCondition_CombinedMinMaxWidth_MatchesWithinRange()
+    {
+        var condition = new MediaCondition { MinWidth = 768, MaxWidth = 1024 };
+
+        condition.Matches(new ViewportInfo(800, 600)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(768, 600)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(1024, 600)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(767, 600)).ShouldBeFalse();
+        condition.Matches(new ViewportInfo(1025, 600)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MediaCondition_NoConditions_AlwaysMatches()
+    {
+        var condition = new MediaCondition();
+
+        condition.Matches(new ViewportInfo(100, 100)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(5000, 5000)).ShouldBeTrue();
+    }
+
+    #endregion
+
+    #region StyleResolver with Media Rules
+
+    [Fact]
+    public void Resolve_MediaRuleMatchesViewport_AppliesStyles()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.AddRule(new ClassSelector("box"), new Style { Width = Length.Px(100) });
+        styleSheet.MediaRules.Add(new MediaRule
+        {
+            Condition = new MediaCondition { MinWidth = 768 },
+            Rules = new List<StyleRule>
+            {
+                new StyleRule
+                {
+                    Selector = new ClassSelector("box"),
+                    Style = new Style { Width = Length.Px(200) }
+                }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        var resolver = new StyleResolver();
+
+        var computed = resolver.Resolve(element, new List<StyleSheet> { styleSheet }, new ViewportInfo(1024, 768));
+        computed.Width.Value.ShouldBe(200);
+    }
+
+    [Fact]
+    public void Resolve_MediaRuleDoesNotMatchViewport_DoesNotApplyStyles()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.AddRule(new ClassSelector("box"), new Style { Width = Length.Px(100) });
+        styleSheet.MediaRules.Add(new MediaRule
+        {
+            Condition = new MediaCondition { MinWidth = 768 },
+            Rules = new List<StyleRule>
+            {
+                new StyleRule
+                {
+                    Selector = new ClassSelector("box"),
+                    Style = new Style { Width = Length.Px(200) }
+                }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        var resolver = new StyleResolver();
+
+        var computed = resolver.Resolve(element, new List<StyleSheet> { styleSheet }, new ViewportInfo(480, 768));
+        computed.Width.Value.ShouldBe(100);
+    }
+
+    [Fact]
+    public void Resolve_NoViewportProvided_SkipsMediaRules()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.AddRule(new ClassSelector("box"), new Style { Width = Length.Px(100) });
+        styleSheet.MediaRules.Add(new MediaRule
+        {
+            Condition = new MediaCondition { MinWidth = 768 },
+            Rules = new List<StyleRule>
+            {
+                new StyleRule
+                {
+                    Selector = new ClassSelector("box"),
+                    Style = new Style { Width = Length.Px(200) }
+                }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        var resolver = new StyleResolver();
+
+        var computed = resolver.Resolve(element, new List<StyleSheet> { styleSheet });
+        computed.Width.Value.ShouldBe(100);
+    }
+
+    [Fact]
+    public void Resolve_MediaRuleWithHigherSpecificity_WinsOverBaseRule()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.AddRule(new ClassSelector("box"), new Style { Width = Length.Px(100) });
+        styleSheet.MediaRules.Add(new MediaRule
+        {
+            Condition = new MediaCondition { MinWidth = 768 },
+            Rules = new List<StyleRule>
+            {
+                new StyleRule
+                {
+                    Selector = new IdSelector("main"),
+                    Style = new Style { Width = Length.Px(300) }
+                }
+            }
+        });
+
+        var element = new DivElement { Id = "main", Class = "box" };
+        var resolver = new StyleResolver();
+
+        var computed = resolver.Resolve(element, new List<StyleSheet> { styleSheet }, new ViewportInfo(1024, 768));
+        computed.Width.Value.ShouldBe(300);
+    }
+
+    [Fact]
+    public void Resolve_MultipleMediaRules_OnlyMatchingOnesApply()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.AddRule(new ClassSelector("box"), new Style { Width = Length.Px(100) });
+        styleSheet.MediaRules.Add(new MediaRule
+        {
+            Condition = new MediaCondition { MaxWidth = 480 },
+            Rules = new List<StyleRule>
+            {
+                new StyleRule
+                {
+                    Selector = new ClassSelector("box"),
+                    Style = new Style { Width = Length.Px(50) }
+                }
+            }
+        });
+        styleSheet.MediaRules.Add(new MediaRule
+        {
+            Condition = new MediaCondition { MinWidth = 1024 },
+            Rules = new List<StyleRule>
+            {
+                new StyleRule
+                {
+                    Selector = new ClassSelector("box"),
+                    Style = new Style { Width = Length.Px(400) }
+                }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        var resolver = new StyleResolver();
+
+        // Viewport 320px: only max-width:480 matches
+        var small = resolver.Resolve(element, new List<StyleSheet> { styleSheet }, new ViewportInfo(320, 600));
+        small.Width.Value.ShouldBe(50);
+
+        // Viewport 800px: neither media rule matches
+        var medium = resolver.Resolve(element, new List<StyleSheet> { styleSheet }, new ViewportInfo(800, 600));
+        medium.Width.Value.ShouldBe(100);
+
+        // Viewport 1200px: only min-width:1024 matches
+        var large = resolver.Resolve(element, new List<StyleSheet> { styleSheet }, new ViewportInfo(1200, 600));
+        large.Width.Value.ShouldBe(400);
+    }
+
+    #endregion
+
+    #region StyleSheet AddMediaRule Helper
+
+    [Fact]
+    public void AddMediaRule_SameCondition_GroupsRulesUnderSameMediaRule()
+    {
+        var styleSheet = new StyleSheet();
+        var condition = new MediaCondition { MinWidth = 768 };
+
+        styleSheet.AddMediaRule(condition, new ClassSelector("a"), new Style { Width = Length.Px(100) });
+        styleSheet.AddMediaRule(condition, new ClassSelector("b"), new Style { Width = Length.Px(200) });
+
+        styleSheet.MediaRules.Count.ShouldBe(1);
+        styleSheet.MediaRules[0].Rules.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void AddMediaRule_DifferentConditions_CreatesSeparateMediaRules()
+    {
+        var styleSheet = new StyleSheet();
+
+        styleSheet.AddMediaRule(new MediaCondition { MinWidth = 768 }, new ClassSelector("a"), new Style { Width = Length.Px(100) });
+        styleSheet.AddMediaRule(new MediaCondition { MinWidth = 1024 }, new ClassSelector("b"), new Style { Width = Length.Px(200) });
+
+        styleSheet.MediaRules.Count.ShouldBe(2);
+    }
+
+    #endregion
+
+    #region Integration with LayoutEngine
+
+    [Fact]
+    public void LayoutEngine_MediaQueryChangesDisplay_AffectsLayout()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.AddRule(new ClassSelector("sidebar"), new Style
+        {
+            Display = Display.Block,
+            Width = Length.Px(200)
+        });
+        styleSheet.MediaRules.Add(new MediaRule
+        {
+            Condition = new MediaCondition { MaxWidth = 600 },
+            Rules = new List<StyleRule>
+            {
+                new StyleRule
+                {
+                    Selector = new ClassSelector("sidebar"),
+                    Style = new Style { Display = Display.None }
+                }
+            }
+        });
+
+        var root = new DivElement { Class = "container" };
+        var sidebar = new DivElement { Class = "sidebar" };
+        root.AddChild(sidebar);
+
+        var layoutEngine = new LayoutEngine();
+
+        // Wide viewport: sidebar is visible
+        var wideLayout = layoutEngine.Layout(root, new List<StyleSheet> { styleSheet }, 1024, 768);
+        wideLayout.Children.Count.ShouldBe(1);
+
+        // Narrow viewport: sidebar is hidden (display: none)
+        var narrowLayout = layoutEngine.Layout(root, new List<StyleSheet> { styleSheet }, 480, 768);
+        narrowLayout.Children.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void LayoutEngine_MediaQueryChangesWidth_AffectsBoxDimensions()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.AddRule(new ClassSelector("content"), new Style
+        {
+            Display = Display.Block,
+            Width = Length.Px(600)
+        });
+        styleSheet.MediaRules.Add(new MediaRule
+        {
+            Condition = new MediaCondition { MaxWidth = 768 },
+            Rules = new List<StyleRule>
+            {
+                new StyleRule
+                {
+                    Selector = new ClassSelector("content"),
+                    Style = new Style { Width = Length.Percent(100) }
+                }
+            }
+        });
+
+        var root = new DivElement { Class = "content" };
+        var layoutEngine = new LayoutEngine();
+
+        // Wide viewport: fixed 600px width
+        var wideLayout = layoutEngine.Layout(root, new List<StyleSheet> { styleSheet }, 1024, 768);
+        wideLayout.BoxModel.Content.Width.ShouldBe(600);
+
+        // Narrow viewport: 100% width = viewport width
+        var narrowLayout = layoutEngine.Layout(root, new List<StyleSheet> { styleSheet }, 480, 768);
+        narrowLayout.BoxModel.Content.Width.ShouldBe(480);
+    }
+
+    #endregion
+}

--- a/tests/Miko.Tests/Styling/MediaQueryTests.cs
+++ b/tests/Miko.Tests/Styling/MediaQueryTests.cs
@@ -14,7 +14,7 @@ public class MediaQueryTests
     [Fact]
     public void MediaCondition_MinWidth_MatchesWhenViewportWiderOrEqual()
     {
-        var condition = new MediaCondition { MinWidth = 768 };
+        var condition = MediaCondition.MinWidth(768);
 
         condition.Matches(new ViewportInfo(1024, 600)).ShouldBeTrue();
         condition.Matches(new ViewportInfo(768, 600)).ShouldBeTrue();
@@ -24,7 +24,7 @@ public class MediaQueryTests
     [Fact]
     public void MediaCondition_MaxWidth_MatchesWhenViewportNarrowerOrEqual()
     {
-        var condition = new MediaCondition { MaxWidth = 768 };
+        var condition = MediaCondition.MaxWidth(768);
 
         condition.Matches(new ViewportInfo(500, 600)).ShouldBeTrue();
         condition.Matches(new ViewportInfo(768, 600)).ShouldBeTrue();
@@ -34,7 +34,7 @@ public class MediaQueryTests
     [Fact]
     public void MediaCondition_MinHeight_MatchesWhenViewportTallerOrEqual()
     {
-        var condition = new MediaCondition { MinHeight = 600 };
+        var condition = MediaCondition.MinHeight(600);
 
         condition.Matches(new ViewportInfo(800, 800)).ShouldBeTrue();
         condition.Matches(new ViewportInfo(800, 600)).ShouldBeTrue();
@@ -44,7 +44,7 @@ public class MediaQueryTests
     [Fact]
     public void MediaCondition_MaxHeight_MatchesWhenViewportShorterOrEqual()
     {
-        var condition = new MediaCondition { MaxHeight = 600 };
+        var condition = MediaCondition.MaxHeight(600);
 
         condition.Matches(new ViewportInfo(800, 400)).ShouldBeTrue();
         condition.Matches(new ViewportInfo(800, 600)).ShouldBeTrue();
@@ -52,9 +52,9 @@ public class MediaQueryTests
     }
 
     [Fact]
-    public void MediaCondition_CombinedMinMaxWidth_MatchesWithinRange()
+    public void MediaCondition_CombinedExpression_MatchesWithinRange()
     {
-        var condition = new MediaCondition { MinWidth = 768, MaxWidth = 1024 };
+        var condition = new MediaCondition(v => v.Width >= 768 && v.Width <= 1024);
 
         condition.Matches(new ViewportInfo(800, 600)).ShouldBeTrue();
         condition.Matches(new ViewportInfo(768, 600)).ShouldBeTrue();
@@ -64,12 +64,20 @@ public class MediaQueryTests
     }
 
     [Fact]
-    public void MediaCondition_NoConditions_AlwaysMatches()
+    public void MediaCondition_CustomExpression_SupportsArbitraryLogic()
     {
-        var condition = new MediaCondition();
+        var condition = new MediaCondition(v => v.Width > v.Height);
 
-        condition.Matches(new ViewportInfo(100, 100)).ShouldBeTrue();
-        condition.Matches(new ViewportInfo(5000, 5000)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(1024, 768)).ShouldBeTrue();
+        condition.Matches(new ViewportInfo(768, 1024)).ShouldBeFalse();
+        condition.Matches(new ViewportInfo(800, 800)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MediaCondition_ExpressionProperty_IsAccessible()
+    {
+        var condition = MediaCondition.MinWidth(768);
+        condition.Expression.ShouldNotBeNull();
     }
 
     #endregion
@@ -83,7 +91,7 @@ public class MediaQueryTests
         styleSheet.AddRule(new ClassSelector("box"), new Style { Width = Length.Px(100) });
         styleSheet.MediaRules.Add(new MediaRule
         {
-            Condition = new MediaCondition { MinWidth = 768 },
+            Condition = MediaCondition.MinWidth(768),
             Rules = new List<StyleRule>
             {
                 new StyleRule
@@ -108,7 +116,7 @@ public class MediaQueryTests
         styleSheet.AddRule(new ClassSelector("box"), new Style { Width = Length.Px(100) });
         styleSheet.MediaRules.Add(new MediaRule
         {
-            Condition = new MediaCondition { MinWidth = 768 },
+            Condition = MediaCondition.MinWidth(768),
             Rules = new List<StyleRule>
             {
                 new StyleRule
@@ -133,7 +141,7 @@ public class MediaQueryTests
         styleSheet.AddRule(new ClassSelector("box"), new Style { Width = Length.Px(100) });
         styleSheet.MediaRules.Add(new MediaRule
         {
-            Condition = new MediaCondition { MinWidth = 768 },
+            Condition = MediaCondition.MinWidth(768),
             Rules = new List<StyleRule>
             {
                 new StyleRule
@@ -158,7 +166,7 @@ public class MediaQueryTests
         styleSheet.AddRule(new ClassSelector("box"), new Style { Width = Length.Px(100) });
         styleSheet.MediaRules.Add(new MediaRule
         {
-            Condition = new MediaCondition { MinWidth = 768 },
+            Condition = MediaCondition.MinWidth(768),
             Rules = new List<StyleRule>
             {
                 new StyleRule
@@ -183,7 +191,7 @@ public class MediaQueryTests
         styleSheet.AddRule(new ClassSelector("box"), new Style { Width = Length.Px(100) });
         styleSheet.MediaRules.Add(new MediaRule
         {
-            Condition = new MediaCondition { MaxWidth = 480 },
+            Condition = MediaCondition.MaxWidth(480),
             Rules = new List<StyleRule>
             {
                 new StyleRule
@@ -195,7 +203,7 @@ public class MediaQueryTests
         });
         styleSheet.MediaRules.Add(new MediaRule
         {
-            Condition = new MediaCondition { MinWidth = 1024 },
+            Condition = MediaCondition.MinWidth(1024),
             Rules = new List<StyleRule>
             {
                 new StyleRule
@@ -209,15 +217,12 @@ public class MediaQueryTests
         var element = new DivElement { Class = "box" };
         var resolver = new StyleResolver();
 
-        // Viewport 320px: only max-width:480 matches
         var small = resolver.Resolve(element, new List<StyleSheet> { styleSheet }, new ViewportInfo(320, 600));
         small.Width.Value.ShouldBe(50);
 
-        // Viewport 800px: neither media rule matches
         var medium = resolver.Resolve(element, new List<StyleSheet> { styleSheet }, new ViewportInfo(800, 600));
         medium.Width.Value.ShouldBe(100);
 
-        // Viewport 1200px: only min-width:1024 matches
         var large = resolver.Resolve(element, new List<StyleSheet> { styleSheet }, new ViewportInfo(1200, 600));
         large.Width.Value.ShouldBe(400);
     }
@@ -230,7 +235,7 @@ public class MediaQueryTests
     public void AddMediaRule_SameCondition_GroupsRulesUnderSameMediaRule()
     {
         var styleSheet = new StyleSheet();
-        var condition = new MediaCondition { MinWidth = 768 };
+        var condition = MediaCondition.MinWidth(768);
 
         styleSheet.AddMediaRule(condition, new ClassSelector("a"), new Style { Width = Length.Px(100) });
         styleSheet.AddMediaRule(condition, new ClassSelector("b"), new Style { Width = Length.Px(200) });
@@ -244,8 +249,8 @@ public class MediaQueryTests
     {
         var styleSheet = new StyleSheet();
 
-        styleSheet.AddMediaRule(new MediaCondition { MinWidth = 768 }, new ClassSelector("a"), new Style { Width = Length.Px(100) });
-        styleSheet.AddMediaRule(new MediaCondition { MinWidth = 1024 }, new ClassSelector("b"), new Style { Width = Length.Px(200) });
+        styleSheet.AddMediaRule(MediaCondition.MinWidth(768), new ClassSelector("a"), new Style { Width = Length.Px(100) });
+        styleSheet.AddMediaRule(MediaCondition.MinWidth(1024), new ClassSelector("b"), new Style { Width = Length.Px(200) });
 
         styleSheet.MediaRules.Count.ShouldBe(2);
     }
@@ -265,7 +270,7 @@ public class MediaQueryTests
         });
         styleSheet.MediaRules.Add(new MediaRule
         {
-            Condition = new MediaCondition { MaxWidth = 600 },
+            Condition = MediaCondition.MaxWidth(600),
             Rules = new List<StyleRule>
             {
                 new StyleRule
@@ -302,7 +307,7 @@ public class MediaQueryTests
         });
         styleSheet.MediaRules.Add(new MediaRule
         {
-            Condition = new MediaCondition { MaxWidth = 768 },
+            Condition = MediaCondition.MaxWidth(768),
             Rules = new List<StyleRule>
             {
                 new StyleRule


### PR DESCRIPTION
## Summary

- Add `@media` query support for responsive layouts, enabling conditional style application based on viewport dimensions
- `MediaCondition` uses `Expression<Func<ViewportInfo, bool>>` for full flexibility — supports arbitrary predicates (aspect ratio, combined ranges, custom logic) while remaining inspectable at runtime
- Static factory methods (`MediaCondition.MinWidth()`, `MaxWidth()`, `MinHeight()`, `MaxHeight()`) preserve ergonomics for common patterns
- `StyleResolver` evaluates media rules during style cascade with correct specificity and definition-order semantics

## Changes

- New: `ViewportInfo`, `MediaCondition`, `MediaRule` types in `src/Miko/Styling/`
- Modified: `StyleSheet` (added `MediaRules` list + `AddMediaRule` helper)
- Modified: `StyleResolver` (accepts optional `ViewportInfo`, evaluates media rules)
- Modified: `LayoutEngine` (passes viewport dimensions to resolver)
- New: 16 unit tests covering condition matching, cascade behavior, and layout integration

## Test plan

- [x] All 442 existing + new tests pass
- [x] Media rules apply only when viewport matches condition
- [x] Media rules are skipped when no viewport info is provided (backward compatible)
- [x] Specificity and cascade ordering work correctly with media rules
- [x] Layout engine respects media query changes (display:none, width changes)