### PR TITLE
Add combinator selectors (descendant, child, adjacent sibling, general sibling)

### DIFF
--- a/src/Miko/Styling/Selectors/CombinatorSelectors.cs
+++ b/src/Miko/Styling/Selectors/CombinatorSelectors.cs
@@ -1,0 +1,115 @@
+using Miko.Core;
+
+namespace Miko.Styling.Selectors;
+
+/// <summary>
+/// 后代选择器 (A B) - 匹配作为A后代的B元素
+/// </summary>
+public class DescendantSelector : Selector
+{
+    public Selector Ancestor { get; }
+    public Selector Descendant { get; }
+
+    public DescendantSelector(Selector ancestor, Selector descendant)
+    {
+        Ancestor = ancestor;
+        Descendant = descendant;
+    }
+
+    public override bool Matches(Element element)
+    {
+        if (!Descendant.Matches(element)) return false;
+
+        var current = element.Parent;
+        while (current != null)
+        {
+            if (Ancestor.Matches(current)) return true;
+            current = current.Parent;
+        }
+        return false;
+    }
+
+    public override int Specificity => Ancestor.Specificity + Descendant.Specificity;
+}
+
+/// <summary>
+/// 子选择器 (A > B) - 匹配作为A直接子元素的B元素
+/// </summary>
+public class ChildSelector : Selector
+{
+    public Selector Parent { get; }
+    public Selector Child { get; }
+
+    public ChildSelector(Selector parent, Selector child)
+    {
+        Parent = parent;
+        Child = child;
+    }
+
+    public override bool Matches(Element element)
+    {
+        if (!Child.Matches(element)) return false;
+        return element.Parent != null && Parent.Matches(element.Parent);
+    }
+
+    public override int Specificity => Parent.Specificity + Child.Specificity;
+}
+
+/// <summary>
+/// 相邻兄弟选择器 (A + B) - 匹配紧跟在A后面的B元素
+/// </summary>
+public class AdjacentSiblingSelector : Selector
+{
+    public Selector Previous { get; }
+    public Selector Target { get; }
+
+    public AdjacentSiblingSelector(Selector previous, Selector target)
+    {
+        Previous = previous;
+        Target = target;
+    }
+
+    public override bool Matches(Element element)
+    {
+        if (!Target.Matches(element)) return false;
+        if (element.Parent == null) return false;
+
+        var siblings = element.Parent.Children;
+        var index = siblings.IndexOf(element);
+        return index > 0 && Previous.Matches(siblings[index - 1]);
+    }
+
+    public override int Specificity => Previous.Specificity + Target.Specificity;
+}
+
+/// <summary>
+/// 通用兄弟选择器 (A ~ B) - 匹配A之后的所有兄弟B元素
+/// </summary>
+public class GeneralSiblingSelector : Selector
+{
+    public Selector Previous { get; }
+    public Selector Target { get; }
+
+    public GeneralSiblingSelector(Selector previous, Selector target)
+    {
+        Previous = previous;
+        Target = target;
+    }
+
+    public override bool Matches(Element element)
+    {
+        if (!Target.Matches(element)) return false;
+        if (element.Parent == null) return false;
+
+        var siblings = element.Parent.Children;
+        var index = siblings.IndexOf(element);
+
+        for (var i = 0; i < index; i++)
+        {
+            if (Previous.Matches(siblings[i])) return true;
+        }
+        return false;
+    }
+
+    public override int Specificity => Previous.Specificity + Target.Specificity;
+}

--- a/src/Miko/Styling/Style.cs
+++ b/src/Miko/Styling/Style.cs
@@ -396,4 +396,28 @@ public class Style
 
     public static TypedStyleBuilder<Element> Id(string id)
         => new TypedStyleBuilder<Element>(new IdSelector(id));
+
+    /// <summary>
+    /// 后代选择器 (ancestor descendant)
+    /// </summary>
+    public static CombinatorStyleBuilder<Element> Descendant(Selector ancestor, Selector descendant)
+        => new(new DescendantSelector(ancestor, descendant));
+
+    /// <summary>
+    /// 子选择器 (parent > child)
+    /// </summary>
+    public static CombinatorStyleBuilder<Element> Child(Selector parent, Selector child)
+        => new(new ChildSelector(parent, child));
+
+    /// <summary>
+    /// 相邻兄弟选择器 (previous + target)
+    /// </summary>
+    public static CombinatorStyleBuilder<Element> Adjacent(Selector previous, Selector target)
+        => new(new AdjacentSiblingSelector(previous, target));
+
+    /// <summary>
+    /// 通用兄弟选择器 (previous ~ target)
+    /// </summary>
+    public static CombinatorStyleBuilder<Element> Sibling(Selector previous, Selector target)
+        => new(new GeneralSiblingSelector(previous, target));
 }

--- a/src/Miko/Styling/StyleSheet.cs
+++ b/src/Miko/Styling/StyleSheet.cs
@@ -22,6 +22,12 @@ public class StyleSheet
         Rules.Add(new StyleRule { Selector = selector, Style = style });
     }
 
+    public void AddRule<T>(CombinatorStyleBuilder<T> builder) where T : Element
+    {
+        var (selector, style) = builder.Build();
+        Rules.Add(new StyleRule { Selector = selector, Style = style });
+    }
+
     public void AddMediaRule<T>(MediaCondition condition, TypedStyleBuilder<T> builder) where T : Element
     {
         var (selector, style) = builder.Build();

--- a/src/Miko/Styling/TypedStyleBuilder.cs
+++ b/src/Miko/Styling/TypedStyleBuilder.cs
@@ -69,9 +69,109 @@ public class TypedStyleBuilder<T> where T : Element
     public TypedStyleBuilder<T> Disabled() { _selectors.Add(new DisabledSelector()); return this; }
     public TypedStyleBuilder<T> Enabled()  { _selectors.Add(new EnabledSelector());  return this; }
 
+    /// <summary>
+    /// 后代选择器 (A B) - 当前选择器作为祖先，匹配后代元素
+    /// </summary>
+    public CombinatorStyleBuilder<TTarget> Descendant<TTarget>(Selector targetSelector) where TTarget : Element
+        => new(new DescendantSelector(BuildSelector(), targetSelector));
+
+    /// <summary>
+    /// 后代选择器 - 使用标签选择器作为后代目标
+    /// </summary>
+    public CombinatorStyleBuilder<TTarget> Descendant<TTarget>() where TTarget : Element, new()
+        => Descendant<TTarget>(new TagSelector(new TTarget().TagName));
+
+    /// <summary>
+    /// 子选择器 (A > B) - 当前选择器作为父元素，匹配直接子元素
+    /// </summary>
+    public CombinatorStyleBuilder<TTarget> Child<TTarget>(Selector targetSelector) where TTarget : Element
+        => new(new ChildSelector(BuildSelector(), targetSelector));
+
+    /// <summary>
+    /// 子选择器 - 使用标签选择器作为子元素目标
+    /// </summary>
+    public CombinatorStyleBuilder<TTarget> Child<TTarget>() where TTarget : Element, new()
+        => Child<TTarget>(new TagSelector(new TTarget().TagName));
+
+    /// <summary>
+    /// 相邻兄弟选择器 (A + B) - 当前选择器作为前一个兄弟，匹配紧邻的下一个兄弟
+    /// </summary>
+    public CombinatorStyleBuilder<TTarget> Adjacent<TTarget>(Selector targetSelector) where TTarget : Element
+        => new(new AdjacentSiblingSelector(BuildSelector(), targetSelector));
+
+    /// <summary>
+    /// 相邻兄弟选择器 - 使用标签选择器作为目标
+    /// </summary>
+    public CombinatorStyleBuilder<TTarget> Adjacent<TTarget>() where TTarget : Element, new()
+        => Adjacent<TTarget>(new TagSelector(new TTarget().TagName));
+
+    /// <summary>
+    /// 通用兄弟选择器 (A ~ B) - 当前选择器作为前一个兄弟，匹配之后的所有兄弟
+    /// </summary>
+    public CombinatorStyleBuilder<TTarget> Sibling<TTarget>(Selector targetSelector) where TTarget : Element
+        => new(new GeneralSiblingSelector(BuildSelector(), targetSelector));
+
+    /// <summary>
+    /// 通用兄弟选择器 - 使用标签选择器作为目标
+    /// </summary>
+    public CombinatorStyleBuilder<TTarget> Sibling<TTarget>() where TTarget : Element, new()
+        => Sibling<TTarget>(new TagSelector(new TTarget().TagName));
+
+    private Selector BuildSelector()
+        => _selectors.Count == 1 ? _selectors[0] : new CompoundSelector(_selectors);
+
     internal (Selector selector, Style style) Build()
     {
-        var selector = _selectors.Count == 1 ? _selectors[0] : new CompoundSelector(_selectors);
+        var selector = BuildSelector();
         return (selector, _style);
     }
+}
+
+/// <summary>
+/// 组合器样式构建器，用于在组合器选择器上设置样式
+/// </summary>
+public class CombinatorStyleBuilder<T> where T : Element
+{
+    private Selector _selector;
+    private readonly Style _style = new();
+
+    internal CombinatorStyleBuilder(Selector selector) => _selector = selector;
+
+    public CombinatorStyleBuilder<T> Set<TValue>(Expression<Func<Style, TValue?>> prop, TValue value)
+    {
+        ((PropertyInfo)((MemberExpression)prop.Body).Member).SetValue(_style, value);
+        return this;
+    }
+
+    public CombinatorStyleBuilder<T> Set(Expression<Func<Style, Padding>> prop, Padding value)
+    {
+        ((PropertyInfo)((MemberExpression)prop.Body).Member).SetValue(_style, value);
+        return this;
+    }
+
+    public CombinatorStyleBuilder<T> Set(Expression<Func<Style, Margin>> prop, Margin value)
+    {
+        ((PropertyInfo)((MemberExpression)prop.Body).Member).SetValue(_style, value);
+        return this;
+    }
+
+    public CombinatorStyleBuilder<T> Set(Expression<Func<Style, Border>> prop, Border value)
+    {
+        ((PropertyInfo)((MemberExpression)prop.Body).Member).SetValue(_style, value);
+        return this;
+    }
+
+    public CombinatorStyleBuilder<T> Set(Expression<Func<Style, BorderSide>> prop, BorderSide value)
+    {
+        ((PropertyInfo)((MemberExpression)prop.Body).Member).SetValue(_style, value);
+        return this;
+    }
+
+    public CombinatorStyleBuilder<T> Set(Expression<Func<Style, BorderRadius>> prop, BorderRadius value)
+    {
+        ((PropertyInfo)((MemberExpression)prop.Body).Member).SetValue(_style, value);
+        return this;
+    }
+
+    internal (Selector selector, Style style) Build() => (_selector, _style);
 }

--- a/tests/Miko.Tests/Styling/CombinatorSelectorTests.cs
+++ b/tests/Miko.Tests/Styling/CombinatorSelectorTests.cs
@@ -1,0 +1,495 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Styling;
+
+public class CombinatorSelectorTests
+{
+    // ========================================
+    // 后代选择器 (A B) Tests
+    // ========================================
+
+    [Fact]
+    public void DescendantSelector_ShouldMatchDirectChild()
+    {
+        var parent = new DivElement { Class = "container" };
+        var child = new SpanElement();
+        parent.AddChild(child);
+
+        var selector = new DescendantSelector(new ClassSelector("container"), new TagSelector("span"));
+        selector.Matches(child).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DescendantSelector_ShouldMatchDeepDescendant()
+    {
+        var grandparent = new DivElement { Class = "container" };
+        var parent = new DivElement();
+        var child = new SpanElement();
+        grandparent.AddChild(parent);
+        parent.AddChild(child);
+
+        var selector = new DescendantSelector(new ClassSelector("container"), new TagSelector("span"));
+        selector.Matches(child).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DescendantSelector_ShouldNotMatchWhenNoMatchingAncestor()
+    {
+        var parent = new DivElement { Class = "other" };
+        var child = new SpanElement();
+        parent.AddChild(child);
+
+        var selector = new DescendantSelector(new ClassSelector("container"), new TagSelector("span"));
+        selector.Matches(child).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DescendantSelector_ShouldNotMatchWhenTargetDoesNotMatch()
+    {
+        var parent = new DivElement { Class = "container" };
+        var child = new DivElement();
+        parent.AddChild(child);
+
+        var selector = new DescendantSelector(new ClassSelector("container"), new TagSelector("span"));
+        selector.Matches(child).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DescendantSelector_ShouldNotMatchRootElement()
+    {
+        var root = new DivElement { Class = "container" };
+
+        var selector = new DescendantSelector(new ClassSelector("container"), new TagSelector("div"));
+        selector.Matches(root).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DescendantSelector_Specificity_ShouldBeSumOfBothSelectors()
+    {
+        var selector = new DescendantSelector(new ClassSelector("container"), new TagSelector("span"));
+        selector.Specificity.ShouldBe(11); // class(10) + tag(1)
+    }
+
+    [Fact]
+    public void DescendantSelector_FluentApi_ShouldWork()
+    {
+        var parent = new DivElement { Class = "form-check" };
+        var child = new InputElement { Class = "form-check-input" };
+        parent.AddChild(child);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Class("form-check")
+            .Descendant<InputElement>(new ClassSelector("form-check-input"))
+            .Set(x => x.BackgroundColor, Color.Red));
+
+        new StyleResolver().Resolve(child, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void DescendantSelector_StaticFactory_ShouldWork()
+    {
+        var parent = new DivElement { Class = "container" };
+        var child = new SpanElement();
+        parent.AddChild(child);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Descendant(new ClassSelector("container"), new TagSelector("span"))
+            .Set(x => x.BackgroundColor, Color.Blue));
+
+        new StyleResolver().Resolve(child, [sheet]).BackgroundColor.ShouldBe(Color.Blue);
+    }
+
+    // ========================================
+    // 子选择器 (A > B) Tests
+    // ========================================
+
+    [Fact]
+    public void ChildSelector_ShouldMatchDirectChild()
+    {
+        var parent = new DivElement { Class = "row" };
+        var child = new SpanElement();
+        parent.AddChild(child);
+
+        var selector = new ChildSelector(new ClassSelector("row"), new TagSelector("span"));
+        selector.Matches(child).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ChildSelector_ShouldNotMatchGrandchild()
+    {
+        var grandparent = new DivElement { Class = "row" };
+        var parent = new DivElement();
+        var child = new SpanElement();
+        grandparent.AddChild(parent);
+        parent.AddChild(child);
+
+        var selector = new ChildSelector(new ClassSelector("row"), new TagSelector("span"));
+        selector.Matches(child).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ChildSelector_ShouldNotMatchWhenParentDoesNotMatch()
+    {
+        var parent = new DivElement { Class = "other" };
+        var child = new SpanElement();
+        parent.AddChild(child);
+
+        var selector = new ChildSelector(new ClassSelector("row"), new TagSelector("span"));
+        selector.Matches(child).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ChildSelector_ShouldNotMatchRootElement()
+    {
+        var root = new DivElement { Class = "row" };
+
+        var selector = new ChildSelector(new ClassSelector("row"), new TagSelector("div"));
+        selector.Matches(root).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ChildSelector_Specificity_ShouldBeSumOfBothSelectors()
+    {
+        var selector = new ChildSelector(new IdSelector("main"), new ClassSelector("btn"));
+        selector.Specificity.ShouldBe(110); // id(100) + class(10)
+    }
+
+    [Fact]
+    public void ChildSelector_FluentApi_ShouldWork()
+    {
+        var parent = new DivElement { Class = "btn-group" };
+        var child = new ButtonElement { Class = "btn" };
+        parent.AddChild(child);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Class("btn-group")
+            .Child<ButtonElement>(new ClassSelector("btn"))
+            .Set(x => x.BackgroundColor, Color.Green));
+
+        new StyleResolver().Resolve(child, [sheet]).BackgroundColor.ShouldBe(Color.Green);
+    }
+
+    [Fact]
+    public void ChildSelector_StaticFactory_ShouldWork()
+    {
+        var parent = new DivElement { Class = "row" };
+        var child = new DivElement();
+        parent.AddChild(child);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Child(new ClassSelector("row"), new UniversalSelector())
+            .Set(x => x.BackgroundColor, Color.Green));
+
+        new StyleResolver().Resolve(child, [sheet]).BackgroundColor.ShouldBe(Color.Green);
+    }
+
+    // ========================================
+    // 相邻兄弟选择器 (A + B) Tests
+    // ========================================
+
+    [Fact]
+    public void AdjacentSiblingSelector_ShouldMatchImmediateNextSibling()
+    {
+        var parent = new DivElement();
+        var first = new DivElement { Class = "breadcrumb-item" };
+        var second = new DivElement { Class = "breadcrumb-item" };
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        var selector = new AdjacentSiblingSelector(
+            new ClassSelector("breadcrumb-item"),
+            new ClassSelector("breadcrumb-item"));
+        selector.Matches(second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AdjacentSiblingSelector_ShouldNotMatchFirstChild()
+    {
+        var parent = new DivElement();
+        var first = new DivElement { Class = "breadcrumb-item" };
+        parent.AddChild(first);
+
+        var selector = new AdjacentSiblingSelector(
+            new ClassSelector("breadcrumb-item"),
+            new ClassSelector("breadcrumb-item"));
+        selector.Matches(first).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AdjacentSiblingSelector_ShouldNotMatchNonAdjacentSibling()
+    {
+        var parent = new DivElement();
+        var first = new DivElement { Class = "item" };
+        var middle = new SpanElement();
+        var third = new DivElement { Class = "item" };
+        parent.AddChild(first);
+        parent.AddChild(middle);
+        parent.AddChild(third);
+
+        var selector = new AdjacentSiblingSelector(
+            new ClassSelector("item"),
+            new ClassSelector("item"));
+        selector.Matches(third).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AdjacentSiblingSelector_ShouldNotMatchWhenPreviousDoesNotMatch()
+    {
+        var parent = new DivElement();
+        var first = new DivElement { Class = "other" };
+        var second = new DivElement { Class = "item" };
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        var selector = new AdjacentSiblingSelector(
+            new ClassSelector("item"),
+            new ClassSelector("item"));
+        selector.Matches(second).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AdjacentSiblingSelector_ShouldNotMatchWithoutParent()
+    {
+        var element = new DivElement { Class = "item" };
+
+        var selector = new AdjacentSiblingSelector(
+            new ClassSelector("item"),
+            new ClassSelector("item"));
+        selector.Matches(element).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AdjacentSiblingSelector_Specificity_ShouldBeSumOfBothSelectors()
+    {
+        var selector = new AdjacentSiblingSelector(
+            new ClassSelector("item"),
+            new ClassSelector("item"));
+        selector.Specificity.ShouldBe(20); // class(10) + class(10)
+    }
+
+    [Fact]
+    public void AdjacentSiblingSelector_FluentApi_ShouldWork()
+    {
+        var parent = new DivElement();
+        var first = new DivElement { Class = "breadcrumb-item" };
+        var second = new DivElement { Class = "breadcrumb-item" };
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Class("breadcrumb-item")
+            .Adjacent<Element>(new ClassSelector("breadcrumb-item"))
+            .Set(x => x.BackgroundColor, Color.Red));
+
+        new StyleResolver().Resolve(second, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void AdjacentSiblingSelector_StaticFactory_ShouldWork()
+    {
+        var parent = new DivElement();
+        var first = new H1Element();
+        var second = new ParagraphElement();
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Adjacent(new TagSelector("h1"), new TagSelector("p"))
+            .Set(x => x.BackgroundColor, Color.Red));
+
+        new StyleResolver().Resolve(second, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+    }
+
+    // ========================================
+    // 通用兄弟选择器 (A ~ B) Tests
+    // ========================================
+
+    [Fact]
+    public void GeneralSiblingSelector_ShouldMatchImmediateNextSibling()
+    {
+        var parent = new DivElement();
+        var first = new DivElement { Class = "trigger" };
+        var second = new SpanElement { Class = "target" };
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        var selector = new GeneralSiblingSelector(
+            new ClassSelector("trigger"),
+            new ClassSelector("target"));
+        selector.Matches(second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GeneralSiblingSelector_ShouldMatchNonAdjacentSibling()
+    {
+        var parent = new DivElement();
+        var first = new DivElement { Class = "trigger" };
+        var middle = new SpanElement();
+        var third = new DivElement { Class = "target" };
+        parent.AddChild(first);
+        parent.AddChild(middle);
+        parent.AddChild(third);
+
+        var selector = new GeneralSiblingSelector(
+            new ClassSelector("trigger"),
+            new ClassSelector("target"));
+        selector.Matches(third).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GeneralSiblingSelector_ShouldNotMatchElementBeforeTrigger()
+    {
+        var parent = new DivElement();
+        var first = new DivElement { Class = "target" };
+        var second = new DivElement { Class = "trigger" };
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        var selector = new GeneralSiblingSelector(
+            new ClassSelector("trigger"),
+            new ClassSelector("target"));
+        selector.Matches(first).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GeneralSiblingSelector_ShouldNotMatchWithoutParent()
+    {
+        var element = new DivElement { Class = "target" };
+
+        var selector = new GeneralSiblingSelector(
+            new ClassSelector("trigger"),
+            new ClassSelector("target"));
+        selector.Matches(element).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GeneralSiblingSelector_ShouldNotMatchWhenNoMatchingPreviousSibling()
+    {
+        var parent = new DivElement();
+        var first = new DivElement { Class = "other" };
+        var second = new DivElement { Class = "target" };
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        var selector = new GeneralSiblingSelector(
+            new ClassSelector("trigger"),
+            new ClassSelector("target"));
+        selector.Matches(second).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GeneralSiblingSelector_Specificity_ShouldBeSumOfBothSelectors()
+    {
+        var selector = new GeneralSiblingSelector(
+            new TagSelector("input"),
+            new ClassSelector("label"));
+        selector.Specificity.ShouldBe(11); // tag(1) + class(10)
+    }
+
+    [Fact]
+    public void GeneralSiblingSelector_FluentApi_ShouldWork()
+    {
+        var parent = new DivElement();
+        var input = new InputElement { Class = "form-check-input" };
+        var label = new LabelElement { Class = "form-check-label" };
+        parent.AddChild(input);
+        parent.AddChild(label);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Class("form-check-input")
+            .Sibling<LabelElement>(new ClassSelector("form-check-label"))
+            .Set(x => x.Color, Color.Gray));
+
+        new StyleResolver().Resolve(label, [sheet]).Color.ShouldBe(Color.Gray);
+    }
+
+    [Fact]
+    public void GeneralSiblingSelector_StaticFactory_ShouldWork()
+    {
+        var parent = new DivElement();
+        var trigger = new DivElement { Class = "trigger" };
+        var middle = new SpanElement();
+        var target = new ParagraphElement();
+        parent.AddChild(trigger);
+        parent.AddChild(middle);
+        parent.AddChild(target);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Sibling(new ClassSelector("trigger"), new TagSelector("p"))
+            .Set(x => x.BackgroundColor, Color.Blue));
+
+        new StyleResolver().Resolve(target, [sheet]).BackgroundColor.ShouldBe(Color.Blue);
+    }
+
+    // ========================================
+    // 组合器与样式级联集成测试
+    // ========================================
+
+    [Fact]
+    public void CombinatorSelector_ShouldParticipateInCascade()
+    {
+        var parent = new DivElement { Class = "container" };
+        var child = new SpanElement { Class = "text" };
+        parent.AddChild(child);
+
+        var sheet = new StyleSheet();
+        // descendant selector: .container span => specificity 11
+        sheet.AddRule(Style.Descendant(new ClassSelector("container"), new TagSelector("span"))
+            .Set(x => x.Color, Color.Red));
+        // class selector: .text => specificity 10
+        sheet.AddRule(Style.Class("text")
+            .Set(x => x.Color, Color.Blue));
+
+        // descendant selector wins (11 > 10)
+        new StyleResolver().Resolve(child, [sheet]).Color.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void ChildSelector_WithUniversalSelector_ShouldMatchAnyDirectChild()
+    {
+        var parent = new DivElement { Class = "row" };
+        var child1 = new DivElement();
+        var child2 = new SpanElement();
+        parent.AddChild(child1);
+        parent.AddChild(child2);
+
+        var selector = new ChildSelector(new ClassSelector("row"), new UniversalSelector());
+        selector.Matches(child1).ShouldBeTrue();
+        selector.Matches(child2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void FluentApi_Descendant_WithTagSelector_ShouldWork()
+    {
+        var parent = new DivElement { Class = "container" };
+        var child = new ButtonElement();
+        parent.AddChild(child);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Class("container")
+            .Descendant<ButtonElement>()
+            .Set(x => x.BackgroundColor, Color.Red));
+
+        new StyleResolver().Resolve(child, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void FluentApi_Child_WithTagSelector_ShouldWork()
+    {
+        var parent = new DivElement { Class = "row" };
+        var child = new SpanElement();
+        parent.AddChild(child);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Class("row")
+            .Child<SpanElement>()
+            .Set(x => x.Color, Color.Blue));
+
+        new StyleResolver().Resolve(child, [sheet]).Color.ShouldBe(Color.Blue);
+    }
+}


### PR DESCRIPTION
## Summary

Add CSS combinator selector support:

- **Descendant selector** (`A B`) - matches elements that are descendants of A
- **Child selector** (`A > B`) - matches direct children of A
- **Adjacent sibling selector** (`A + B`) - matches B immediately preceded by A
- **General sibling selector** (`A ~ B`) - matches B preceded by A (any position)

## Fluent API

Added chainable methods on `TypedStyleBuilder<T>`: `.Descendant<T>()`, `.Child<T>()`, `.Adjacent<T>()`, `.Sibling<T>()`

Added static factory methods on `Style`: `Style.Descendant()`, `Style.Child()`, `Style.Adjacent()`, `Style.Sibling()`

## Testing

35 new unit tests covering matching logic, specificity, fluent API, and style resolution integration. All 505 tests pass.

Closes #17