### PR TITLE
Fix Razor event binding, icon rendering, and form input types

### DIFF
--- a/examples/MikoApp1.Razor/Components/FormControlExample.razor
+++ b/examples/MikoApp1.Razor/Components/FormControlExample.razor
@@ -56,32 +56,32 @@
 
     <h2>Checkboxes</h2>
     <div class="form-check">
-        <input class="form-check-input" id="check1" />
+        <input type="checkbox" class="form-check-input" id="check1" />
         <label class="form-check-label" id="check1">Default checkbox</label>
     </div>
     <div class="form-check">
-        <input class="form-check-input" id="check2" />
+        <input type="checkbox" class="form-check-input" id="check2" />
         <label class="form-check-label" id="check2">Checked checkbox</label>
     </div>
 
     <h2>Radio Buttons</h2>
     <div class="form-check">
-        <input class="form-check-input" id="radio1" />
+        <input type="radio" class="form-check-input" id="radio1" />
         <label class="form-check-label" id="radio1">Default radio</label>
     </div>
     <div class="form-check">
-        <input class="form-check-input" id="radio2" />
+        <input type="radio" class="form-check-input" id="radio2" />
         <label class="form-check-label" id="radio2">Second radio</label>
     </div>
     <div class="form-check">
-        <input class="form-check-input" id="radio3" />
+        <input type="radio" class="form-check-input" id="radio3" />
         <label class="form-check-label" id="radio3">Third radio</label>
     </div>
 
     <h2>Range Input</h2>
     <div class="mb-3">
         <label class="form-label">Example range</label>
-        <input class="form-range" />
+        <input type="range" class="form-range" />
     </div>
 
     <h2>Validation States</h2>

--- a/examples/MikoApp1.Razor/MainLayout.razor
+++ b/examples/MikoApp1.Razor/MainLayout.razor
@@ -2,20 +2,20 @@
 
 <div class="layout">
     <div class="sidebar">
-        <h2>Miko Demo</h2>
-        <div class="nav-item">
+        <h2 class="title">Miko Demo</h2>
+        <div class="nav-item" @onclick="NavigateToButton">
             <span>Button</span>
         </div>
-        <div class="nav-item">
+        <div class="nav-item" @onclick="NavigateToForm">
             <span>Form</span>
         </div>
-        <div class="nav-item">
+        <div class="nav-item" @onclick="NavigateToList">
             <span>List</span>
         </div>
-        <div class="nav-item">
+        <div class="nav-item" @onclick="NavigateToIcon">
             <span>Icon</span>
         </div>
-        <div class="nav-item">
+        <div class="nav-item" @onclick="NavigateToTable">
             <span>Table</span>
         </div>
     </div>
@@ -25,6 +25,33 @@
 </div>
 
 @code {
+
+    private void NavigateToButton()
+    {
+        NavigationManager?.NavigateTo("/button");
+    }
+
+    private void NavigateToForm()
+    {
+        NavigationManager?.NavigateTo("/form");
+    }
+
+    private void NavigateToList()
+    {
+        NavigationManager?.NavigateTo("/list");
+    }
+
+    private void NavigateToIcon()
+    {
+        NavigationManager?.NavigateTo("/icon");
+    }
+
+    private void NavigateToTable()
+    {
+        NavigationManager?.NavigateTo("/table");
+    }
+
+
     public static Miko.Styling.StyleSheet CreateLayoutStyleSheet()
     {
         return new Miko.Styling.StyleSheet
@@ -50,6 +77,14 @@
                         Height = Miko.Common.Length.Percent(100),
                         Padding = Miko.Common.Length.Px(16),
                         BackgroundColor = Miko.Common.Color.FromRgb(52, 58, 64),
+                        Color = Miko.Common.Color.White,
+                    }
+                },
+                new()
+                {
+                    Selector = new Miko.Styling.Selectors.ClassSelector("title"),
+                    Style = new Miko.Styling.Style
+                    {
                         Color = Miko.Common.Color.White,
                     }
                 },

--- a/examples/MikoApp1.Razor/MikoApp1.Razor.csproj
+++ b/examples/MikoApp1.Razor/MikoApp1.Razor.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RazorLangVersion>Latest</RazorLangVersion>
     <StartupObject>MikoApp1.Razor.Program</StartupObject>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>

--- a/src/Miko/Components/EventCallback.cs
+++ b/src/Miko/Components/EventCallback.cs
@@ -1,0 +1,23 @@
+using Miko.Events;
+
+namespace Miko.Components;
+
+public static class EventCallback
+{
+    public static readonly EventCallbackFactory Factory = new();
+}
+
+public readonly struct EventCallback<T> where T : MikoEventArgs
+{
+    public readonly MikoEventHandler<T>? Handler;
+    internal EventCallback(MikoEventHandler<T>? handler) => Handler = handler;
+}
+
+public sealed class EventCallbackFactory
+{
+    public EventCallback<T> Create<T>(object receiver, MikoEventHandler<T> handler)
+        where T : MikoEventArgs => new(handler);
+
+    public EventCallback<T> Create<T>(object receiver, Action handler)
+        where T : MikoEventArgs => new(_ => handler());
+}

--- a/src/Miko/Components/EventHandlerAttribute.cs
+++ b/src/Miko/Components/EventHandlerAttribute.cs
@@ -1,0 +1,10 @@
+namespace Miko.Components;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public sealed class EventHandlerAttribute(
+    string attributeName, Type eventArgsType,
+    bool enableStopPropagation = false, bool enablePreventDefault = false) : Attribute
+{
+    public string AttributeName { get; } = attributeName;
+    public Type EventArgsType { get; } = eventArgsType;
+}

--- a/src/Miko/Components/EventHandlers.cs
+++ b/src/Miko/Components/EventHandlers.cs
@@ -1,0 +1,16 @@
+using Miko.Events;
+
+namespace Miko.Components;
+
+[EventHandler("onclick",      typeof(MouseEventArgs),    true, true)]
+[EventHandler("onmouseenter", typeof(MouseEventArgs))]
+[EventHandler("onmouseleave", typeof(MouseEventArgs))]
+[EventHandler("onmousedown",  typeof(MouseEventArgs),    true, true)]
+[EventHandler("onmouseup",    typeof(MouseEventArgs),    true, true)]
+[EventHandler("onfocus",      typeof(FocusEventArgs))]
+[EventHandler("onblur",       typeof(FocusEventArgs))]
+[EventHandler("onchange",     typeof(ChangeEventArgs))]
+[EventHandler("onscroll",     typeof(ScrollEventArgs))]
+[EventHandler("onkeydown",    typeof(KeyboardEventArgs), true, true)]
+[EventHandler("oninput",      typeof(InputEventArgs))]
+public static class EventHandlers { }

--- a/src/Miko/Components/RenderTreeBuilder.cs
+++ b/src/Miko/Components/RenderTreeBuilder.cs
@@ -1,5 +1,8 @@
+using Miko.Common;
 using Miko.Core;
 using Miko.Core.DomElements;
+using Miko.Events;
+using System.Net;
 using System.Text.RegularExpressions;
 
 namespace Miko.Components;
@@ -63,6 +66,16 @@ public class RenderTreeBuilder
         {
             case "class": element.Class = value; break;
             case "id": element.Id = value; break;
+            case "type" when element is InputElement input:
+                input.Type = value?.ToLowerInvariant() switch
+                {
+                    "checkbox" => InputType.Checkbox,
+                    "radio" => InputType.Radio,
+                    "password" => InputType.Password,
+                    "range" => InputType.Range,
+                    _ => InputType.Text,
+                };
+                break;
         }
     }
 
@@ -70,6 +83,27 @@ public class RenderTreeBuilder
         AddAttribute(seq, name, value?.ToString());
 
     public void AddAttribute(int seq, string name, bool value) { }
+
+    public void AddAttribute<T>(int seq, string name, EventCallback<T> callback)
+        where T : MikoEventArgs
+    {
+        if (_stack.Count == 0 || callback.Handler is null) return;
+        var element = _stack.Peek();
+        switch (name)
+        {
+            case "onclick"      when callback.Handler is MikoEventHandler<MouseEventArgs> h:    element.OnClick = h; break;
+            case "onmouseenter" when callback.Handler is MikoEventHandler<MouseEventArgs> h:    element.OnMouseEnter = h; break;
+            case "onmouseleave" when callback.Handler is MikoEventHandler<MouseEventArgs> h:    element.OnMouseLeave = h; break;
+            case "onmousedown"  when callback.Handler is MikoEventHandler<MouseEventArgs> h:    element.OnMouseDown = h; break;
+            case "onmouseup"    when callback.Handler is MikoEventHandler<MouseEventArgs> h:    element.OnMouseUp = h; break;
+            case "onfocus"      when callback.Handler is MikoEventHandler<FocusEventArgs> h:    element.OnFocus = h; break;
+            case "onblur"       when callback.Handler is MikoEventHandler<FocusEventArgs> h:    element.OnBlur = h; break;
+            case "onchange"     when callback.Handler is MikoEventHandler<ChangeEventArgs> h:   element.OnChange = h; break;
+            case "onscroll"     when callback.Handler is MikoEventHandler<ScrollEventArgs> h:   element.OnScroll = h; break;
+            case "onkeydown"    when callback.Handler is MikoEventHandler<KeyboardEventArgs> h: element.OnKeyDown = h; break;
+            case "oninput"      when callback.Handler is MikoEventHandler<InputEventArgs> h:    element.OnInput = h; break;
+        }
+    }
 
     public void AddContent(int seq, object? text)
     {
@@ -81,7 +115,7 @@ public class RenderTreeBuilder
         }
         var str = text.ToString();
         if (string.IsNullOrWhiteSpace(str)) return;
-        _stack.Peek().TextContent = str;
+        _stack.Peek().TextContent = WebUtility.HtmlDecode(str);
     }
 
     public void AddMarkupContent(int seq, string? markup)


### PR DESCRIPTION
## Summary
- Add `EventHandlerAttribute`, `EventCallback<T>`, and `EventHandlers` types so the Razor compiler recognizes `@onclick` and other event directives
- Decode HTML entities in `RenderTreeBuilder.AddContent` for correct icon rendering (`&#xf425;` → ``)
- Handle `type` attribute in `RenderTreeBuilder` for input elements (checkbox, radio, range)
- Add click event handlers with `NavigationManager` navigation to MainLayout sidebar
- Add missing `type` attributes to form checkbox, radio, and range inputs

## Test plan
- [x] `dotnet build` succeeds with 0 errors
- [x] All 449 existing tests pass
- [x] Generated Razor code correctly emits `EventCallback.Factory.Create<MouseEventArgs>` for `@onclick`
- [x] Generated Razor code correctly emits `AddAttribute("type", "checkbox")` for typed inputs