### PR TITLE
Fix margin-auto and align-items for block, flex, and pseudo-elements

### DIFF
--- a/src/Miko/Common/BackgroundImage.cs
+++ b/src/Miko/Common/BackgroundImage.cs
@@ -1,19 +1,52 @@
 using SkiaSharp;
+using Svg.Skia;
 using System.Reflection;
 
 namespace Miko.Common;
 
 public class BackgroundImage
 {
-    public SKBitmap? Bitmap { get; private set; }
+    private SKBitmap? _bitmap;
+    private SKPicture? _picture;
+    private float _viewBoxWidth;
+    private float _viewBoxHeight;
+
+    public SKBitmap? Bitmap
+    {
+        get
+        {
+            if (_bitmap != null) return _bitmap;
+            if (_picture != null)
+            {
+                _bitmap = RenderPictureToBitmap((int)_viewBoxWidth, (int)_viewBoxHeight);
+            }
+            return _bitmap;
+        }
+        private set => _bitmap = value;
+    }
+
+    public float OriginalWidth => _bitmap?.Width ?? _viewBoxWidth;
+    public float OriginalHeight => _bitmap?.Height ?? _viewBoxHeight;
+
+    public BackgroundRepeat Repeat { get; set; } = BackgroundRepeat.Repeat;
+    public BackgroundSize Size { get; set; } = BackgroundSize.Auto;
+    public BackgroundPosition Position { get; set; } = BackgroundPosition.LeftTop;
 
     private BackgroundImage() { }
 
     public static BackgroundImage FromFile(string path)
     {
         var image = new BackgroundImage();
-        using var stream = System.IO.File.OpenRead(path);
-        image.Bitmap = SKBitmap.Decode(stream);
+        if (IsSvgFile(path))
+        {
+            using var stream = File.OpenRead(path);
+            image.LoadSvg(stream);
+        }
+        else
+        {
+            using var stream = File.OpenRead(path);
+            image._bitmap = SKBitmap.Decode(stream);
+        }
         return image;
     }
 
@@ -21,7 +54,7 @@ public class BackgroundImage
     {
         var image = new BackgroundImage();
         var bytes = Convert.FromBase64String(base64);
-        image.Bitmap = SKBitmap.Decode(bytes);
+        image._bitmap = SKBitmap.Decode(bytes);
         return image;
     }
 
@@ -31,26 +64,82 @@ public class BackgroundImage
         using var stream = assembly.GetManifestResourceStream(resourceName);
         if (stream == null)
             throw new InvalidOperationException($"Resource '{resourceName}' not found in assembly '{assembly.FullName}'.");
-        image.Bitmap = SKBitmap.Decode(stream);
+
+        if (IsSvgResource(resourceName))
+            image.LoadSvg(stream);
+        else
+            image._bitmap = SKBitmap.Decode(stream);
+
         return image;
     }
 
     public static BackgroundImage FromStream(Stream stream)
     {
         var image = new BackgroundImage();
-        image.Bitmap = SKBitmap.Decode(stream);
+        image._bitmap = SKBitmap.Decode(stream);
         return image;
     }
 
     public static BackgroundImage FromBytes(byte[] data)
     {
         var image = new BackgroundImage();
-        image.Bitmap = SKBitmap.Decode(data);
+        image._bitmap = SKBitmap.Decode(data);
         return image;
     }
 
     public static BackgroundImage FromBitmap(SKBitmap bitmap)
     {
-        return new BackgroundImage { Bitmap = bitmap };
+        return new BackgroundImage { _bitmap = bitmap };
     }
+
+    public static BackgroundImage FromSvgStream(Stream stream)
+    {
+        var image = new BackgroundImage();
+        image.LoadSvg(stream);
+        return image;
+    }
+
+    public SKBitmap? RenderAtSize(int width, int height)
+    {
+        if (_picture != null)
+            return RenderPictureToBitmap(width, height);
+        return _bitmap;
+    }
+
+    private void LoadSvg(Stream stream)
+    {
+        var svg = new SKSvg();
+        svg.Load(stream);
+        if (svg.Picture != null)
+        {
+            _picture = svg.Picture;
+            _viewBoxWidth = svg.Picture.CullRect.Width;
+            _viewBoxHeight = svg.Picture.CullRect.Height;
+            if (_viewBoxWidth <= 0) _viewBoxWidth = 16;
+            if (_viewBoxHeight <= 0) _viewBoxHeight = 16;
+        }
+    }
+
+    private SKBitmap RenderPictureToBitmap(int width, int height)
+    {
+        if (width <= 0) width = 16;
+        if (height <= 0) height = 16;
+
+        var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Transparent);
+
+        var scaleX = width / _picture!.CullRect.Width;
+        var scaleY = height / _picture.CullRect.Height;
+        canvas.Scale(scaleX, scaleY);
+        canvas.DrawPicture(_picture);
+
+        return bitmap;
+    }
+
+    private static bool IsSvgFile(string path) =>
+        path.EndsWith(".svg", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsSvgResource(string resourceName) =>
+        resourceName.EndsWith(".svg", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Miko/Common/BackgroundSize.cs
+++ b/src/Miko/Common/BackgroundSize.cs
@@ -1,0 +1,37 @@
+﻿namespace Miko.Common;
+
+public readonly struct BackgroundSize : IEquatable<BackgroundSize>
+{
+    public BackgroundSizeMode Mode { get; }
+    public Length Width { get; }
+    public Length Height { get; }
+
+    private BackgroundSize(BackgroundSizeMode mode, Length width = default, Length height = default)
+    {
+        Mode = mode;
+        Width = width;
+        Height = height;
+    }
+
+    public static BackgroundSize Auto => new(BackgroundSizeMode.Auto);
+    public static BackgroundSize Cover => new(BackgroundSizeMode.Cover);
+    public static BackgroundSize Contain => new(BackgroundSizeMode.Contain);
+    public static BackgroundSize Px(float width, float height) => new(BackgroundSizeMode.Explicit, Length.Px(width), Length.Px(height));
+    public static BackgroundSize Px(float size) => new(BackgroundSizeMode.Explicit, Length.Px(size), Length.Px(size));
+    public static BackgroundSize From(Length width, Length height) => new(BackgroundSizeMode.Explicit, width, height);
+    public static BackgroundSize From(Length size) => new(BackgroundSizeMode.Explicit, size, size);
+
+    public float ResolveWidth(float containerWidth, float imageWidth) =>
+        Mode == BackgroundSizeMode.Explicit ? Width.ToPixels(containerWidth) : imageWidth;
+
+    public float ResolveHeight(float containerHeight, float imageHeight) =>
+        Mode == BackgroundSizeMode.Explicit ? Height.ToPixels(containerHeight) : imageHeight;
+
+    public bool Equals(BackgroundSize other) =>
+        Mode == other.Mode && Width.Equals(other.Width) && Height.Equals(other.Height);
+
+    public override bool Equals(object? obj) => obj is BackgroundSize other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(Mode, Width, Height);
+    public static bool operator ==(BackgroundSize left, BackgroundSize right) => left.Equals(right);
+    public static bool operator !=(BackgroundSize left, BackgroundSize right) => !left.Equals(right);
+}

--- a/src/Miko/Common/Enums.cs
+++ b/src/Miko/Common/Enums.cs
@@ -169,3 +169,6 @@ public enum AlignContent { FlexStart, FlexEnd, Center, SpaceBetween, SpaceAround
 public enum UserSelect { Auto, None, Text, All }
 public enum VerticalAlign { Baseline, Top, Middle, Bottom, TextTop, TextBottom }
 public enum BoxSizing { ContentBox, BorderBox }
+public enum BackgroundRepeat { Repeat, RepeatX, RepeatY, NoRepeat }
+public enum BackgroundSizeMode { Auto, Cover, Contain, Explicit }
+public enum BackgroundPosition { LeftTop, CenterTop, RightTop, LeftCenter, Center, RightCenter, LeftBottom, CenterBottom, RightBottom }

--- a/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
@@ -15,6 +15,9 @@ public class BlockLayout
         // 1. 计算 margin, border, padding
         float containerWidth = constraints.AvailableWidth ?? 0;
 
+        bool marginLeftAuto = style.MarginLeft.IsAuto;
+        bool marginRightAuto = style.MarginRight.IsAuto;
+
         box.BoxModel.Margin = new EdgeSizes(
             style.MarginTop.ToPixels(containerWidth),
             style.MarginRight.ToPixels(containerWidth),
@@ -81,6 +84,39 @@ public class BlockLayout
         if (!style.MaxWidth.IsAuto)
         {
             contentWidth = Math.Min(contentWidth, style.MaxWidth.ToPixels(containerWidth));
+        }
+
+        // 解析 margin auto：当元素有明确宽度时，auto margin 占据剩余空间
+        if ((marginLeftAuto || marginRightAuto) && !style.Width.IsAuto && containerWidth > 0)
+        {
+            float usedWidth = contentWidth + box.BoxModel.Border.Horizontal + box.BoxModel.Padding.Horizontal;
+            float remainingSpace = Math.Max(0, containerWidth - usedWidth
+                - (marginLeftAuto ? 0 : box.BoxModel.Margin.Left)
+                - (marginRightAuto ? 0 : box.BoxModel.Margin.Right));
+
+            float newMarginLeft = box.BoxModel.Margin.Left;
+            float newMarginRight = box.BoxModel.Margin.Right;
+
+            if (marginLeftAuto && marginRightAuto)
+            {
+                newMarginLeft = remainingSpace / 2f;
+                newMarginRight = remainingSpace / 2f;
+            }
+            else if (marginLeftAuto)
+            {
+                newMarginLeft = remainingSpace;
+            }
+            else
+            {
+                newMarginRight = remainingSpace;
+            }
+
+            box.BoxModel.Margin = new EdgeSizes(
+                box.BoxModel.Margin.Top,
+                newMarginRight,
+                box.BoxModel.Margin.Bottom,
+                newMarginLeft
+            );
         }
 
         // 判断是否需要为滚动条预留空间（Classic 模式占用布局）

--- a/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
@@ -247,29 +247,42 @@ public class FlexLayout
         // 计算剩余空间
         float freeSpace = contentWidth - totalFlexBasisSize;
 
-        // 分配空间（grow 或 shrink）
-        bool anyAdjustment = false;
-        if (freeSpace > 0 && totalFlexGrow > 0)
+        // 检查是否有 auto margin（主轴方向：left/right）
+        int autoMarginCount = 0;
+        foreach (var info in childInfos)
         {
-            // 有剩余空间且有元素可以增长
-            anyAdjustment = true;
-            foreach (var info in childInfos)
-            {
-                float growRatio = info.FlexGrow / totalFlexGrow;
-                info.FinalSize = info.FlexBasis + freeSpace * growRatio;
-            }
+            var childStyle = info.Child.ComputedStyle;
+            if (childStyle.MarginLeft.IsAuto) autoMarginCount++;
+            if (childStyle.MarginRight.IsAuto) autoMarginCount++;
         }
-        else if (freeSpace < 0 && totalFlexShrinkWeighted > 0)
+
+        // 如果有 auto margin 且有剩余空间，auto margin 消耗剩余空间（优先于 flex-grow）
+        bool hasAutoMargins = autoMarginCount > 0 && freeSpace > 0;
+        float autoMarginSize = hasAutoMargins ? Math.Max(0, freeSpace) / autoMarginCount : 0;
+
+        // 分配空间（grow 或 shrink）— 仅在没有 auto margin 时生效
+        bool anyAdjustment = false;
+        if (!hasAutoMargins)
         {
-            // 空间不足且有元素可以收缩
-            anyAdjustment = true;
-            float shrinkAmount = -freeSpace;
-            foreach (var info in childInfos)
+            if (freeSpace > 0 && totalFlexGrow > 0)
             {
-                float shrinkRatio = (info.FlexShrink * info.FlexBasis) / totalFlexShrinkWeighted;
-                info.FinalSize = info.FlexBasis - shrinkAmount * shrinkRatio;
-                // 确保不会收缩到负值
-                info.FinalSize = Math.Max(0, info.FinalSize);
+                anyAdjustment = true;
+                foreach (var info in childInfos)
+                {
+                    float growRatio = info.FlexGrow / totalFlexGrow;
+                    info.FinalSize = info.FlexBasis + freeSpace * growRatio;
+                }
+            }
+            else if (freeSpace < 0 && totalFlexShrinkWeighted > 0)
+            {
+                anyAdjustment = true;
+                float shrinkAmount = -freeSpace;
+                foreach (var info in childInfos)
+                {
+                    float shrinkRatio = (info.FlexShrink * info.FlexBasis) / totalFlexShrinkWeighted;
+                    info.FinalSize = info.FlexBasis - shrinkAmount * shrinkRatio;
+                    info.FinalSize = Math.Max(0, info.FinalSize);
+                }
             }
         }
 
@@ -279,13 +292,24 @@ public class FlexLayout
         {
             var child = info.Child;
             var childStyle = child.ComputedStyle;
+
+            // 处理主轴 auto margin
+            float extraMarginLeft = 0;
+            float extraMarginRight = 0;
+            if (hasAutoMargins)
+            {
+                if (childStyle.MarginLeft.IsAuto) extraMarginLeft = autoMarginSize;
+                if (childStyle.MarginRight.IsAuto) extraMarginRight = autoMarginSize;
+                currentX += extraMarginLeft;
+            }
+
             bool needsResize = anyAdjustment && Math.Abs(info.FinalSize - info.FlexBasis) > 0.01f;
 
             if (needsResize || !info.UsedAutoSize)
             {
                 // 需要调整大小，或者使用了显式的 flex-basis/width
-                float childMarginLeft = childStyle.MarginLeft.ToPixels(contentWidth);
-                float childMarginRight = childStyle.MarginRight.ToPixels(contentWidth);
+                float childMarginLeft = childStyle.MarginLeft.IsAuto ? 0 : childStyle.MarginLeft.ToPixels(contentWidth);
+                float childMarginRight = childStyle.MarginRight.IsAuto ? 0 : childStyle.MarginRight.ToPixels(contentWidth);
                 float childBorderLeftWidth = childStyle.BorderLeftWidth.ToPixels(contentWidth);
                 float childBorderRightWidth = childStyle.BorderRightWidth.ToPixels(contentWidth);
                 float childPaddingLeft = childStyle.PaddingLeft.ToPixels(contentWidth);
@@ -317,7 +341,7 @@ public class FlexLayout
                 LayoutDispatcher.Dispatch(child, childConstraints, currentX, contentY);
             }
 
-            currentX = child.BoxModel.MarginBox.Right;
+            currentX = child.BoxModel.MarginBox.Right + extraMarginRight;
             maxCrossSize = Math.Max(maxCrossSize, child.BoxModel.MarginBox.Height);
         }
 
@@ -341,8 +365,9 @@ public class FlexLayout
             ApplyJustifyContent(box, contentX, contentWidth, totalWidth, true);
         }
 
-        // 交叉轴对齐 (align-items)
-        ApplyAlignItems(box, contentY, maxCrossSize, true);
+        // 交叉轴对齐 (align-items) — 使用容器高度（如果明确）或最大子元素高度
+        float crossSize = contentHeight > 0 ? Math.Max(contentHeight, maxCrossSize) : maxCrossSize;
+        ApplyAlignItems(box, contentY, crossSize, true);
     }
 
     private void LayoutColumnDirection(LayoutBox box, float contentX, float contentY,
@@ -412,29 +437,42 @@ public class FlexLayout
         bool hasDefiniteHeight = contentHeight > 0;
         float freeSpace = hasDefiniteHeight ? contentHeight - totalFlexBasisSize : 0;
 
-        // 分配空间（grow 或 shrink）
-        bool anyAdjustment = false;
-        if (freeSpace > 0 && totalFlexGrow > 0)
+        // 检查是否有 auto margin（主轴方向：top/bottom）
+        int autoMarginCount = 0;
+        foreach (var info in childInfos)
         {
-            // 有剩余空间且有元素可以增长
-            anyAdjustment = true;
-            foreach (var info in childInfos)
-            {
-                float growRatio = info.FlexGrow / totalFlexGrow;
-                info.FinalSize = info.FlexBasis + freeSpace * growRatio;
-            }
+            var childStyle = info.Child.ComputedStyle;
+            if (childStyle.MarginTop.IsAuto) autoMarginCount++;
+            if (childStyle.MarginBottom.IsAuto) autoMarginCount++;
         }
-        else if (freeSpace < 0 && totalFlexShrinkWeighted > 0)
+
+        // 如果有 auto margin 且有剩余空间，auto margin 消耗剩余空间（优先于 flex-grow）
+        bool hasAutoMargins = autoMarginCount > 0 && freeSpace > 0;
+        float autoMarginSize = hasAutoMargins ? Math.Max(0, freeSpace) / autoMarginCount : 0;
+
+        // 分配空间（grow 或 shrink）— 仅在没有 auto margin 时生效
+        bool anyAdjustment = false;
+        if (!hasAutoMargins)
         {
-            // 空间不足且有元素可以收缩
-            anyAdjustment = true;
-            float shrinkAmount = -freeSpace;
-            foreach (var info in childInfos)
+            if (freeSpace > 0 && totalFlexGrow > 0)
             {
-                float shrinkRatio = (info.FlexShrink * info.FlexBasis) / totalFlexShrinkWeighted;
-                info.FinalSize = info.FlexBasis - shrinkAmount * shrinkRatio;
-                // 确保不会收缩到负值
-                info.FinalSize = Math.Max(0, info.FinalSize);
+                anyAdjustment = true;
+                foreach (var info in childInfos)
+                {
+                    float growRatio = info.FlexGrow / totalFlexGrow;
+                    info.FinalSize = info.FlexBasis + freeSpace * growRatio;
+                }
+            }
+            else if (freeSpace < 0 && totalFlexShrinkWeighted > 0)
+            {
+                anyAdjustment = true;
+                float shrinkAmount = -freeSpace;
+                foreach (var info in childInfos)
+                {
+                    float shrinkRatio = (info.FlexShrink * info.FlexBasis) / totalFlexShrinkWeighted;
+                    info.FinalSize = info.FlexBasis - shrinkAmount * shrinkRatio;
+                    info.FinalSize = Math.Max(0, info.FinalSize);
+                }
             }
         }
 
@@ -444,13 +482,24 @@ public class FlexLayout
         {
             var child = info.Child;
             var childStyle = child.ComputedStyle;
+
+            // 处理主轴 auto margin
+            float extraMarginTop = 0;
+            float extraMarginBottom = 0;
+            if (hasAutoMargins)
+            {
+                if (childStyle.MarginTop.IsAuto) extraMarginTop = autoMarginSize;
+                if (childStyle.MarginBottom.IsAuto) extraMarginBottom = autoMarginSize;
+                currentY += extraMarginTop;
+            }
+
             bool needsResize = anyAdjustment && Math.Abs(info.FinalSize - info.FlexBasis) > 0.01f;
 
             if (needsResize || !info.UsedAutoSize)
             {
                 // 需要调整大小，或者使用了显式的 flex-basis/height
-                float childMarginTop = childStyle.MarginTop.ToPixels(contentWidth);
-                float childMarginBottom = childStyle.MarginBottom.ToPixels(contentWidth);
+                float childMarginTop = childStyle.MarginTop.IsAuto ? 0 : childStyle.MarginTop.ToPixels(contentWidth);
+                float childMarginBottom = childStyle.MarginBottom.IsAuto ? 0 : childStyle.MarginBottom.ToPixels(contentWidth);
                 float childBorderTopWidth = childStyle.BorderTopWidth.ToPixels(contentWidth);
                 float childBorderBottomWidth = childStyle.BorderBottomWidth.ToPixels(contentWidth);
                 float childPaddingTop = childStyle.PaddingTop.ToPixels(contentWidth);
@@ -480,7 +529,7 @@ public class FlexLayout
                 LayoutDispatcher.Dispatch(child, childConstraints, contentX, currentY);
             }
 
-            currentY = child.BoxModel.MarginBox.Bottom;
+            currentY = child.BoxModel.MarginBox.Bottom + extraMarginBottom;
             maxCrossSize = Math.Max(maxCrossSize, child.BoxModel.MarginBox.Width);
         }
 
@@ -505,8 +554,9 @@ public class FlexLayout
             ApplyJustifyContent(box, contentY, contentHeight, totalHeight, false);
         }
 
-        // 交叉轴对齐 (align-items)
-        ApplyAlignItems(box, contentX, maxCrossSize, false);
+        // 交叉轴对齐 (align-items) — 使用容器宽度（如果明确）或最大子元素宽度
+        float crossSize = contentWidth > 0 ? Math.Max(contentWidth, maxCrossSize) : maxCrossSize;
+        ApplyAlignItems(box, contentX, crossSize, false);
     }
 
     private void ApplyJustifyContent(LayoutBox box, float start, float containerSize, float contentSize, bool isRow)

--- a/src/Miko/Miko.csproj
+++ b/src/Miko/Miko.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageReference Include="Svg.Skia" Version="2.0.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Miko/Rendering/Painter.cs
+++ b/src/Miko/Rendering/Painter.cs
@@ -358,6 +358,12 @@ public class Painter
         _canvas.ClipRect(rect.ToSKRect());
     }
 
+    public void SaveClip(RectF rect)
+    {
+        _canvas.Save();
+        _canvas.ClipRect(rect.ToSKRect());
+    }
+
     /// <summary>
     /// 清空画布
     /// </summary>

--- a/src/Miko/Rendering/RenderEngine.cs
+++ b/src/Miko/Rendering/RenderEngine.cs
@@ -1,6 +1,7 @@
 using Miko.Common;
 using Miko.Core.DomElements;
 using Miko.Layout;
+using Miko.Styling;
 using SkiaSharp;
 
 namespace Miko.Rendering;
@@ -243,7 +244,115 @@ public class RenderEngine
 
         if (style.BackgroundImage?.Bitmap != null)
         {
-            _painter.DrawImage(style.BackgroundImage.Bitmap, box.BoxModel.PaddingBox);
+            RenderBackgroundImage(style, box.BoxModel.PaddingBox);
+        }
+    }
+
+    private void RenderBackgroundImage(ComputedStyle style, RectF area)
+    {
+        var bgImage = style.BackgroundImage!;
+        var bitmap = bgImage.Bitmap!;
+        var imgWidth = bgImage.OriginalWidth;
+        var imgHeight = bgImage.OriginalHeight;
+
+        float drawWidth, drawHeight;
+        switch (style.BackgroundSize.Mode)
+        {
+            case BackgroundSizeMode.Cover:
+                var coverScale = Math.Max(area.Width / imgWidth, area.Height / imgHeight);
+                drawWidth = imgWidth * coverScale;
+                drawHeight = imgHeight * coverScale;
+                break;
+            case BackgroundSizeMode.Contain:
+                var containScale = Math.Min(area.Width / imgWidth, area.Height / imgHeight);
+                drawWidth = imgWidth * containScale;
+                drawHeight = imgHeight * containScale;
+                break;
+            case BackgroundSizeMode.Explicit:
+                drawWidth = style.BackgroundSize.ResolveWidth(area.Width, imgWidth);
+                drawHeight = style.BackgroundSize.ResolveHeight(area.Height, imgHeight);
+                break;
+            default:
+                drawWidth = imgWidth;
+                drawHeight = imgHeight;
+                break;
+        }
+
+        float startX = area.X, startY = area.Y;
+        switch (style.BackgroundPosition)
+        {
+            case BackgroundPosition.CenterTop:
+            case BackgroundPosition.Center:
+            case BackgroundPosition.CenterBottom:
+                startX = area.X + (area.Width - drawWidth) / 2;
+                break;
+            case BackgroundPosition.RightTop:
+            case BackgroundPosition.RightCenter:
+            case BackgroundPosition.RightBottom:
+                startX = area.X + area.Width - drawWidth;
+                break;
+        }
+        switch (style.BackgroundPosition)
+        {
+            case BackgroundPosition.LeftCenter:
+            case BackgroundPosition.Center:
+            case BackgroundPosition.RightCenter:
+                startY = area.Y + (area.Height - drawHeight) / 2;
+                break;
+            case BackgroundPosition.LeftBottom:
+            case BackgroundPosition.CenterBottom:
+            case BackgroundPosition.RightBottom:
+                startY = area.Y + area.Height - drawHeight;
+                break;
+        }
+
+        var renderBitmap = (drawWidth != imgWidth || drawHeight != imgHeight)
+            ? bgImage.RenderAtSize((int)drawWidth, (int)drawHeight) ?? bitmap
+            : bitmap;
+
+        _painter!.SaveClip(area);
+
+        switch (style.BackgroundRepeat)
+        {
+            case BackgroundRepeat.Repeat:
+                TileImage(renderBitmap, area, startX, startY, drawWidth, drawHeight, true, true);
+                break;
+            case BackgroundRepeat.RepeatX:
+                TileImage(renderBitmap, area, startX, startY, drawWidth, drawHeight, true, false);
+                break;
+            case BackgroundRepeat.RepeatY:
+                TileImage(renderBitmap, area, startX, startY, drawWidth, drawHeight, false, true);
+                break;
+            case BackgroundRepeat.NoRepeat:
+                _painter.DrawImage(renderBitmap, new RectF(startX, startY, drawWidth, drawHeight));
+                break;
+        }
+
+        _painter.Restore();
+    }
+
+    private void TileImage(SKBitmap bitmap, RectF area, float startX, float startY, float tileW, float tileH, bool repeatX, bool repeatY)
+    {
+        float originX = startX;
+        if (repeatX)
+        {
+            while (originX > area.X) originX -= tileW;
+        }
+        float originY = startY;
+        if (repeatY)
+        {
+            while (originY > area.Y) originY -= tileH;
+        }
+
+        float endX = repeatX ? area.Right : originX + tileW;
+        float endY = repeatY ? area.Bottom : originY + tileH;
+
+        for (float y = originY; y < endY; y += tileH)
+        {
+            for (float x = originX; x < endX; x += tileW)
+            {
+                _painter!.DrawImage(bitmap, new RectF(x, y, tileW, tileH));
+            }
         }
     }
 

--- a/src/Miko/Styling/ComputedStyle.cs
+++ b/src/Miko/Styling/ComputedStyle.cs
@@ -68,6 +68,9 @@ public class ComputedStyle : Style
 
     public new Color BackgroundColor { get; set; } = Color.Transparent;
     public new BackgroundImage? BackgroundImage { get; set; }
+    public new BackgroundRepeat BackgroundRepeat { get; set; } = Common.BackgroundRepeat.Repeat;
+    public new BackgroundSize BackgroundSize { get; set; } = Common.BackgroundSize.Auto;
+    public new BackgroundPosition BackgroundPosition { get; set; } = Common.BackgroundPosition.LeftTop;
     public new Color Color { get; set; } = Color.Black;
     public new string FontFamily { get; set; } = "Arial";
     public new Length FontSize { get; set; } = Length.Px(16);
@@ -209,6 +212,9 @@ public class ComputedStyle : Style
 
             if (style.BackgroundColor.HasValue) computed.BackgroundColor = style.BackgroundColor.Value;
             if (style.BackgroundImage != null) computed.BackgroundImage = style.BackgroundImage;
+            if (style.BackgroundRepeat.HasValue) computed.BackgroundRepeat = style.BackgroundRepeat.Value;
+            if (style.BackgroundSize.HasValue) computed.BackgroundSize = style.BackgroundSize.Value;
+            if (style.BackgroundPosition.HasValue) computed.BackgroundPosition = style.BackgroundPosition.Value;
             if (style.Color.HasValue) computed.Color = style.Color.Value;
             if (style.FontFamily != null) computed.FontFamily = style.FontFamily;
             if (style.FontSize.HasValue) computed.FontSize = style.FontSize.Value;

--- a/src/Miko/Styling/CssObjectResolver.cs
+++ b/src/Miko/Styling/CssObjectResolver.cs
@@ -71,6 +71,8 @@ internal static class CssObjectResolver
                style.BorderTopLeftRadius != null || style.BorderTopRightRadius != null ||
                style.BorderBottomRightRadius != null || style.BorderBottomLeftRadius != null ||
                style.BackgroundColor != null || style.BackgroundImage != null ||
+               style.BackgroundRepeat != null || style.BackgroundSize != null ||
+               style.BackgroundPosition != null ||
                style.Color != null || style.FontFamily != null || style.FontSize != null ||
                style.FontWeight != null || style.TextAlign != null || style.LineHeight != null ||
                style.Position != null || style.Top != null || style.Right != null ||

--- a/src/Miko/Styling/CssObjectResolver.cs
+++ b/src/Miko/Styling/CssObjectResolver.cs
@@ -24,7 +24,22 @@ internal static class CssObjectResolver
         if (HasAnyProperty(style))
         {
             var selector = CssSelectorParser.Parse(fullSelector);
-            sheet.AddRule(selector, style);
+
+            // 检查是否包含伪元素选择器
+            var pseudoInfo = ExtractPseudoElement(selector, fullSelector);
+            if (pseudoInfo != null)
+            {
+                sheet.PseudoElementRules.Add(new PseudoElementRule
+                {
+                    Selector = pseudoInfo.Value.parentSelector,
+                    Type = pseudoInfo.Value.type,
+                    Style = style
+                });
+            }
+            else
+            {
+                sheet.AddRule(selector, style);
+            }
         }
 
         // 递归处理子选择器
@@ -32,6 +47,74 @@ internal static class CssObjectResolver
         {
             Flatten(childSelectorStr, child, fullSelector, sheet);
         }
+    }
+
+    private static (Selector parentSelector, PseudoElementType type)? ExtractPseudoElement(Selector selector, string fullSelector)
+    {
+        // Case 1: selector is directly a PseudoElementSelector (e.g., "::after" alone — unlikely but handle)
+        if (selector is BeforePseudoElement)
+            return (new UniversalSelector(), PseudoElementType.Before);
+        if (selector is AfterPseudoElement)
+            return (new UniversalSelector(), PseudoElementType.After);
+
+        // Case 2: CompoundSelector containing a PseudoElementSelector (e.g., ".btn::after")
+        if (selector is CompoundSelector compound)
+        {
+            var pseudoPart = compound.Selectors.OfType<PseudoElementSelector>().FirstOrDefault();
+            if (pseudoPart != null)
+            {
+                var type = pseudoPart is BeforePseudoElement ? PseudoElementType.Before : PseudoElementType.After;
+                var remaining = compound.Selectors.Where(s => s is not PseudoElementSelector).ToList();
+                var parentSelector = remaining.Count == 1 ? remaining[0] : new CompoundSelector(remaining);
+                return (parentSelector, type);
+            }
+        }
+
+        // Case 3: Combinator selector where the rightmost part contains a PseudoElementSelector
+        // e.g., ".parent .child::after" → DescendantSelector(ClassSelector("parent"), CompoundSelector([ClassSelector("child"), AfterPseudoElement]))
+        // We need to rebuild the selector without the pseudo-element part
+        if (selector is DescendantSelector or ChildSelector or AdjacentSiblingSelector or GeneralSiblingSelector)
+        {
+            var (left, right, combinatorType) = DecomposeCombinator(selector);
+            var rightPseudo = ExtractPseudoElement(right, "");
+            if (rightPseudo != null)
+            {
+                // The right side had a pseudo-element; rebuild parent selector without it
+                var parentSelector = RecomposeCombinator(left, rightPseudo.Value.parentSelector, combinatorType);
+                return (parentSelector, rightPseudo.Value.type);
+            }
+        }
+
+        return null;
+    }
+
+    private static (Selector left, Selector right, char combinator) DecomposeCombinator(Selector selector)
+    {
+        return selector switch
+        {
+            DescendantSelector d => (d.Ancestor, d.Descendant, ' '),
+            ChildSelector c => (c.Parent, c.Child, '>'),
+            AdjacentSiblingSelector a => (a.Previous, a.Target, '+'),
+            GeneralSiblingSelector g => (g.Previous, g.Target, '~'),
+            _ => throw new InvalidOperationException()
+        };
+    }
+
+    private static Selector RecomposeCombinator(Selector left, Selector right, char combinator)
+    {
+        // If the right side became a universal selector (pseudo-element was the only part),
+        // just use the left side as the parent selector
+        if (right is UniversalSelector)
+            return left;
+
+        return combinator switch
+        {
+            ' ' => new DescendantSelector(left, right),
+            '>' => new ChildSelector(left, right),
+            '+' => new AdjacentSiblingSelector(left, right),
+            '~' => new GeneralSiblingSelector(left, right),
+            _ => new DescendantSelector(left, right)
+        };
     }
 
     private static string BuildFullSelector(string current, string parent)

--- a/src/Miko/Styling/Style.cs
+++ b/src/Miko/Styling/Style.cs
@@ -218,6 +218,9 @@ public class Style
     // 视觉属性
     public Color? BackgroundColor { get; set; }
     public BackgroundImage? BackgroundImage { get; set; }
+    public BackgroundRepeat? BackgroundRepeat { get; set; }
+    public BackgroundSize? BackgroundSize { get; set; }
+    public BackgroundPosition? BackgroundPosition { get; set; }
     public Color? Color { get; set; }
     public string? FontFamily { get; set; }
     public Length? FontSize { get; set; }
@@ -338,6 +341,9 @@ public class Style
 
         BackgroundColor ??= other.BackgroundColor;
         BackgroundImage ??= other.BackgroundImage;
+        BackgroundRepeat ??= other.BackgroundRepeat;
+        BackgroundSize ??= other.BackgroundSize;
+        BackgroundPosition ??= other.BackgroundPosition;
         Color ??= other.Color;
         FontFamily ??= other.FontFamily;
         FontSize ??= other.FontSize;

--- a/tests/Miko.Tests/Common/BackgroundImageTests.cs
+++ b/tests/Miko.Tests/Common/BackgroundImageTests.cs
@@ -72,6 +72,54 @@ public class BackgroundImageTests
     }
 
     [Fact]
+    public void FromSvgStream_ShouldLoadSvg()
+    {
+        var svgContent = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='m2 5 6 6 6-6'/></svg>";
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(svgContent));
+
+        var bg = BackgroundImage.FromSvgStream(stream);
+
+        bg.Bitmap.ShouldNotBeNull();
+        bg.OriginalWidth.ShouldBe(16);
+        bg.OriginalHeight.ShouldBe(16);
+    }
+
+    [Fact]
+    public void FromSvgStream_RenderAtSize_ShouldScaleSvg()
+    {
+        var svgContent = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><rect width='16' height='16' fill='red'/></svg>";
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(svgContent));
+
+        var bg = BackgroundImage.FromSvgStream(stream);
+        var scaled = bg.RenderAtSize(32, 32);
+
+        scaled.ShouldNotBeNull();
+        scaled!.Width.ShouldBe(32);
+        scaled.Height.ShouldBe(32);
+    }
+
+    [Fact]
+    public void OriginalWidth_ShouldReturnBitmapDimensions()
+    {
+        var bitmap = CreateTestBitmap(24, 18);
+        var bg = BackgroundImage.FromBitmap(bitmap);
+
+        bg.OriginalWidth.ShouldBe(24);
+        bg.OriginalHeight.ShouldBe(18);
+    }
+
+    [Fact]
+    public void DefaultProperties_ShouldMatchBrowserDefaults()
+    {
+        var bitmap = CreateTestBitmap(4, 4);
+        var bg = BackgroundImage.FromBitmap(bitmap);
+
+        bg.Repeat.ShouldBe(BackgroundRepeat.Repeat);
+        bg.Size.ShouldBe(BackgroundSize.Auto);
+        bg.Position.ShouldBe(BackgroundPosition.LeftTop);
+    }
+
+    [Fact]
     public void Style_BackgroundImage_ShouldBeNullByDefault()
     {
         var style = new Style();
@@ -106,6 +154,66 @@ public class BackgroundImageTests
         style1.Merge(style2);
 
         style1.BackgroundImage.ShouldBe(bg1);
+    }
+
+    [Fact]
+    public void Style_BackgroundRepeat_ShouldMerge()
+    {
+        var style1 = new Style();
+        var style2 = new Style { BackgroundRepeat = BackgroundRepeat.NoRepeat };
+
+        style1.Merge(style2);
+
+        style1.BackgroundRepeat.ShouldBe(BackgroundRepeat.NoRepeat);
+    }
+
+    [Fact]
+    public void Style_BackgroundSize_ShouldMerge()
+    {
+        var style1 = new Style();
+        var style2 = new Style { BackgroundSize = BackgroundSize.Cover };
+
+        style1.Merge(style2);
+
+        style1.BackgroundSize.ShouldBe(BackgroundSize.Cover);
+    }
+
+    [Fact]
+    public void Style_BackgroundPosition_ShouldMerge()
+    {
+        var style1 = new Style();
+        var style2 = new Style { BackgroundPosition = BackgroundPosition.Center };
+
+        style1.Merge(style2);
+
+        style1.BackgroundPosition.ShouldBe(BackgroundPosition.Center);
+    }
+
+    [Fact]
+    public void ComputedStyle_BackgroundDefaults()
+    {
+        var computed = ComputedStyle.FromStyle(new Style());
+
+        computed.BackgroundRepeat.ShouldBe(BackgroundRepeat.Repeat);
+        computed.BackgroundSize.ShouldBe(BackgroundSize.Auto);
+        computed.BackgroundPosition.ShouldBe(BackgroundPosition.LeftTop);
+    }
+
+    [Fact]
+    public void ComputedStyle_BackgroundProperties_FromStyle()
+    {
+        var style = new Style
+        {
+            BackgroundRepeat = BackgroundRepeat.NoRepeat,
+            BackgroundSize = BackgroundSize.Contain,
+            BackgroundPosition = BackgroundPosition.Center
+        };
+
+        var computed = ComputedStyle.FromStyle(style);
+
+        computed.BackgroundRepeat.ShouldBe(BackgroundRepeat.NoRepeat);
+        computed.BackgroundSize.ShouldBe(BackgroundSize.Contain);
+        computed.BackgroundPosition.ShouldBe(BackgroundPosition.Center);
     }
 
     private static SKBitmap CreateTestBitmap(int width, int height)

--- a/tests/Miko.Tests/Layout/LayoutEngineTests.cs
+++ b/tests/Miko.Tests/Layout/LayoutEngineTests.cs
@@ -211,6 +211,140 @@ public class LayoutEngineTests
         layoutChild.BoxModel.Content.Y.ShouldBe(10);
     }
 
+    [Fact]
+    public void BlockLayout_MarginLeftAuto_ShouldPushElementToRight()
+    {
+        // Arrange
+        var root = new DivElement { Class = "root" };
+        var child = new DivElement { Class = "child" };
+        root.AddChild(child);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("root"),
+                        Style = new Style { Display = Display.Block }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("child"),
+                        Style = new Style
+                        {
+                            Display = Display.Block,
+                            Width = Length.Px(200),
+                            MarginLeft = Length.Auto
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        // Assert
+        var layoutChild = layoutRoot.Children[0];
+        // margin-left: auto 应该占据剩余空间 (800 - 200 = 600)
+        layoutChild.BoxModel.Margin.Left.ShouldBe(600);
+        layoutChild.BoxModel.Content.X.ShouldBe(600);
+        layoutChild.BoxModel.Content.Width.ShouldBe(200);
+    }
+
+    [Fact]
+    public void BlockLayout_MarginLeftAndRightAuto_ShouldCenterElement()
+    {
+        // Arrange
+        var root = new DivElement { Class = "root" };
+        var child = new DivElement { Class = "child" };
+        root.AddChild(child);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("root"),
+                        Style = new Style { Display = Display.Block }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("child"),
+                        Style = new Style
+                        {
+                            Display = Display.Block,
+                            Width = Length.Px(200),
+                            MarginLeft = Length.Auto,
+                            MarginRight = Length.Auto
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        // Assert
+        var layoutChild = layoutRoot.Children[0];
+        // margin-left: auto; margin-right: auto 应该居中 (800 - 200) / 2 = 300
+        layoutChild.BoxModel.Margin.Left.ShouldBe(300);
+        layoutChild.BoxModel.Margin.Right.ShouldBe(300);
+        layoutChild.BoxModel.Content.X.ShouldBe(300);
+        layoutChild.BoxModel.Content.Width.ShouldBe(200);
+    }
+
+    [Fact]
+    public void BlockLayout_MarginRightAuto_ShouldKeepElementOnLeft()
+    {
+        // Arrange
+        var root = new DivElement { Class = "root" };
+        var child = new DivElement { Class = "child" };
+        root.AddChild(child);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("root"),
+                        Style = new Style { Display = Display.Block }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("child"),
+                        Style = new Style
+                        {
+                            Display = Display.Block,
+                            Width = Length.Px(200),
+                            MarginRight = Length.Auto
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        // Assert
+        var layoutChild = layoutRoot.Children[0];
+        // margin-right: auto 应该占据剩余空间，元素保持在左侧
+        layoutChild.BoxModel.Margin.Right.ShouldBe(600);
+        layoutChild.BoxModel.Content.X.ShouldBe(0);
+        layoutChild.BoxModel.Content.Width.ShouldBe(200);
+    }
+
     #endregion
 
     #region Display.Flex Tests
@@ -676,6 +810,223 @@ public class LayoutEngineTests
         // btn-lg: padding-left=16, padding-right=16, total horizontal padding=32
         box1.BorderBox.Width.ShouldBeLessThan(box2.BorderBox.Width);
         box2.BorderBox.Width.ShouldBeLessThan(box3.BorderBox.Width);
+    }
+
+    [Fact]
+    public void FlexLayout_Row_AlignItemsCenter_ShouldCenterChildVertically()
+    {
+        // Arrange
+        var root = new DivElement { Class = "container" };
+        var child = new DivElement { Class = "item" };
+        root.AddChild(child);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("container"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            AlignItems = AlignItems.Center,
+                            Width = Length.Px(500),
+                            Height = Length.Px(100)
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("item"),
+                        Style = new Style
+                        {
+                            Width = Length.Px(20),
+                            Height = Length.Px(20)
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        // Assert
+        var layoutChild = layoutRoot.Children[0];
+        // 子元素应该垂直居中: (100 - 20) / 2 = 40
+        layoutChild.BoxModel.Content.Y.ShouldBe(40);
+        layoutChild.BoxModel.Content.Height.ShouldBe(20);
+    }
+
+    [Fact]
+    public void FlexLayout_Row_MarginLeftAuto_ShouldPushItemToRight()
+    {
+        // Arrange
+        var root = new DivElement { Class = "container" };
+        var child1 = new DivElement { Class = "item1" };
+        var child2 = new DivElement { Class = "item2" };
+        root.AddChild(child1);
+        root.AddChild(child2);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("container"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            FlexDirection = FlexDirection.Row,
+                            Width = Length.Px(800)
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("item1"),
+                        Style = new Style { Width = Length.Px(100) }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("item2"),
+                        Style = new Style
+                        {
+                            Width = Length.Px(100),
+                            MarginLeft = Length.Auto
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        // Assert
+        var layoutChild1 = layoutRoot.Children[0];
+        var layoutChild2 = layoutRoot.Children[1];
+
+        // item1 应该在左侧
+        layoutChild1.BoxModel.Content.X.ShouldBe(0);
+        layoutChild1.BoxModel.Content.Width.ShouldBe(100);
+
+        // item2 应该被推到右侧 (800 - 100 - 100 = 600 的 margin-left)
+        layoutChild2.BoxModel.Content.X.ShouldBe(700);
+        layoutChild2.BoxModel.Content.Width.ShouldBe(100);
+    }
+
+    [Fact]
+    public void FlexLayout_Row_MarginLeftAndRightAuto_ShouldCenterItem()
+    {
+        // Arrange
+        var root = new DivElement { Class = "container" };
+        var child = new DivElement { Class = "item" };
+        root.AddChild(child);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("container"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            FlexDirection = FlexDirection.Row,
+                            Width = Length.Px(800)
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("item"),
+                        Style = new Style
+                        {
+                            Width = Length.Px(200),
+                            MarginLeft = Length.Auto,
+                            MarginRight = Length.Auto
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        // Assert
+        var layoutChild = layoutRoot.Children[0];
+
+        // item 应该居中 (800 - 200) / 2 = 300
+        layoutChild.BoxModel.Content.X.ShouldBe(300);
+        layoutChild.BoxModel.Content.Width.ShouldBe(200);
+    }
+
+    [Fact]
+    public void FlexLayout_Column_MarginTopAuto_ShouldPushItemToBottom()
+    {
+        // Arrange
+        var root = new DivElement { Class = "container" };
+        var child1 = new DivElement { Class = "item1" };
+        var child2 = new DivElement { Class = "item2" };
+        root.AddChild(child1);
+        root.AddChild(child2);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("container"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            FlexDirection = FlexDirection.Column,
+                            Height = Length.Px(600)
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("item1"),
+                        Style = new Style { Height = Length.Px(100) }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("item2"),
+                        Style = new Style
+                        {
+                            Height = Length.Px(100),
+                            MarginTop = Length.Auto
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        // Assert
+        var layoutChild1 = layoutRoot.Children[0];
+        var layoutChild2 = layoutRoot.Children[1];
+
+        // item1 应该在顶部
+        layoutChild1.BoxModel.Content.Y.ShouldBe(0);
+        layoutChild1.BoxModel.Content.Height.ShouldBe(100);
+
+        // item2 应该被推到底部 (600 - 100 - 100 = 400 的 margin-top)
+        layoutChild2.BoxModel.Content.Y.ShouldBe(500);
+        layoutChild2.BoxModel.Content.Height.ShouldBe(100);
     }
 
     #endregion

--- a/tests/Miko.Tests/Rendering/BackgroundRenderingTests.cs
+++ b/tests/Miko.Tests/Rendering/BackgroundRenderingTests.cs
@@ -1,0 +1,236 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Rendering;
+using Miko.Styling;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Rendering;
+
+public class BackgroundRenderingTests : IDisposable
+{
+    private readonly SKBitmap _canvasBitmap;
+    private readonly SKCanvas _canvas;
+    private readonly RenderEngine _renderEngine;
+    private readonly LayoutEngine _layoutEngine;
+
+    public BackgroundRenderingTests()
+    {
+        _canvasBitmap = new SKBitmap(200, 200);
+        _canvas = new SKCanvas(_canvasBitmap);
+        _canvas.Clear(SKColors.White);
+        _renderEngine = new RenderEngine();
+        _renderEngine.SetCanvas(_canvas);
+        _layoutEngine = new LayoutEngine();
+    }
+
+    public void Dispose()
+    {
+        _canvas.Dispose();
+        _canvasBitmap.Dispose();
+    }
+
+    [Fact]
+    public void BackgroundImage_NoRepeat_ShouldDrawOnce()
+    {
+        var bg = BackgroundImage.FromBitmap(CreateTestBitmap(20, 20, SKColors.Red));
+        bg.Repeat = BackgroundRepeat.NoRepeat;
+
+        var root = CreateRootWithBackground(bg, 100, 100);
+        RenderElement(root);
+
+        GetPixelColor(10, 10).ShouldBe(SKColors.Red);
+        GetPixelColor(50, 50).ShouldBe(SKColors.White);
+    }
+
+    [Fact]
+    public void BackgroundImage_Repeat_ShouldTile()
+    {
+        var bg = BackgroundImage.FromBitmap(CreateTestBitmap(20, 20, SKColors.Blue));
+        bg.Repeat = BackgroundRepeat.Repeat;
+
+        var root = CreateRootWithBackground(bg, 100, 100);
+        RenderElement(root);
+
+        GetPixelColor(10, 10).ShouldBe(SKColors.Blue);
+        GetPixelColor(30, 30).ShouldBe(SKColors.Blue);
+        GetPixelColor(70, 70).ShouldBe(SKColors.Blue);
+        GetPixelColor(90, 90).ShouldBe(SKColors.Blue);
+    }
+
+    [Fact]
+    public void BackgroundImage_RepeatX_ShouldTileHorizontallyOnly()
+    {
+        var bg = BackgroundImage.FromBitmap(CreateTestBitmap(20, 20, SKColors.Green));
+        bg.Repeat = BackgroundRepeat.RepeatX;
+
+        var root = CreateRootWithBackground(bg, 100, 100);
+        RenderElement(root);
+
+        GetPixelColor(10, 10).ShouldBe(SKColors.Green);
+        GetPixelColor(50, 10).ShouldBe(SKColors.Green);
+        GetPixelColor(10, 50).ShouldBe(SKColors.White);
+    }
+
+    [Fact]
+    public void BackgroundImage_RepeatY_ShouldTileVerticallyOnly()
+    {
+        var bg = BackgroundImage.FromBitmap(CreateTestBitmap(20, 20, SKColors.Green));
+        bg.Repeat = BackgroundRepeat.RepeatY;
+
+        var root = CreateRootWithBackground(bg, 100, 100);
+        RenderElement(root);
+
+        GetPixelColor(10, 10).ShouldBe(SKColors.Green);
+        GetPixelColor(10, 50).ShouldBe(SKColors.Green);
+        GetPixelColor(50, 10).ShouldBe(SKColors.White);
+    }
+
+    [Fact]
+    public void BackgroundImage_NoRepeat_Center_ShouldPositionInCenter()
+    {
+        var bg = BackgroundImage.FromBitmap(CreateTestBitmap(20, 20, SKColors.Red));
+        bg.Repeat = BackgroundRepeat.NoRepeat;
+        bg.Position = BackgroundPosition.Center;
+
+        var root = CreateRootWithBackground(bg, 100, 100);
+        RenderElement(root);
+
+        GetPixelColor(50, 50).ShouldBe(SKColors.Red);
+        GetPixelColor(5, 5).ShouldBe(SKColors.White);
+    }
+
+    [Fact]
+    public void BackgroundImage_SizeContain_ShouldFitWithinArea()
+    {
+        var bg = BackgroundImage.FromBitmap(CreateTestBitmap(40, 20, SKColors.Red));
+        bg.Repeat = BackgroundRepeat.NoRepeat;
+        bg.Size = BackgroundSize.Contain;
+
+        var root = CreateRootWithBackground(bg, 100, 100);
+        RenderElement(root);
+
+        GetPixelColor(50, 30).ShouldBe(SKColors.Red);
+    }
+
+    [Fact]
+    public void BackgroundImage_SizeCover_ShouldCoverEntireArea()
+    {
+        var bg = BackgroundImage.FromBitmap(CreateTestBitmap(40, 20, SKColors.Red));
+        bg.Repeat = BackgroundRepeat.NoRepeat;
+        bg.Size = BackgroundSize.Cover;
+
+        var root = CreateRootWithBackground(bg, 100, 100);
+        RenderElement(root);
+
+        GetPixelColor(10, 10).ShouldBe(SKColors.Red);
+        GetPixelColor(90, 90).ShouldBe(SKColors.Red);
+    }
+
+    [Fact]
+    public void BackgroundImage_ExplicitSize_ShouldScaleToSpecifiedDimensions()
+    {
+        var bg = BackgroundImage.FromBitmap(CreateTestBitmap(40, 40, SKColors.Red));
+        bg.Repeat = BackgroundRepeat.NoRepeat;
+        bg.Size = BackgroundSize.Px(16, 16);
+
+        var root = CreateRootWithBackground(bg, 100, 100);
+        RenderElement(root);
+
+        GetPixelColor(8, 8).ShouldBe(SKColors.Red);
+        GetPixelColor(50, 50).ShouldBe(SKColors.White);
+    }
+
+    [Fact]
+    public void BackgroundImage_ExplicitSize_WithRepeat_ShouldTileAtSpecifiedSize()
+    {
+        var bg = BackgroundImage.FromBitmap(CreateTestBitmap(40, 40, SKColors.Blue));
+        bg.Repeat = BackgroundRepeat.Repeat;
+        bg.Size = BackgroundSize.Px(20, 20);
+
+        var root = CreateRootWithBackground(bg, 100, 100);
+        RenderElement(root);
+
+        GetPixelColor(10, 10).ShouldBe(SKColors.Blue);
+        GetPixelColor(30, 30).ShouldBe(SKColors.Blue);
+        GetPixelColor(70, 70).ShouldBe(SKColors.Blue);
+    }
+
+    [Fact]
+    public void BackgroundImage_ExplicitSize_WithLength_ShouldResolvePercentage()
+    {
+        var bg = BackgroundImage.FromBitmap(CreateTestBitmap(40, 40, SKColors.Red));
+        bg.Repeat = BackgroundRepeat.NoRepeat;
+        bg.Size = BackgroundSize.From(Length.Percent(50), Length.Percent(50));
+
+        var root = CreateRootWithBackground(bg, 100, 100);
+        RenderElement(root);
+
+        // 50% of 100px = 50px, so image fills top-left 50x50 area
+        GetPixelColor(25, 25).ShouldBe(SKColors.Red);
+        GetPixelColor(75, 75).ShouldBe(SKColors.White);
+    }
+
+    [Fact]
+    public void BackgroundImage_ExplicitSize_WithMixedUnits()
+    {
+        var bg = BackgroundImage.FromBitmap(CreateTestBitmap(40, 40, SKColors.Green));
+        bg.Repeat = BackgroundRepeat.NoRepeat;
+        bg.Size = BackgroundSize.From(Length.Px(30), Length.Percent(100));
+
+        var root = CreateRootWithBackground(bg, 100, 100);
+        RenderElement(root);
+
+        // 30px wide, 100% of 100px = 100px tall
+        GetPixelColor(15, 50).ShouldBe(SKColors.Green);
+        GetPixelColor(50, 50).ShouldBe(SKColors.White);
+    }
+
+    [Fact]
+    public void BackgroundImage_SvgStream_ShouldRender()
+    {
+        var svgContent = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><rect width='16' height='16' fill='blue'/></svg>";
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(svgContent));
+        var bg = BackgroundImage.FromSvgStream(stream);
+        bg.Repeat = BackgroundRepeat.NoRepeat;
+
+        var root = CreateRootWithBackground(bg, 100, 100);
+        RenderElement(root);
+
+        GetPixelColor(8, 8).ShouldBe(SKColors.Blue);
+    }
+
+    private DivElement CreateRootWithBackground(BackgroundImage bg, int width, int height)
+    {
+        var root = new DivElement();
+        root.Style = new Style
+        {
+            Width = Length.Px(width),
+            Height = Length.Px(height),
+            BackgroundImage = bg,
+            BackgroundRepeat = bg.Repeat,
+            BackgroundSize = bg.Size,
+            BackgroundPosition = bg.Position,
+        };
+        return root;
+    }
+
+    private void RenderElement(Element root)
+    {
+        var engine = new MikoEngine();
+        engine.Initialize(root, [], _canvas, 200, 200);
+        engine.Render(_canvas);
+    }
+
+    private SKColor GetPixelColor(int x, int y) => _canvasBitmap.GetPixel(x, y);
+
+    private static SKBitmap CreateTestBitmap(int width, int height, SKColor color)
+    {
+        var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(color);
+        return bitmap;
+    }
+}

--- a/tests/Miko.Tests/Styling/PseudoElementTests.cs
+++ b/tests/Miko.Tests/Styling/PseudoElementTests.cs
@@ -176,4 +176,151 @@ public class PseudoElementTests
 
         style1.Content.ShouldBe("first");
     }
+
+    [Fact]
+    public void FlexContainer_AlignItemsCenter_ShouldApplyToPseudoElement()
+    {
+        var root = new DivElement { Class = "btn" };
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Class("btn")
+            .Set(x => x.Display, Display.Flex)
+            .Set(x => x.AlignItems, AlignItems.Center)
+            .Set(x => x.Width, Length.Px(500))
+            .Set(x => x.Height, Length.Px(100)));
+        sheet.AddRule(Style.Class("btn")
+            .After()
+            .Set(x => x.Content, "X")
+            .Set(x => x.Display, Display.Block)
+            .Set(x => x.Width, Length.Px(20))
+            .Set(x => x.Height, Length.Px(20)));
+
+        var engine = new LayoutEngine();
+        var layoutRoot = engine.Layout(root, [sheet], 800, 600);
+
+        layoutRoot.Children.Count.ShouldBe(1);
+        var pseudoBox = layoutRoot.Children[0];
+        pseudoBox.Element.ShouldBeOfType<PseudoElement>();
+
+        // align-items: center 应该让伪元素垂直居中: (100 - 20) / 2 = 40
+        pseudoBox.BoxModel.Content.Y.ShouldBe(40);
+        pseudoBox.BoxModel.Content.Width.ShouldBe(20);
+        pseudoBox.BoxModel.Content.Height.ShouldBe(20);
+    }
+
+    [Fact]
+    public void FlexContainer_MarginLeftAuto_ShouldApplyToPseudoElement()
+    {
+        var root = new DivElement { Class = "btn" };
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(Style.Class("btn")
+            .Set(x => x.Display, Display.Flex)
+            .Set(x => x.Width, Length.Px(500))
+            .Set(x => x.Height, Length.Px(100)));
+        sheet.AddRule(Style.Class("btn")
+            .After()
+            .Set(x => x.Content, "X")
+            .Set(x => x.Display, Display.Block)
+            .Set(x => x.Width, Length.Px(20))
+            .Set(x => x.Height, Length.Px(20))
+            .Set(x => x.MarginLeft, Length.Auto));
+
+        var engine = new LayoutEngine();
+        var layoutRoot = engine.Layout(root, [sheet], 800, 600);
+
+        layoutRoot.Children.Count.ShouldBe(1);
+        var pseudoBox = layoutRoot.Children[0];
+        pseudoBox.Element.ShouldBeOfType<PseudoElement>();
+
+        // margin-left: auto 应该把伪元素推到右侧: 500 - 20 = 480
+        pseudoBox.BoxModel.Content.X.ShouldBe(480);
+        pseudoBox.BoxModel.Content.Width.ShouldBe(20);
+    }
+
+    [Fact]
+    public void CssObject_ShouldRegisterPseudoElementRules()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".btn::after"] = new CssObject
+            {
+                Content = "",
+                Display = Display.Block,
+                Width = Length.Px(20),
+                Height = Length.Px(20)
+            }
+        });
+
+        sheet.PseudoElementRules.Count.ShouldBe(1);
+        sheet.PseudoElementRules[0].Type.ShouldBe(PseudoElementType.After);
+        sheet.PseudoElementRules[0].Style.Width.ShouldBe(Length.Px(20));
+    }
+
+    [Fact]
+    public void CssObject_NestedPseudoElement_ShouldRegisterPseudoElementRules()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".btn"] = new CssObject
+            {
+                Display = Display.Flex,
+                AlignItems = AlignItems.Center,
+                Width = Length.Px(500),
+                Height = Length.Px(100),
+                ["&::after"] = new CssObject
+                {
+                    Content = "X",
+                    Display = Display.Block,
+                    Width = Length.Px(20),
+                    Height = Length.Px(20),
+                    MarginLeft = Length.Auto
+                }
+            }
+        });
+
+        sheet.PseudoElementRules.Count.ShouldBe(1);
+        sheet.PseudoElementRules[0].Type.ShouldBe(PseudoElementType.After);
+        sheet.PseudoElementRules[0].Style.MarginLeft.ShouldBe(Length.Auto);
+    }
+
+    [Fact]
+    public void CssObject_PseudoElement_MarginLeftAutoAndAlignCenter_ShouldWork()
+    {
+        var root = new DivElement { Class = "btn" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".btn"] = new CssObject
+            {
+                Display = Display.Flex,
+                AlignItems = AlignItems.Center,
+                Width = Length.Px(500),
+                Height = Length.Px(100),
+                ["&::after"] = new CssObject
+                {
+                    Content = "X",
+                    Display = Display.Block,
+                    Width = Length.Px(20),
+                    Height = Length.Px(20),
+                    MarginLeft = Length.Auto
+                }
+            }
+        });
+
+        var engine = new LayoutEngine();
+        var layoutRoot = engine.Layout(root, [sheet], 800, 600);
+
+        layoutRoot.Children.Count.ShouldBe(1);
+        var pseudoBox = layoutRoot.Children[0];
+        pseudoBox.Element.ShouldBeOfType<PseudoElement>();
+
+        // margin-left: auto 应该把伪元素推到右侧: 500 - 20 = 480
+        pseudoBox.BoxModel.Content.X.ShouldBe(480);
+        // align-items: center 应该让伪元素垂直居中: (100 - 20) / 2 = 40
+        pseudoBox.BoxModel.Content.Y.ShouldBe(40);
+    }
 }


### PR DESCRIPTION
## Summary
- Fix `margin-left: auto` / `margin-right: auto` not working for block and flex items
- Fix `align-items: center` not centering children when flex container has explicit height
- Fix pseudo-element styles (::after/::before) defined via CssObject API being silently ignored

## Changes
- **BlockLayout**: Resolve auto margins by distributing remaining space when element has explicit width
- **FlexLayout (row/column)**: Auto margins on main axis consume free space before flex-grow; use container cross-axis size for align-items alignment
- **CssObjectResolver**: Detect pseudo-element selectors and route to `PseudoElementRules` instead of regular `Rules`

## Test plan
- [x] Unit tests for block margin-auto (left, right, both)
- [x] Unit tests for flex row/column margin-auto
- [x] Unit test for align-items: center with explicit container height
- [x] Unit tests for CssObject pseudo-element rule registration
- [x] Integration test for pseudo-element with margin-auto + align-items: center
- [x] Full test suite passes (636 tests)