### PR TITLE
Add anchor element (a tag) with default rendering behavior

### DIFF
--- a/src/Miko/Common/Enums.cs
+++ b/src/Miko/Common/Enums.cs
@@ -138,3 +138,14 @@ public enum Overflow
     Scroll,
     Auto
 }
+
+/// <summary>
+/// 文本装饰
+/// </summary>
+public enum TextDecoration
+{
+    None,
+    Underline,
+    Overline,
+    LineThrough
+}

--- a/src/Miko/Components/RenderTreeBuilder.cs
+++ b/src/Miko/Components/RenderTreeBuilder.cs
@@ -14,6 +14,7 @@ public class RenderTreeBuilder
 
     private static readonly Dictionary<string, Func<Element>> _tagMap = new(StringComparer.OrdinalIgnoreCase)
     {
+        ["a"] = () => new AnchorElement(),
         ["div"] = () => new DivElement(),
         ["span"] = () => new SpanElement(),
         ["p"] = () => new ParagraphElement(),
@@ -66,6 +67,12 @@ public class RenderTreeBuilder
         {
             case "class": element.Class = value; break;
             case "id": element.Id = value; break;
+            case "href" when element is AnchorElement anchor:
+                anchor.Href = value; break;
+            case "target" when element is AnchorElement anchor:
+                anchor.Target = value; break;
+            case "rel" when element is AnchorElement anchor:
+                anchor.Rel = value; break;
             case "type" when element is InputElement input:
                 input.Type = value?.ToLowerInvariant() switch
                 {

--- a/src/Miko/Core/DomElements/InteractiveElements.cs
+++ b/src/Miko/Core/DomElements/InteractiveElements.cs
@@ -3,6 +3,29 @@ using Miko.Common;
 namespace Miko.Core.DomElements;
 
 /// <summary>
+/// 锚点（超链接）元素
+/// </summary>
+public class AnchorElement : Element
+{
+    public override string TagName => "a";
+
+    /// <summary>
+    /// 链接目标 URL
+    /// </summary>
+    public string? Href { get; set; }
+
+    /// <summary>
+    /// 链接打开方式（_self, _blank, _parent, _top）
+    /// </summary>
+    public string? Target { get; set; }
+
+    /// <summary>
+    /// 链接与目标之间的关系（如 noopener, noreferrer）
+    /// </summary>
+    public string? Rel { get; set; }
+}
+
+/// <summary>
 /// 按钮元素
 /// </summary>
 public class ButtonElement : Element

--- a/src/Miko/Rendering/Painter.cs
+++ b/src/Miko/Rendering/Painter.cs
@@ -753,6 +753,56 @@ public class Painter
     }
 
     /// <summary>
+    /// 绘制文本装饰（下划线、上划线、删除线）
+    /// </summary>
+    public void DrawTextDecoration(string text, RectF rect, Color color, string fontFamily, float fontSize, FontWeight fontWeight, TextAlign textAlign, TextDecoration decoration)
+    {
+        if (decoration == TextDecoration.None || string.IsNullOrEmpty(text) || color.A == 0) return;
+
+        var fontManager = FontManager.Instance;
+        var fallbackResolver = new FontFallbackResolver(fontManager);
+        var textRuns = fallbackResolver.ResolveTextRuns(text, fontFamily, fontWeight);
+
+        if (textRuns.Count == 0) return;
+
+        using var measurePaint = new SKPaint { IsAntialias = true };
+
+        float totalWidth = 0;
+        foreach (var run in textRuns)
+        {
+            using var font = new SKFont(run.Typeface, fontSize);
+            totalWidth += font.MeasureText(run.Text, measurePaint);
+        }
+
+        float x = textAlign switch
+        {
+            TextAlign.Left => rect.Left,
+            TextAlign.Right => rect.Right - totalWidth,
+            TextAlign.Center => rect.Left + (rect.Width - totalWidth) / 2,
+            _ => rect.Left
+        };
+
+        float baselineY = rect.Top + (rect.Height + fontSize) / 2;
+        float lineY = decoration switch
+        {
+            TextDecoration.Underline => baselineY + fontSize * 0.15f,
+            TextDecoration.Overline => baselineY - fontSize,
+            TextDecoration.LineThrough => baselineY - fontSize * 0.35f,
+            _ => baselineY
+        };
+
+        using var paint = new SKPaint
+        {
+            Color = color.ToSKColor(),
+            StrokeWidth = Math.Max(1f, fontSize / 14f),
+            Style = SKPaintStyle.Stroke,
+            IsAntialias = true
+        };
+
+        _canvas.DrawLine(x, lineY, x + totalWidth, lineY, paint);
+    }
+
+    /// <summary>
     /// 平移画布
     /// </summary>
     public void Translate(float dx, float dy)

--- a/src/Miko/Rendering/RenderEngine.cs
+++ b/src/Miko/Rendering/RenderEngine.cs
@@ -297,6 +297,20 @@ public class RenderEngine
                 style.FontWeight,
                 style.TextAlign
             );
+
+            if (style.TextDecoration != Common.TextDecoration.None)
+            {
+                _painter.DrawTextDecoration(
+                    element.TextContent,
+                    box.BoxModel.Content,
+                    style.Color,
+                    style.FontFamily,
+                    style.FontSize.Value,
+                    style.FontWeight,
+                    style.TextAlign,
+                    style.TextDecoration
+                );
+            }
         }
 
         // 渲染图片

--- a/src/Miko/Styling/ComputedStyle.cs
+++ b/src/Miko/Styling/ComputedStyle.cs
@@ -78,6 +78,8 @@ public class ComputedStyle : Style
     public new Length Bottom { get; set; } = Length.Auto;
     public new Length Left { get; set; } = Length.Auto;
 
+    public new TextDecoration TextDecoration { get; set; } = Common.TextDecoration.None;
+
     public new float Opacity { get; set; } = 1.0f;
     public new int ZIndex { get; set; } = 0;
 
@@ -200,6 +202,8 @@ public class ComputedStyle : Style
             if (style.Right.HasValue) computed.Right = style.Right.Value;
             if (style.Bottom.HasValue) computed.Bottom = style.Bottom.Value;
             if (style.Left.HasValue) computed.Left = style.Left.Value;
+
+            if (style.TextDecoration.HasValue) computed.TextDecoration = style.TextDecoration.Value;
 
             if (style.Opacity.HasValue) computed.Opacity = style.Opacity.Value;
             if (style.ZIndex.HasValue) computed.ZIndex = style.ZIndex.Value;

--- a/src/Miko/Styling/Style.cs
+++ b/src/Miko/Styling/Style.cs
@@ -226,6 +226,8 @@ public class Style
     public Length? Bottom { get; set; }
     public Length? Left { get; set; }
 
+    public TextDecoration? TextDecoration { get; set; }
+
     public float? Opacity { get; set; }
     public int? ZIndex { get; set; }
 
@@ -313,6 +315,8 @@ public class Style
         Right ??= other.Right;
         Bottom ??= other.Bottom;
         Left ??= other.Left;
+
+        TextDecoration ??= other.TextDecoration;
 
         Opacity ??= other.Opacity;
         ZIndex ??= other.ZIndex;

--- a/src/Miko/Styling/StyleResolver.cs
+++ b/src/Miko/Styling/StyleResolver.cs
@@ -275,6 +275,14 @@ public class StyleResolver
                 style.Display ??= Common.Display.Inline;
                 break;
 
+            case "a":
+                // Browser default: display: inline, color: blue, text-decoration: underline
+                // Cursor: pointer (not implemented)
+                style.Display ??= Common.Display.Inline;
+                style.Color ??= new Common.Color(0, 0, 238);  // Browser default link blue
+                style.TextDecoration ??= Common.TextDecoration.Underline;
+                break;
+
             case "ul":
                 // Browser default: display: block, margin: 1em 0, padding-left: 40px
                 // list-style-type: disc (not implemented - visual bullets would need Painter support)

--- a/tests/Miko.Tests/Core/AnchorElementTests.cs
+++ b/tests/Miko.Tests/Core/AnchorElementTests.cs
@@ -1,0 +1,93 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Styling;
+using Shouldly;
+
+namespace Miko.Tests.Core;
+
+public class AnchorElementTests
+{
+    [Fact]
+    public void TagName_ShouldBeA()
+    {
+        var anchor = new AnchorElement();
+        anchor.TagName.ShouldBe("a");
+    }
+
+    [Fact]
+    public void Href_ShouldBeSettable()
+    {
+        var anchor = new AnchorElement { Href = "https://example.com" };
+        anchor.Href.ShouldBe("https://example.com");
+    }
+
+    [Fact]
+    public void Target_ShouldBeSettable()
+    {
+        var anchor = new AnchorElement { Target = "_blank" };
+        anchor.Target.ShouldBe("_blank");
+    }
+
+    [Fact]
+    public void Rel_ShouldBeSettable()
+    {
+        var anchor = new AnchorElement { Rel = "noopener noreferrer" };
+        anchor.Rel.ShouldBe("noopener noreferrer");
+    }
+
+    [Fact]
+    public void DefaultStyle_ShouldBeInline()
+    {
+        var anchor = new AnchorElement { TextContent = "Link" };
+        var resolver = new StyleResolver();
+        var style = resolver.Resolve(anchor, new List<StyleSheet>());
+
+        style.Display.ShouldBe(Display.Inline);
+    }
+
+    [Fact]
+    public void DefaultStyle_ShouldHaveBlueColor()
+    {
+        var anchor = new AnchorElement { TextContent = "Link" };
+        var resolver = new StyleResolver();
+        var style = resolver.Resolve(anchor, new List<StyleSheet>());
+
+        style.Color.ShouldBe(new Color(0, 0, 238));
+    }
+
+    [Fact]
+    public void DefaultStyle_ShouldHaveUnderline()
+    {
+        var anchor = new AnchorElement { TextContent = "Link" };
+        var resolver = new StyleResolver();
+        var style = resolver.Resolve(anchor, new List<StyleSheet>());
+
+        style.TextDecoration.ShouldBe(TextDecoration.Underline);
+    }
+
+    [Fact]
+    public void CanContainChildren()
+    {
+        var anchor = new AnchorElement { Href = "https://example.com" };
+        var span = new SpanElement { TextContent = "Click here" };
+
+        anchor.AddChild(span);
+
+        anchor.Children.Count.ShouldBe(1);
+        anchor.Children[0].ShouldBe(span);
+    }
+
+    [Fact]
+    public void InlineStyle_ShouldOverrideDefaultColor()
+    {
+        var anchor = new AnchorElement
+        {
+            TextContent = "Link",
+            Style = new Style { Color = Color.Red }
+        };
+        var resolver = new StyleResolver();
+        var style = resolver.Resolve(anchor, new List<StyleSheet>());
+
+        style.Color.ShouldBe(Color.Red);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AnchorElement` class with `Href`, `Target`, `Rel` properties
- Add `TextDecoration` enum and full style system support (underline, overline, line-through)
- Apply browser-default styles for `<a>` tag: `display: inline`, `color: rgb(0,0,238)`, `text-decoration: underline`
- Add underline rendering support in `Painter` and `RenderEngine`
- Register `<a>` tag in `RenderTreeBuilder` with `href`, `target`, `rel` attribute parsing

## Test plan
- [x] 9 new unit tests for AnchorElement (properties, default styles, style override, child containment)
- [x] All 458 existing tests pass with no regressions
- [x] Build succeeds across all projects