### PR TITLE
Add Transition fluent API with strongly-typed property expressions

### DIFF
--- a/src/Miko/Animation/AnimationManager.cs
+++ b/src/Miko/Animation/AnimationManager.cs
@@ -413,25 +413,25 @@ public class AnimationManager
     {
         return property switch
         {
-            "opacity" => (e, v) => { e.Style ??= new Style(); e.Style.Opacity = v; },
-            "width" => (e, v) => { e.Style ??= new Style(); e.Style.Width = Length.Px(v); },
-            "height" => (e, v) => { e.Style ??= new Style(); e.Style.Height = Length.Px(v); },
-            "margin-top" => (e, v) => { e.Style ??= new Style(); e.Style.MarginTop = Length.Px(v); },
-            "margin-right" => (e, v) => { e.Style ??= new Style(); e.Style.MarginRight = Length.Px(v); },
-            "margin-bottom" => (e, v) => { e.Style ??= new Style(); e.Style.MarginBottom = Length.Px(v); },
-            "margin-left" => (e, v) => { e.Style ??= new Style(); e.Style.MarginLeft = Length.Px(v); },
-            "padding-top" => (e, v) => { e.Style ??= new Style(); e.Style.PaddingTop = Length.Px(v); },
-            "padding-right" => (e, v) => { e.Style ??= new Style(); e.Style.PaddingRight = Length.Px(v); },
-            "padding-bottom" => (e, v) => { e.Style ??= new Style(); e.Style.PaddingBottom = Length.Px(v); },
-            "padding-left" => (e, v) => { e.Style ??= new Style(); e.Style.PaddingLeft = Length.Px(v); },
-            "top" => (e, v) => { e.Style ??= new Style(); e.Style.Top = Length.Px(v); },
-            "right" => (e, v) => { e.Style ??= new Style(); e.Style.Right = Length.Px(v); },
-            "bottom" => (e, v) => { e.Style ??= new Style(); e.Style.Bottom = Length.Px(v); },
-            "left" => (e, v) => { e.Style ??= new Style(); e.Style.Left = Length.Px(v); },
-            "font-size" => (e, v) => { e.Style ??= new Style(); e.Style.FontSize = Length.Px(v); },
-            "border-width" => (e, v) => { e.Style ??= new Style(); e.Style.BorderWidth = Length.Px(v); },
-            "flex-grow" => (e, v) => { e.Style ??= new Style(); e.Style.FlexGrow = v; },
-            "flex-shrink" => (e, v) => { e.Style ??= new Style(); e.Style.FlexShrink = v; },
+            nameof(Style.Opacity) => (e, v) => { e.Style ??= new Style(); e.Style.Opacity = v; },
+            nameof(Style.Width) => (e, v) => { e.Style ??= new Style(); e.Style.Width = Length.Px(v); },
+            nameof(Style.Height) => (e, v) => { e.Style ??= new Style(); e.Style.Height = Length.Px(v); },
+            nameof(Style.MarginTop) => (e, v) => { e.Style ??= new Style(); e.Style.MarginTop = Length.Px(v); },
+            nameof(Style.MarginRight) => (e, v) => { e.Style ??= new Style(); e.Style.MarginRight = Length.Px(v); },
+            nameof(Style.MarginBottom) => (e, v) => { e.Style ??= new Style(); e.Style.MarginBottom = Length.Px(v); },
+            nameof(Style.MarginLeft) => (e, v) => { e.Style ??= new Style(); e.Style.MarginLeft = Length.Px(v); },
+            nameof(Style.PaddingTop) => (e, v) => { e.Style ??= new Style(); e.Style.PaddingTop = Length.Px(v); },
+            nameof(Style.PaddingRight) => (e, v) => { e.Style ??= new Style(); e.Style.PaddingRight = Length.Px(v); },
+            nameof(Style.PaddingBottom) => (e, v) => { e.Style ??= new Style(); e.Style.PaddingBottom = Length.Px(v); },
+            nameof(Style.PaddingLeft) => (e, v) => { e.Style ??= new Style(); e.Style.PaddingLeft = Length.Px(v); },
+            nameof(Style.Top) => (e, v) => { e.Style ??= new Style(); e.Style.Top = Length.Px(v); },
+            nameof(Style.Right) => (e, v) => { e.Style ??= new Style(); e.Style.Right = Length.Px(v); },
+            nameof(Style.Bottom) => (e, v) => { e.Style ??= new Style(); e.Style.Bottom = Length.Px(v); },
+            nameof(Style.Left) => (e, v) => { e.Style ??= new Style(); e.Style.Left = Length.Px(v); },
+            nameof(Style.FontSize) => (e, v) => { e.Style ??= new Style(); e.Style.FontSize = Length.Px(v); },
+            nameof(Style.BorderWidth) => (e, v) => { e.Style ??= new Style(); e.Style.BorderWidth = Length.Px(v); },
+            nameof(Style.FlexGrow) => (e, v) => { e.Style ??= new Style(); e.Style.FlexGrow = v; },
+            nameof(Style.FlexShrink) => (e, v) => { e.Style ??= new Style(); e.Style.FlexShrink = v; },
             _ => null
         };
     }
@@ -440,9 +440,9 @@ public class AnimationManager
     {
         return property switch
         {
-            "background-color" => (e, c) => { e.Style ??= new Style(); e.Style.BackgroundColor = c; },
-            "color" => (e, c) => { e.Style ??= new Style(); e.Style.Color = c; },
-            "border-color" => (e, c) => { e.Style ??= new Style(); e.Style.BorderColor = c; },
+            nameof(Style.BackgroundColor) => (e, c) => { e.Style ??= new Style(); e.Style.BackgroundColor = c; },
+            nameof(Style.Color) => (e, c) => { e.Style ??= new Style(); e.Style.Color = c; },
+            nameof(Style.BorderColor) => (e, c) => { e.Style ??= new Style(); e.Style.BorderColor = c; },
             _ => null
         };
     }

--- a/src/Miko/Animation/Transition.cs
+++ b/src/Miko/Animation/Transition.cs
@@ -1,3 +1,6 @@
+using System.Linq.Expressions;
+using Miko.Styling;
+
 namespace Miko.Animation;
 
 public record struct CubicBezierParams(float X1, float Y1, float X2, float Y2);
@@ -25,4 +28,7 @@ public class Transition
 
     public static Transition For(string property, float duration, TimingFunction timingFunction = TimingFunction.Ease, float delay = 0)
         => new(property, duration, timingFunction, delay);
+
+    public static TransitionBuilder For<T>(Expression<Func<Style, T>> propertyExpr)
+        => new(TransitionPropertyMapper.GetPropertyName(propertyExpr));
 }

--- a/src/Miko/Animation/TransitionBuilder.cs
+++ b/src/Miko/Animation/TransitionBuilder.cs
@@ -1,0 +1,32 @@
+namespace Miko.Animation;
+
+public class TransitionBuilder
+{
+    private readonly string _property;
+    private float _duration;
+    private TimingFunction _timingFunction = TimingFunction.Ease;
+    private CubicBezierParams? _cubicBezier;
+    private float _delay;
+
+    internal TransitionBuilder(string property) => _property = property;
+
+    public TransitionBuilder Duration(float seconds) { _duration = seconds; return this; }
+    public TransitionBuilder Ease() { _timingFunction = TimingFunction.Ease; return this; }
+    public TransitionBuilder Linear() { _timingFunction = TimingFunction.Linear; return this; }
+    public TransitionBuilder EaseIn() { _timingFunction = TimingFunction.EaseIn; return this; }
+    public TransitionBuilder EaseOut() { _timingFunction = TimingFunction.EaseOut; return this; }
+    public TransitionBuilder EaseInOut() { _timingFunction = TimingFunction.EaseInOut; return this; }
+
+    public TransitionBuilder CubicBezier(float x1, float y1, float x2, float y2)
+    {
+        _timingFunction = TimingFunction.CubicBezier;
+        _cubicBezier = new CubicBezierParams(x1, y1, x2, y2);
+        return this;
+    }
+
+    public TransitionBuilder Delay(float seconds) { _delay = seconds; return this; }
+
+    public Transition Build() => new(_property, _duration, _timingFunction, _delay) { CubicBezier = _cubicBezier };
+
+    public static implicit operator Transition(TransitionBuilder builder) => builder.Build();
+}

--- a/src/Miko/Animation/TransitionPropertyMapper.cs
+++ b/src/Miko/Animation/TransitionPropertyMapper.cs
@@ -1,0 +1,10 @@
+using System.Linq.Expressions;
+using Miko.Styling;
+
+namespace Miko.Animation;
+
+internal static class TransitionPropertyMapper
+{
+    public static string GetPropertyName<T>(Expression<Func<Style, T>> expression)
+        => ((MemberExpression)expression.Body).Member.Name;
+}

--- a/tests/Miko.Tests/Animation/AnimationManagerTests.cs
+++ b/tests/Miko.Tests/Animation/AnimationManagerTests.cs
@@ -21,9 +21,9 @@ public class AnimationManagerTests
     public void TrackPropertyChange_ShouldCreateTransition()
     {
         var element = new DivElement { Style = new Style { Opacity = 1f } };
-        var transition = Transition.For("opacity", 1f, TimingFunction.Linear);
+        var transition = Transition.For(nameof(Style.Opacity), 1f, TimingFunction.Linear);
 
-        _manager.TrackPropertyChange(element, "opacity", 1f, 0f, transition);
+        _manager.TrackPropertyChange(element, nameof(Style.Opacity), 1f, 0f, transition);
 
         _manager.HasActiveAnimations.ShouldBeTrue();
     }
@@ -32,9 +32,9 @@ public class AnimationManagerTests
     public void Update_ShouldInterpolatePropertyOverTime()
     {
         var element = new DivElement { Style = new Style { Opacity = 1f } };
-        var transition = Transition.For("opacity", 1f, TimingFunction.Linear);
+        var transition = Transition.For(nameof(Style.Opacity), 1f, TimingFunction.Linear);
 
-        _manager.TrackPropertyChange(element, "opacity", 1f, 0f, transition);
+        _manager.TrackPropertyChange(element, nameof(Style.Opacity), 1f, 0f, transition);
 
         _manager.Update(0.5f);
         element.Style!.Opacity!.Value.ShouldBe(0.5f, 0.01f);
@@ -47,9 +47,9 @@ public class AnimationManagerTests
     public void Update_ShouldRespectDelay()
     {
         var element = new DivElement { Style = new Style { Opacity = 1f } };
-        var transition = Transition.For("opacity", 1f, TimingFunction.Linear, delay: 0.5f);
+        var transition = Transition.For(nameof(Style.Opacity), 1f, TimingFunction.Linear, delay: 0.5f);
 
-        _manager.TrackPropertyChange(element, "opacity", 1f, 0f, transition);
+        _manager.TrackPropertyChange(element, nameof(Style.Opacity), 1f, 0f, transition);
 
         _manager.Update(0.3f);
         element.Style!.Opacity!.Value.ShouldBe(1f);
@@ -62,9 +62,9 @@ public class AnimationManagerTests
     public void TrackColorChange_ShouldInterpolateColor()
     {
         var element = new DivElement { Style = new Style { BackgroundColor = Color.Black } };
-        var transition = Transition.For("background-color", 1f, TimingFunction.Linear);
+        var transition = Transition.For(nameof(Style.BackgroundColor), 1f, TimingFunction.Linear);
 
-        _manager.TrackColorChange(element, "background-color", Color.Black, Color.White, transition);
+        _manager.TrackColorChange(element, nameof(Style.BackgroundColor), Color.Black, Color.White, transition);
 
         _manager.Update(0.5f);
         element.Style!.BackgroundColor!.Value.R.ShouldBeInRange((byte)120, (byte)135);
@@ -76,9 +76,9 @@ public class AnimationManagerTests
     public void Transition_ShouldCompleteAndRemove()
     {
         var element = new DivElement { Style = new Style { Opacity = 1f } };
-        var transition = Transition.For("opacity", 0.5f, TimingFunction.Linear);
+        var transition = Transition.For(nameof(Style.Opacity), 0.5f, TimingFunction.Linear);
 
-        _manager.TrackPropertyChange(element, "opacity", 1f, 0f, transition);
+        _manager.TrackPropertyChange(element, nameof(Style.Opacity), 1f, 0f, transition);
         _manager.Update(1f);
 
         element.Style!.Opacity!.Value.ShouldBe(0f, 0.01f);
@@ -214,10 +214,10 @@ public class AnimationManagerTests
     public void TrackPropertyChange_ShouldReplaceExistingTransition()
     {
         var element = new DivElement { Style = new Style { Opacity = 1f } };
-        var transition = Transition.For("opacity", 1f, TimingFunction.Linear);
+        var transition = Transition.For(nameof(Style.Opacity), 1f, TimingFunction.Linear);
 
-        _manager.TrackPropertyChange(element, "opacity", 1f, 0.5f, transition);
-        _manager.TrackPropertyChange(element, "opacity", 0.5f, 0f, transition);
+        _manager.TrackPropertyChange(element, nameof(Style.Opacity), 1f, 0.5f, transition);
+        _manager.TrackPropertyChange(element, nameof(Style.Opacity), 0.5f, 0f, transition);
 
         _manager.Update(1f);
         element.Style!.Opacity!.Value.ShouldBe(0f, 0.01f);

--- a/tests/Miko.Tests/Animation/TransitionTests.cs
+++ b/tests/Miko.Tests/Animation/TransitionTests.cs
@@ -1,4 +1,6 @@
 using Miko.Animation;
+using Miko.Common;
+using Miko.Styling;
 using Shouldly;
 
 namespace Miko.Tests.Animation;
@@ -19,9 +21,9 @@ public class TransitionTests
     [Fact]
     public void For_ShouldCreateTransitionForSpecificProperty()
     {
-        var transition = Transition.For("opacity", 0.5f, TimingFunction.Linear, 0.1f);
+        var transition = Transition.For(nameof(Style.Opacity), 0.5f, TimingFunction.Linear, 0.1f);
 
-        transition.Property.ShouldBe("opacity");
+        transition.Property.ShouldBe(nameof(Style.Opacity));
         transition.Duration.ShouldBe(0.5f);
         transition.TimingFunction.ShouldBe(TimingFunction.Linear);
         transition.Delay.ShouldBe(0.1f);
@@ -41,12 +43,52 @@ public class TransitionTests
     [Fact]
     public void CubicBezier_ShouldBeSettable()
     {
-        var transition = new Transition("opacity", 1f, TimingFunction.CubicBezier)
+        var transition = new Transition(nameof(Style.Opacity), 1f, TimingFunction.CubicBezier)
         {
             CubicBezier = new CubicBezierParams(0.25f, 0.1f, 0.25f, 1f)
         };
 
         transition.CubicBezier.ShouldNotBeNull();
         transition.CubicBezier.Value.X1.ShouldBe(0.25f);
+    }
+
+    [Fact]
+    public void FluentApi_ShouldCreateTransitionWithExpression()
+    {
+        Transition transition = Transition.For<float?>(x => x.Opacity).Duration(0.5f).Linear().Delay(0.1f);
+
+        transition.Property.ShouldBe(nameof(Style.Opacity));
+        transition.Duration.ShouldBe(0.5f);
+        transition.TimingFunction.ShouldBe(TimingFunction.Linear);
+        transition.Delay.ShouldBe(0.1f);
+    }
+
+    [Fact]
+    public void FluentApi_ShouldSupportColorProperty()
+    {
+        Transition transition = Transition.For<Color?>(x => x.BackgroundColor).Duration(1f).EaseInOut();
+
+        transition.Property.ShouldBe(nameof(Style.BackgroundColor));
+        transition.TimingFunction.ShouldBe(TimingFunction.EaseInOut);
+    }
+
+    [Fact]
+    public void FluentApi_ShouldSupportCubicBezier()
+    {
+        Transition transition = Transition.For<float?>(x => x.Opacity).Duration(0.3f).CubicBezier(0.25f, 0.1f, 0.25f, 1f);
+
+        transition.TimingFunction.ShouldBe(TimingFunction.CubicBezier);
+        transition.CubicBezier.ShouldNotBeNull();
+        transition.CubicBezier.Value.X1.ShouldBe(0.25f);
+    }
+
+    [Fact]
+    public void FluentApi_ShouldSupportImplicitConversion()
+    {
+        Transition transition = Transition.For<Length?>(x => x.Width).Duration(0.5f);
+
+        transition.Property.ShouldBe(nameof(Style.Width));
+        transition.Duration.ShouldBe(0.5f);
+        transition.TimingFunction.ShouldBe(TimingFunction.Ease);
     }
 }


### PR DESCRIPTION
## Summary
- Add expression-based fluent API for `Transition`: `Transition.For<float?>(x => x.Opacity).Duration(0.3f).EaseInOut()`
- Replace CSS-style magic strings (`"opacity"`, `"background-color"`) with `nameof(Style.*)` throughout `AnimationManager`
- Add `TransitionBuilder` with implicit conversion to `Transition` and fluent methods for timing functions
- Add `TransitionPropertyMapper` to extract property names from expressions

## Test plan
- [x] All 8 `TransitionTests` pass (4 existing + 4 new fluent API tests)
- [x] All 23 animation-related tests pass
- [x] Build succeeds with zero errors