### PR TITLE
Add CssObject style API with selector parser (#23)

### DIFF
--- a/examples/MikoApp1.Razor/GlobalStyles.cs
+++ b/examples/MikoApp1.Razor/GlobalStyles.cs
@@ -1,71 +1,77 @@
-// The Chaldea licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
 using Miko.Common;
 using Miko.Styling;
 
-namespace MikoApp1.Razor
+namespace MikoApp1.Razor;
+
+internal class GlobalStyles
 {
-    internal class GlobalStyles
+    public static StyleSheet Create()
     {
-        public static StyleSheet Create()
+        var styleSheet = new StyleSheet();
+
+        styleSheet.Add(new CssObject
         {
-            var styleSheet = new StyleSheet();
+            [".layout"] = new()
+            {
+                Display = Display.Flex,
+                Width = Length.Percent(100),
+                Height = Length.Percent(100)
+            },
+            [".sidebar"] = new()
+            {
+                Width = Length.Px(200),
+                Height = Length.Percent(100),
+                Padding = new Padding(16),
+                BackgroundColor = Color.FromRgb(52, 58, 64),
+                Color = Color.White
+            },
+            [".title"] = new() { Color = Color.White },
+            [".main-content"] = new()
+            {
+                FlexGrow = 1,
+                Padding = new Padding(16),
+                OverflowY = Overflow.Scroll
+            },
+            [".nav-item"] = new()
+            {
+                Padding = new Padding(10),
+                MarginBottom = Length.Px(4),
+                Color = Color.White
+            },
+            [".icon-row"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Row,
+                FlexWrap = FlexWrap.Wrap,
+                Gap = Length.Px(16),
+                MarginBottom = Length.Px(20),
+                AlignItems = AlignItems.FlexEnd
+            },
+            [".icon-item"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                AlignItems = AlignItems.Center,
+                Width = Length.Px(80)
+            },
+            [".icon-label"] = new()
+            {
+                FontSize = Length.Px(12),
+                Color = Color.FromRgb(108, 117, 125)
+            },
+            [".icon-btn"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Row,
+                AlignItems = AlignItems.Center,
+                Width = Length.Px(100)
+            },
+            [".table-row-striped"] = new()
+            {
+                BackgroundColor = Color.FromHex("f2f2f2")
+            }
+        });
 
-            //
-            styleSheet.AddRule(Style.Class("layout")
-                .Set(x => x.Display, Display.Flex)
-                .Set(x => x.Width, Length.Percent(100))
-                .Set(x => x.Height, Length.Percent(100)));
-
-            styleSheet.AddRule(Style.Class("sidebar")
-                .Set(x => x.Width, Length.Px(200))
-                .Set(x => x.Height, Length.Percent(100))
-                .Set(x => x.Padding, Length.Px(16))
-                .Set(x => x.BackgroundColor, Color.FromRgb(52, 58, 64))
-                .Set(x => x.Color, Color.White));
-
-            styleSheet.AddRule(Style.Class("title")
-                .Set(x => x.Color, Color.White));
-
-            styleSheet.AddRule(Style.Class("main-content")
-                .Set(x => x.FlexGrow, 1)
-                .Set(x => x.Padding, Length.Px(16))
-                .Set(x => x.OverflowY, Overflow.Scroll));
-
-            styleSheet.AddRule(Style.Class("nav-item")
-                .Set(x => x.Padding, Length.Px(10))
-                .Set(x => x.MarginBottom, Length.Px(4))
-                .Set(x => x.Color, Color.White));
-
-            styleSheet.AddRule(Style.Class("icon-row")
-                .Set(x => x.Display, Display.Flex)
-                .Set(x => x.FlexDirection, FlexDirection.Row)
-                .Set(x => x.FlexWrap, FlexWrap.Wrap)
-                .Set(x => x.Gap, Length.Px(16))
-                .Set(x => x.MarginBottom, Length.Px(20))
-                .Set(x => x.AlignItems, AlignItems.FlexEnd));
-
-            styleSheet.AddRule(Style.Class("icon-item")
-                .Set(x => x.Display, Display.Flex)
-                .Set(x => x.FlexDirection, FlexDirection.Column)
-                .Set(x => x.AlignItems, AlignItems.Center)
-                .Set(x => x.Width, Length.Px(80)));
-
-            styleSheet.AddRule(Style.Class("icon-label")
-                .Set(x => x.FontSize, Length.Px(12))
-                .Set(x => x.Color, Color.FromRgb(108, 117, 125)));
-
-            styleSheet.AddRule(Style.Class("icon-btn")
-                .Set(x => x.Display, Display.Flex)
-                .Set(x => x.FlexDirection, FlexDirection.Row)
-                .Set(x => x.AlignItems, AlignItems.Center)
-                .Set(x => x.Width, Length.Px(100)));
-
-            styleSheet.AddRule(Style.Class("table-row-striped")
-                .Set(x => x.BackgroundColor, Color.FromHex("f2f2f2")));
-
-            return styleSheet;
-        }
+        return styleSheet;
     }
 }

--- a/src/Miko/Common/BorderSide.cs
+++ b/src/Miko/Common/BorderSide.cs
@@ -29,6 +29,13 @@ public struct BorderSide
         Color = color;
     }
 
+    public BorderSide(Length width, BorderStyle style)
+    {
+        Width = width;
+        Style = style;
+        Color = Color.Black;
+    }
+
     /// <summary>
     /// Creates a solid black border side with specified width
     /// </summary>

--- a/src/Miko/Styling/CssObject.cs
+++ b/src/Miko/Styling/CssObject.cs
@@ -1,0 +1,17 @@
+namespace Miko.Styling;
+
+/// <summary>
+/// CSS 对象，支持嵌套选择器的样式声明
+/// </summary>
+public class CssObject : Style
+{
+    private readonly Dictionary<string, CssObject> _children = new();
+
+    public CssObject this[string selector]
+    {
+        get => _children[selector];
+        set => _children[selector] = value;
+    }
+
+    internal IReadOnlyDictionary<string, CssObject> Children => _children;
+}

--- a/src/Miko/Styling/CssObjectResolver.cs
+++ b/src/Miko/Styling/CssObjectResolver.cs
@@ -1,0 +1,87 @@
+using Miko.Styling.Selectors;
+
+namespace Miko.Styling;
+
+/// <summary>
+/// 将 CssObject 树展开为扁平的 StyleRule 列表
+/// </summary>
+internal static class CssObjectResolver
+{
+    internal static void Resolve(CssObject css, StyleSheet sheet)
+    {
+        foreach (var (selectorStr, child) in css.Children)
+        {
+            Flatten(selectorStr, child, "", sheet);
+        }
+    }
+
+    private static void Flatten(string selectorStr, CssObject css, string parentSelector, StyleSheet sheet)
+    {
+        var fullSelector = BuildFullSelector(selectorStr, parentSelector);
+
+        // 将当前节点的样式属性提取为 StyleRule
+        var style = ExtractStyle(css);
+        if (HasAnyProperty(style))
+        {
+            var selector = CssSelectorParser.Parse(fullSelector);
+            sheet.AddRule(selector, style);
+        }
+
+        // 递归处理子选择器
+        foreach (var (childSelectorStr, child) in css.Children)
+        {
+            Flatten(childSelectorStr, child, fullSelector, sheet);
+        }
+    }
+
+    private static string BuildFullSelector(string current, string parent)
+    {
+        if (string.IsNullOrEmpty(parent))
+            return current;
+
+        if (current.Contains('&'))
+            return current.Replace("&", parent);
+
+        // 默认后代关系
+        return $"{parent} {current}";
+    }
+
+    private static Style ExtractStyle(CssObject css)
+    {
+        // CssObject 继承自 Style，直接克隆其样式属性
+        return css.Clone();
+    }
+
+    private static bool HasAnyProperty(Style style)
+    {
+        return style.Display != null || style.FlexDirection != null || style.JustifyContent != null ||
+               style.AlignItems != null || style.FlexGrow != null || style.FlexShrink != null ||
+               style.FlexBasis != null || style.Width != null || style.Height != null ||
+               style.MinWidth != null || style.MinHeight != null || style.MaxWidth != null ||
+               style.MaxHeight != null || style.PaddingTop != null || style.PaddingRight != null ||
+               style.PaddingBottom != null || style.PaddingLeft != null || style.MarginTop != null ||
+               style.MarginRight != null || style.MarginBottom != null || style.MarginLeft != null ||
+               style.BorderWidth != null || style.BorderColor != null || style.BorderStyle != null ||
+               style.BorderTopWidth != null || style.BorderRightWidth != null ||
+               style.BorderBottomWidth != null || style.BorderLeftWidth != null ||
+               style.BorderTopColor != null || style.BorderRightColor != null ||
+               style.BorderBottomColor != null || style.BorderLeftColor != null ||
+               style.BorderTopStyle != null || style.BorderRightStyle != null ||
+               style.BorderBottomStyle != null || style.BorderLeftStyle != null ||
+               style.BorderTopLeftRadius != null || style.BorderTopRightRadius != null ||
+               style.BorderBottomRightRadius != null || style.BorderBottomLeftRadius != null ||
+               style.BackgroundColor != null || style.BackgroundImage != null ||
+               style.Color != null || style.FontFamily != null || style.FontSize != null ||
+               style.FontWeight != null || style.TextAlign != null || style.LineHeight != null ||
+               style.Position != null || style.Top != null || style.Right != null ||
+               style.Bottom != null || style.Left != null || style.TextDecoration != null ||
+               style.TextTransform != null || style.FontStyle != null || style.WhiteSpace != null ||
+               style.LetterSpacing != null || style.VerticalAlign != null || style.Opacity != null ||
+               style.ZIndex != null || style.Visibility != null || style.Cursor != null ||
+               style.UserSelect != null || style.FlexWrap != null || style.AlignSelf != null ||
+               style.AlignContent != null || style.Gap != null || style.RowGap != null ||
+               style.ColumnGap != null || style.BoxShadow != null || style.OverflowX != null ||
+               style.OverflowY != null || style.Transform != null || style.TransformOrigin != null ||
+               style.Transitions != null || style.Animations != null || style.Content != null;
+    }
+}

--- a/src/Miko/Styling/Selectors/CssSelectorParser.cs
+++ b/src/Miko/Styling/Selectors/CssSelectorParser.cs
@@ -1,0 +1,227 @@
+using Miko.Core;
+
+namespace Miko.Styling.Selectors;
+
+/// <summary>
+/// CSS 选择器字符串解析器
+/// </summary>
+public static class CssSelectorParser
+{
+    public static Selector Parse(string input)
+    {
+        input = input.Trim();
+
+        // 处理分组选择器 (逗号分隔)
+        var groups = SplitGroups(input);
+        if (groups.Count > 1)
+        {
+            var selectors = groups.Select(g => ParseSingle(g.Trim())).ToArray();
+            return new GroupSelector(selectors);
+        }
+
+        return ParseSingle(input);
+    }
+
+    private static Selector ParseSingle(string input)
+    {
+        // 按组合器拆分: >, +, ~, 空格(后代)
+        var segments = SplitByCombinators(input);
+
+        if (segments.Count == 1)
+            return ParseCompound(segments[0].selector);
+
+        // 从左到右构建组合器链
+        var result = ParseCompound(segments[0].selector);
+        for (int i = 1; i < segments.Count; i++)
+        {
+            var right = ParseCompound(segments[i].selector);
+            result = segments[i].combinator switch
+            {
+                '>' => new ChildSelector(result, right),
+                '+' => new AdjacentSiblingSelector(result, right),
+                '~' => new GeneralSiblingSelector(result, right),
+                _ => new DescendantSelector(result, right), // 空格
+            };
+        }
+
+        return result;
+    }
+
+    private static Selector ParseCompound(string input)
+    {
+        var parts = new List<Selector>();
+        var i = 0;
+
+        while (i < input.Length)
+        {
+            if (input[i] == '#')
+            {
+                i++;
+                var name = ReadIdentifier(input, ref i);
+                parts.Add(new IdSelector(name));
+            }
+            else if (input[i] == '.')
+            {
+                i++;
+                var name = ReadIdentifier(input, ref i);
+                parts.Add(new ClassSelector(name));
+            }
+            else if (input[i] == ':')
+            {
+                i++;
+                var pseudo = ReadIdentifier(input, ref i);
+
+                if (pseudo == "not" && i < input.Length && input[i] == '(')
+                {
+                    i++; // skip (
+                    var inner = ReadUntilClose(input, ref i);
+                    parts.Add(new NotSelector(ParseCompound(inner)));
+                }
+                else
+                {
+                    parts.Add(ParsePseudoClass(pseudo));
+                }
+            }
+            else if (input[i] == '*')
+            {
+                parts.Add(new UniversalSelector());
+                i++;
+            }
+            else
+            {
+                var name = ReadIdentifier(input, ref i);
+                if (!string.IsNullOrEmpty(name))
+                    parts.Add(new TagSelector(name));
+            }
+        }
+
+        return parts.Count == 1 ? parts[0] : new CompoundSelector(parts);
+    }
+
+    private static Selector ParsePseudoClass(string name) => name switch
+    {
+        "hover" => new HoverSelector(),
+        "active" => new ActiveSelector(),
+        "focus" => new FocusSelector(),
+        "disabled" => new DisabledSelector(),
+        "enabled" => new EnabledSelector(),
+        "first-child" => new FirstChildSelector(),
+        "last-child" => new LastChildSelector(),
+        "first-of-type" => new FirstOfTypeSelector(),
+        "last-of-type" => new LastOfTypeSelector(),
+        _ => throw new ArgumentException($"Unknown pseudo-class: :{name}")
+    };
+
+    private static string ReadIdentifier(string input, ref int i)
+    {
+        var start = i;
+        while (i < input.Length && (char.IsLetterOrDigit(input[i]) || input[i] == '-' || input[i] == '_'))
+            i++;
+        return input[start..i];
+    }
+
+    private static string ReadUntilClose(string input, ref int i)
+    {
+        var depth = 1;
+        var start = i;
+        while (i < input.Length && depth > 0)
+        {
+            if (input[i] == '(') depth++;
+            else if (input[i] == ')') depth--;
+            if (depth > 0) i++;
+        }
+        var result = input[start..i];
+        if (i < input.Length) i++; // skip )
+        return result;
+    }
+
+    private static List<string> SplitGroups(string input)
+    {
+        var result = new List<string>();
+        var depth = 0;
+        var start = 0;
+
+        for (int i = 0; i < input.Length; i++)
+        {
+            if (input[i] == '(') depth++;
+            else if (input[i] == ')') depth--;
+            else if (input[i] == ',' && depth == 0)
+            {
+                result.Add(input[start..i]);
+                start = i + 1;
+            }
+        }
+        result.Add(input[start..]);
+        return result;
+    }
+
+    private static List<(char combinator, string selector)> SplitByCombinators(string input)
+    {
+        var result = new List<(char combinator, string selector)>();
+        var i = 0;
+        var current = "";
+        char pendingCombinator = ' ';
+        bool isFirst = true;
+
+        while (i < input.Length)
+        {
+            if (input[i] == '(')
+            {
+                var start = i;
+                var depth = 1;
+                i++;
+                while (i < input.Length && depth > 0)
+                {
+                    if (input[i] == '(') depth++;
+                    else if (input[i] == ')') depth--;
+                    i++;
+                }
+                current += input[start..i];
+            }
+            else if (input[i] == '>' || input[i] == '+' || input[i] == '~')
+            {
+                if (current.Trim().Length > 0)
+                {
+                    result.Add((isFirst ? ' ' : pendingCombinator, current.Trim()));
+                    isFirst = false;
+                }
+                pendingCombinator = input[i];
+                current = "";
+                i++;
+            }
+            else if (input[i] == ' ')
+            {
+                // 可能是后代组合器，也可能是组合器周围的空格
+                var trimmed = current.Trim();
+                if (trimmed.Length > 0)
+                {
+                    // 向前看是否有显式组合器
+                    var j = i;
+                    while (j < input.Length && input[j] == ' ') j++;
+                    if (j < input.Length && (input[j] == '>' || input[j] == '+' || input[j] == '~'))
+                    {
+                        // 空格后面是显式组合器，跳过空格
+                        i = j;
+                        continue;
+                    }
+                    // 这是后代组合器
+                    result.Add((isFirst ? ' ' : pendingCombinator, trimmed));
+                    isFirst = false;
+                    pendingCombinator = ' ';
+                    current = "";
+                }
+                i++;
+            }
+            else
+            {
+                current += input[i];
+                i++;
+            }
+        }
+
+        if (current.Trim().Length > 0)
+            result.Add((isFirst ? ' ' : pendingCombinator, current.Trim()));
+
+        return result;
+    }
+}

--- a/src/Miko/Styling/Selectors/GroupSelector.cs
+++ b/src/Miko/Styling/Selectors/GroupSelector.cs
@@ -1,0 +1,19 @@
+using Miko.Core;
+
+namespace Miko.Styling.Selectors;
+
+/// <summary>
+/// 分组选择器 (A, B, C) - 任一选择器匹配即可
+/// </summary>
+public class GroupSelector : Selector
+{
+    private readonly List<Selector> _selectors;
+
+    public GroupSelector(params Selector[] selectors) => _selectors = new(selectors);
+    public GroupSelector(IEnumerable<Selector> selectors) => _selectors = new(selectors);
+
+    public Selector[] Selectors => _selectors.ToArray();
+
+    public override bool Matches(Element element) => _selectors.Any(s => s.Matches(element));
+    public override int Specificity => _selectors.Max(s => s.Specificity);
+}

--- a/src/Miko/Styling/Selectors/PseudoClassSelectors.cs
+++ b/src/Miko/Styling/Selectors/PseudoClassSelectors.cs
@@ -64,3 +64,64 @@ public class EnabledSelector : PseudoClassSelector
         return !element.IsDisabled;
     }
 }
+
+/// <summary>
+/// :first-child 伪类选择器
+/// </summary>
+public class FirstChildSelector : PseudoClassSelector
+{
+    public override bool Matches(Element element)
+    {
+        return element.Parent?.Children.FirstOrDefault() == element;
+    }
+}
+
+/// <summary>
+/// :last-child 伪类选择器
+/// </summary>
+public class LastChildSelector : PseudoClassSelector
+{
+    public override bool Matches(Element element)
+    {
+        return element.Parent?.Children.LastOrDefault() == element;
+    }
+}
+
+/// <summary>
+/// :first-of-type 伪类选择器
+/// </summary>
+public class FirstOfTypeSelector : PseudoClassSelector
+{
+    public override bool Matches(Element element)
+    {
+        if (element.Parent == null) return false;
+        return element.Parent.Children.FirstOrDefault(e => e.TagName == element.TagName) == element;
+    }
+}
+
+/// <summary>
+/// :last-of-type 伪类选择器
+/// </summary>
+public class LastOfTypeSelector : PseudoClassSelector
+{
+    public override bool Matches(Element element)
+    {
+        if (element.Parent == null) return false;
+        return element.Parent.Children.LastOrDefault(e => e.TagName == element.TagName) == element;
+    }
+}
+
+/// <summary>
+/// :not() 伪类选择器
+/// </summary>
+public class NotSelector : PseudoClassSelector
+{
+    private readonly Selector _inner;
+
+    public NotSelector(Selector inner) => _inner = inner;
+
+    public Selector Inner => _inner;
+
+    public override bool Matches(Element element) => !_inner.Matches(element);
+    public override int Specificity => _inner.Specificity;
+}

--- a/src/Miko/Styling/Style.cs
+++ b/src/Miko/Styling/Style.cs
@@ -404,6 +404,9 @@ public class Style
     public static TypedStyleBuilder<Element> Id(string id)
         => new TypedStyleBuilder<Element>(new IdSelector(id));
 
+    public static CombinatorStyleBuilder<Element> Group(params Selector[] selectors)
+        => new(new GroupSelector(selectors));
+
     /// <summary>
     /// 后代选择器 (ancestor descendant)
     /// </summary>

--- a/src/Miko/Styling/StyleSheet.cs
+++ b/src/Miko/Styling/StyleSheet.cs
@@ -1,4 +1,4 @@
-using Miko.Core;
+﻿using Miko.Core;
 using Miko.Styling.Selectors;
 
 namespace Miko.Styling;
@@ -12,23 +12,31 @@ public class StyleSheet
     public List<PseudoElementRule> PseudoElementRules { get; set; } = new();
     public List<MediaRule> MediaRules { get; set; } = new();
 
+    public void Add(CssObject css)
+    {
+        CssObjectResolver.Resolve(css, this);
+    }
+
     public void AddRule(Selector selector, Style style)
     {
         Rules.Add(new StyleRule { Selector = selector, Style = style });
     }
 
+    [Obsolete("Use StyleSheet.Register(CssObject) instead.")]
     public void AddRule<T>(TypedStyleBuilder<T> builder) where T : Element
     {
         var (selector, style) = builder.Build();
         Rules.Add(new StyleRule { Selector = selector, Style = style });
     }
 
+    [Obsolete("Use StyleSheet.Register(CssObject) instead.")]
     public void AddRule<T>(CombinatorStyleBuilder<T> builder) where T : Element
     {
         var (selector, style) = builder.Build();
         Rules.Add(new StyleRule { Selector = selector, Style = style });
     }
 
+    [Obsolete("Use StyleSheet.Register(CssObject) instead.")]
     public void AddRule<T>(PseudoElementStyleBuilder<T> builder) where T : Element
     {
         var (selector, type, style) = builder.Build();

--- a/src/Miko/Styling/TypedStyleBuilder.cs
+++ b/src/Miko/Styling/TypedStyleBuilder.cs
@@ -68,6 +68,11 @@ public class TypedStyleBuilder<T> where T : Element
     public TypedStyleBuilder<T> Focus()    { _selectors.Add(new FocusSelector());    return this; }
     public TypedStyleBuilder<T> Disabled() { _selectors.Add(new DisabledSelector()); return this; }
     public TypedStyleBuilder<T> Enabled()  { _selectors.Add(new EnabledSelector());  return this; }
+    public TypedStyleBuilder<T> FirstChild()  { _selectors.Add(new FirstChildSelector());  return this; }
+    public TypedStyleBuilder<T> LastChild()   { _selectors.Add(new LastChildSelector());   return this; }
+    public TypedStyleBuilder<T> FirstOfType() { _selectors.Add(new FirstOfTypeSelector()); return this; }
+    public TypedStyleBuilder<T> LastOfType()  { _selectors.Add(new LastOfTypeSelector());  return this; }
+    public TypedStyleBuilder<T> Not(Selector inner) { _selectors.Add(new NotSelector(inner)); return this; }
 
     /// <summary>
     /// 后代选择器 (A B) - 当前选择器作为祖先，匹配后代元素
@@ -148,6 +153,12 @@ public class CombinatorStyleBuilder<T> where T : Element
     private readonly Style _style = new();
 
     internal CombinatorStyleBuilder(Selector selector) => _selector = selector;
+
+    public CombinatorStyleBuilder<Element> Child(Selector child)
+        => new(new ChildSelector(_selector, child));
+
+    public CombinatorStyleBuilder<Element> Descendant(Selector descendant)
+        => new(new DescendantSelector(_selector, descendant));
 
     public CombinatorStyleBuilder<T> Set<TValue>(Expression<Func<Style, TValue?>> prop, TValue value)
     {

--- a/tests/Miko.Tests/Styling/CssObjectTests.cs
+++ b/tests/Miko.Tests/Styling/CssObjectTests.cs
@@ -1,0 +1,256 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Styling;
+
+public class CssObjectTests
+{
+    [Fact]
+    public void Register_SimpleClassSelector()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".btn"] = new() { Display = Display.Block }
+        });
+
+        sheet.Rules.Count.ShouldBe(1);
+        var element = new DivElement { Class = "btn" };
+        new StyleResolver().Resolve(element, [sheet]).Display.ShouldBe(Display.Block);
+    }
+
+    [Fact]
+    public void Register_TagSelector()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            ["div"] = new() { Color = Color.Red }
+        });
+
+        var element = new DivElement();
+        new StyleResolver().Resolve(element, [sheet]).Color.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void Register_IdSelector()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            ["#main"] = new() { Width = Length.Px(100) }
+        });
+
+        var element = new DivElement { Id = "main" };
+        new StyleResolver().Resolve(element, [sheet]).Width.ShouldBe(Length.Px(100));
+    }
+
+    [Fact]
+    public void Register_NestedDescendant()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".parent"] = new()
+            {
+                [".child"] = new() { Color = Color.Blue }
+            }
+        });
+
+        var parent = new DivElement { Class = "parent" };
+        var child = new DivElement { Class = "child" };
+        parent.AddChild(child);
+
+        new StyleResolver().Resolve(child, [sheet]).Color.ShouldBe(Color.Blue);
+    }
+
+    [Fact]
+    public void Register_ParentReference_PseudoClass()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".btn"] = new()
+            {
+                Color = Color.Blue,
+                ["&:hover"] = new() { Color = Color.Red }
+            }
+        });
+
+        // & expands to .btn:hover
+        sheet.Rules.Count.ShouldBe(2);
+        var element = new DivElement { Class = "btn" };
+        element.SetState(ElementState.Hover);
+        new StyleResolver().Resolve(element, [sheet]).Color.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void Register_ParentReference_CompoundClass()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".nav-pills"] = new()
+            {
+                ["&.active"] = new() { BackgroundColor = Color.Blue }
+            }
+        });
+
+        var element = new DivElement { Class = "nav-pills active" };
+        new StyleResolver().Resolve(element, [sheet]).BackgroundColor.ShouldBe(Color.Blue);
+    }
+
+    [Fact]
+    public void Register_ChildCombinator()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".parent > .child"] = new() { Color = Color.Green }
+        });
+
+        var parent = new DivElement { Class = "parent" };
+        var child = new DivElement { Class = "child" };
+        parent.AddChild(child);
+
+        new StyleResolver().Resolve(child, [sheet]).Color.ShouldBe(Color.Green);
+    }
+
+    [Fact]
+    public void Register_GroupSelector()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            ["h1, h2, h3"] = new() { FontWeight = FontWeight.Bold }
+        });
+
+        var h1 = new H1Element();
+        var h2 = new H2Element();
+        new StyleResolver().Resolve(h1, [sheet]).FontWeight.ShouldBe(FontWeight.Bold);
+        new StyleResolver().Resolve(h2, [sheet]).FontWeight.ShouldBe(FontWeight.Bold);
+    }
+
+    [Fact]
+    public void Register_PseudoClass_FirstOfType()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".item:first-of-type"] = new() { Color = Color.Red }
+        });
+
+        var parent = new DivElement();
+        var first = new DivElement { Class = "item" };
+        var second = new DivElement { Class = "item" };
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        new StyleResolver().Resolve(first, [sheet]).Color.ShouldBe(Color.Red);
+        new StyleResolver().Resolve(second, [sheet]).Color.ShouldBe(Color.Black);
+    }
+
+    [Fact]
+    public void Register_NotSelector()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".item:not(:first-of-type)"] = new() { Color = Color.Blue }
+        });
+
+        var parent = new DivElement();
+        var first = new DivElement { Class = "item" };
+        var second = new DivElement { Class = "item" };
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        new StyleResolver().Resolve(first, [sheet]).Color.ShouldBe(Color.Black);
+        new StyleResolver().Resolve(second, [sheet]).Color.ShouldBe(Color.Blue);
+    }
+
+    [Fact]
+    public void Register_DeepNesting()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".a"] = new()
+            {
+                [".b"] = new()
+                {
+                    [".c"] = new() { Color = Color.Red }
+                }
+            }
+        });
+
+        // Expands to: .a .b .c
+        var a = new DivElement { Class = "a" };
+        var b = new DivElement { Class = "b" };
+        var c = new DivElement { Class = "c" };
+        a.AddChild(b);
+        b.AddChild(c);
+
+        new StyleResolver().Resolve(c, [sheet]).Color.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void Register_MultipleProperties()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                Width = Length.Px(100),
+                Height = Length.Px(200),
+                BackgroundColor = Color.Red,
+                Padding = new Padding(16)
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        var resolved = new StyleResolver().Resolve(element, [sheet]);
+        resolved.Width.ShouldBe(Length.Px(100));
+        resolved.Height.ShouldBe(Length.Px(200));
+        resolved.BackgroundColor.ShouldBe(Color.Red);
+        resolved.PaddingTop.ShouldBe(Length.Px(16));
+    }
+
+    [Fact]
+    public void Register_NoStyleProperties_NoRule()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".parent"] = new()
+            {
+                [".child"] = new() { Color = Color.Red }
+            }
+        });
+
+        // .parent has no style properties, so only 1 rule for .parent .child
+        sheet.Rules.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Register_ParentWithStyleAndChildren()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".parent"] = new()
+            {
+                Color = Color.Blue,
+                [".child"] = new() { Color = Color.Red }
+            }
+        });
+
+        // Both .parent and .parent .child should have rules
+        sheet.Rules.Count.ShouldBe(2);
+    }
+}

--- a/tests/Miko.Tests/Styling/CssSelectorParserTests.cs
+++ b/tests/Miko.Tests/Styling/CssSelectorParserTests.cs
@@ -1,0 +1,160 @@
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Styling;
+
+public class CssSelectorParserTests
+{
+    [Fact]
+    public void Parse_TagSelector()
+    {
+        var selector = CssSelectorParser.Parse("div");
+        selector.ShouldBeOfType<TagSelector>();
+    }
+
+    [Fact]
+    public void Parse_ClassSelector()
+    {
+        var selector = CssSelectorParser.Parse(".btn");
+        selector.ShouldBeOfType<ClassSelector>();
+    }
+
+    [Fact]
+    public void Parse_IdSelector()
+    {
+        var selector = CssSelectorParser.Parse("#main");
+        selector.ShouldBeOfType<IdSelector>();
+    }
+
+    [Fact]
+    public void Parse_UniversalSelector()
+    {
+        var selector = CssSelectorParser.Parse("*");
+        selector.ShouldBeOfType<UniversalSelector>();
+    }
+
+    [Fact]
+    public void Parse_CompoundSelector_TagAndClass()
+    {
+        var selector = CssSelectorParser.Parse("div.active");
+        var compound = selector.ShouldBeOfType<CompoundSelector>();
+        compound.Selectors.Count.ShouldBe(2);
+        compound.Selectors[0].ShouldBeOfType<TagSelector>();
+        compound.Selectors[1].ShouldBeOfType<ClassSelector>();
+    }
+
+    [Fact]
+    public void Parse_CompoundSelector_ClassAndPseudoClass()
+    {
+        var selector = CssSelectorParser.Parse(".btn:hover");
+        var compound = selector.ShouldBeOfType<CompoundSelector>();
+        compound.Selectors[0].ShouldBeOfType<ClassSelector>();
+        compound.Selectors[1].ShouldBeOfType<HoverSelector>();
+    }
+
+    [Fact]
+    public void Parse_PseudoClasses()
+    {
+        CssSelectorParser.Parse(".a:hover").ShouldBeOfType<CompoundSelector>();
+        CssSelectorParser.Parse(".a:active").ShouldBeOfType<CompoundSelector>();
+        CssSelectorParser.Parse(".a:focus").ShouldBeOfType<CompoundSelector>();
+        CssSelectorParser.Parse(".a:disabled").ShouldBeOfType<CompoundSelector>();
+        CssSelectorParser.Parse(".a:enabled").ShouldBeOfType<CompoundSelector>();
+        CssSelectorParser.Parse(".a:first-child").ShouldBeOfType<CompoundSelector>();
+        CssSelectorParser.Parse(".a:last-child").ShouldBeOfType<CompoundSelector>();
+        CssSelectorParser.Parse(".a:first-of-type").ShouldBeOfType<CompoundSelector>();
+        CssSelectorParser.Parse(".a:last-of-type").ShouldBeOfType<CompoundSelector>();
+    }
+
+    [Fact]
+    public void Parse_NotSelector()
+    {
+        var selector = CssSelectorParser.Parse(".item:not(:first-of-type)");
+        var compound = selector.ShouldBeOfType<CompoundSelector>();
+        compound.Selectors[0].ShouldBeOfType<ClassSelector>();
+        var not = compound.Selectors[1].ShouldBeOfType<NotSelector>();
+        not.Inner.ShouldBeOfType<FirstOfTypeSelector>();
+    }
+
+    [Fact]
+    public void Parse_NotSelector_WithClass()
+    {
+        var selector = CssSelectorParser.Parse(".btn:not(.collapsed)");
+        var compound = selector.ShouldBeOfType<CompoundSelector>();
+        compound.Selectors[0].ShouldBeOfType<ClassSelector>();
+        var not = compound.Selectors[1].ShouldBeOfType<NotSelector>();
+        not.Inner.ShouldBeOfType<ClassSelector>();
+    }
+
+    [Fact]
+    public void Parse_DescendantCombinator()
+    {
+        var selector = CssSelectorParser.Parse(".parent .child");
+        var desc = selector.ShouldBeOfType<DescendantSelector>();
+        desc.Ancestor.ShouldBeOfType<ClassSelector>();
+        desc.Descendant.ShouldBeOfType<ClassSelector>();
+    }
+
+    [Fact]
+    public void Parse_ChildCombinator()
+    {
+        var selector = CssSelectorParser.Parse(".parent > .child");
+        var child = selector.ShouldBeOfType<ChildSelector>();
+        child.Parent.ShouldBeOfType<ClassSelector>();
+        child.Child.ShouldBeOfType<ClassSelector>();
+    }
+
+    [Fact]
+    public void Parse_AdjacentSiblingCombinator()
+    {
+        var selector = CssSelectorParser.Parse(".a + .b");
+        var adj = selector.ShouldBeOfType<AdjacentSiblingSelector>();
+        adj.Previous.ShouldBeOfType<ClassSelector>();
+        adj.Target.ShouldBeOfType<ClassSelector>();
+    }
+
+    [Fact]
+    public void Parse_GeneralSiblingCombinator()
+    {
+        var selector = CssSelectorParser.Parse(".a ~ .b");
+        var gen = selector.ShouldBeOfType<GeneralSiblingSelector>();
+        gen.Previous.ShouldBeOfType<ClassSelector>();
+        gen.Target.ShouldBeOfType<ClassSelector>();
+    }
+
+    [Fact]
+    public void Parse_GroupSelector()
+    {
+        var selector = CssSelectorParser.Parse("h1, h2, h3");
+        var group = selector.ShouldBeOfType<GroupSelector>();
+        group.Selectors.Length.ShouldBe(3);
+    }
+
+    [Fact]
+    public void Parse_ComplexSelector_ChildWithPseudoClass()
+    {
+        // .accordion-item:first-of-type > .accordion-header
+        var selector = CssSelectorParser.Parse(".accordion-item:first-of-type > .accordion-header");
+        var child = selector.ShouldBeOfType<ChildSelector>();
+        child.Parent.ShouldBeOfType<CompoundSelector>();
+        child.Child.ShouldBeOfType<ClassSelector>();
+    }
+
+    [Fact]
+    public void Parse_MultiLevelDescendant()
+    {
+        var selector = CssSelectorParser.Parse(".a .b .c");
+        var outer = selector.ShouldBeOfType<DescendantSelector>();
+        outer.Ancestor.ShouldBeOfType<DescendantSelector>();
+        outer.Descendant.ShouldBeOfType<ClassSelector>();
+    }
+
+    [Fact]
+    public void Parse_MultipleClasses()
+    {
+        var selector = CssSelectorParser.Parse(".btn.active.large");
+        var compound = selector.ShouldBeOfType<CompoundSelector>();
+        compound.Selectors.Count.ShouldBe(3);
+        compound.Selectors.ShouldAllBe(s => s is ClassSelector);
+    }
+}

--- a/tests/Miko.Tests/Styling/StructuralPseudoClassTests.cs
+++ b/tests/Miko.Tests/Styling/StructuralPseudoClassTests.cs
@@ -1,0 +1,211 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Styling;
+
+public class StructuralPseudoClassTests
+{
+    [Fact]
+    public void FirstChild_ShouldMatchFirstChild()
+    {
+        var parent = new DivElement();
+        var first = new DivElement();
+        var second = new DivElement();
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.For<DivElement>().FirstChild().Set(x => x.BackgroundColor, Color.Red));
+
+        new StyleResolver().Resolve(first, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+        new StyleResolver().Resolve(second, [sheet]).BackgroundColor.ShouldBe(Color.Transparent);
+    }
+
+    [Fact]
+    public void LastChild_ShouldMatchLastChild()
+    {
+        var parent = new DivElement();
+        var first = new DivElement();
+        var last = new DivElement();
+        parent.AddChild(first);
+        parent.AddChild(last);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.For<DivElement>().LastChild().Set(x => x.BackgroundColor, Color.Red));
+
+        new StyleResolver().Resolve(first, [sheet]).BackgroundColor.ShouldBe(Color.Transparent);
+        new StyleResolver().Resolve(last, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void FirstOfType_ShouldMatchFirstElementOfSameType()
+    {
+        var parent = new DivElement();
+        var span1 = new SpanElement();
+        var div1 = new DivElement();
+        var span2 = new SpanElement();
+        parent.AddChild(span1);
+        parent.AddChild(div1);
+        parent.AddChild(span2);
+
+        var selector = new CompoundSelector(new TagSelector("span"), new FirstOfTypeSelector());
+        selector.Matches(span1).ShouldBeTrue();
+        selector.Matches(span2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LastOfType_ShouldMatchLastElementOfSameType()
+    {
+        var parent = new DivElement();
+        var span1 = new SpanElement();
+        var div1 = new DivElement();
+        var span2 = new SpanElement();
+        parent.AddChild(span1);
+        parent.AddChild(div1);
+        parent.AddChild(span2);
+
+        var selector = new CompoundSelector(new TagSelector("span"), new LastOfTypeSelector());
+        selector.Matches(span1).ShouldBeFalse();
+        selector.Matches(span2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Not_ShouldNegateInnerSelector()
+    {
+        var parent = new DivElement();
+        var first = new DivElement();
+        var second = new DivElement();
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.For<DivElement>().Not(new FirstOfTypeSelector()).Set(x => x.BackgroundColor, Color.Red));
+
+        new StyleResolver().Resolve(first, [sheet]).BackgroundColor.ShouldBe(Color.Transparent);
+        new StyleResolver().Resolve(second, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void FluentApi_FirstOfType_ShouldWork()
+    {
+        var parent = new DivElement();
+        var first = new DivElement();
+        var second = new DivElement();
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.For<DivElement>().FirstOfType().Set(x => x.BackgroundColor, Color.Red));
+
+        new StyleResolver().Resolve(first, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+        new StyleResolver().Resolve(second, [sheet]).BackgroundColor.ShouldBe(Color.Transparent);
+    }
+
+    [Fact]
+    public void FluentApi_LastOfType_ShouldWork()
+    {
+        var parent = new DivElement();
+        var first = new DivElement();
+        var second = new DivElement();
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.For<DivElement>().LastOfType().Set(x => x.BackgroundColor, Color.Red));
+
+        new StyleResolver().Resolve(first, [sheet]).BackgroundColor.ShouldBe(Color.Transparent);
+        new StyleResolver().Resolve(second, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void GroupSelector_ShouldMatchAnyOfTheSelectors()
+    {
+        var div = new DivElement();
+        var span = new SpanElement();
+        var button = new ButtonElement();
+
+        var selector = new GroupSelector(new TagSelector("div"), new TagSelector("span"));
+        selector.Matches(div).ShouldBeTrue();
+        selector.Matches(span).ShouldBeTrue();
+        selector.Matches(button).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void StyleGroup_ShouldApplyToMultipleSelectors()
+    {
+        var div = new DivElement();
+        var span = new SpanElement();
+        var button = new ButtonElement();
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Group(new TagSelector("div"), new TagSelector("span")).Set(x => x.BackgroundColor, Color.Red));
+
+        new StyleResolver().Resolve(div, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+        new StyleResolver().Resolve(span, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+        new StyleResolver().Resolve(button, [sheet]).BackgroundColor.ShouldBe(Color.Transparent);
+    }
+
+    [Fact]
+    public void CombinatorBuilder_Child_ShouldChain()
+    {
+        // .accordion-item:first-of-type > .accordion-header
+        var parent = new DivElement();
+        var item = new DivElement { Class = "accordion-item" };
+        var header = new DivElement { Class = "accordion-header" };
+        parent.AddChild(item);
+        item.AddChild(header);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(
+            Style.Class("accordion-item").FirstOfType()
+                .Child<Element>(new ClassSelector("accordion-header"))
+                .Set(x => x.BackgroundColor, Color.Red)
+        );
+
+        new StyleResolver().Resolve(header, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void CombinatorBuilder_Child_Descendant_ShouldChain()
+    {
+        // .accordion-item:first-of-type > .accordion-header .accordion-button
+        var parent = new DivElement();
+        var item = new DivElement { Class = "accordion-item" };
+        var header = new DivElement { Class = "accordion-header" };
+        var button = new ButtonElement { Class = "accordion-button" };
+        parent.AddChild(item);
+        item.AddChild(header);
+        header.AddChild(button);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(
+            Style.Class("accordion-item").FirstOfType()
+                .Child<Element>(new ClassSelector("accordion-header"))
+                .Descendant(new ClassSelector("accordion-button"))
+                .Set(x => x.BackgroundColor, Color.Red)
+        );
+
+        new StyleResolver().Resolve(button, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void Not_FirstOfType_ShouldMatchNonFirstElements()
+    {
+        // .accordion-item:not(:first-of-type)
+        var parent = new DivElement();
+        var first = new DivElement { Class = "accordion-item" };
+        var second = new DivElement { Class = "accordion-item" };
+        parent.AddChild(first);
+        parent.AddChild(second);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Class("accordion-item").Not(new FirstOfTypeSelector()).Set(x => x.BackgroundColor, Color.Red));
+
+        new StyleResolver().Resolve(first, [sheet]).BackgroundColor.ShouldBe(Color.Transparent);
+        new StyleResolver().Resolve(second, [sheet]).BackgroundColor.ShouldBe(Color.Red);
+    }
+}


### PR DESCRIPTION
## Summary

Refactor style declaration interface by introducing CssObject — a CSS-in-C# approach similar to Sass/Less nesting, using C# object initializer syntax.

## Changes

- Add `CssObject` as a nested style declaration wrapper
- Add `CssObjectResolver` to flatten nested CssObject into StyleRules
- Add `CssSelectorParser` supporting tag, class, id, group, combinator, pseudo-class, and parent reference (`&`) selectors
- Add `GroupSelector` for comma-separated selector lists
- Add structural pseudo-class selectors (first-child, last-child, nth-child, etc.)
- Migrate GlobalStyles example to new CssObject API
- Add comprehensive unit tests

## Testing

- CssObject resolution tests
- CssSelectorParser tests covering all selector types
- Structural pseudo-class tests

Closes #23