### PR TITLE
Fix border rendering, transition triggering, and StateHasChanged

### DIFF
--- a/src/Miko/Animation/AnimationManager.cs
+++ b/src/Miko/Animation/AnimationManager.cs
@@ -47,6 +47,7 @@ public class AnimationManager
     private readonly Dictionary<string, KeyframeAnimation> _registeredAnimations = new();
     private readonly Dictionary<Element, Dictionary<string, float>> _previousValues = new();
     private readonly Dictionary<Element, Dictionary<string, Color>> _previousColors = new();
+    private readonly HashSet<(Element, string)> _recentlyCompleted = new();
     private ILogger _logger = NullLogger.Instance;
 
     public AnimationManager() { }
@@ -56,6 +57,8 @@ public class AnimationManager
     public void SetLogger(ILogger logger) => _logger = logger;
 
     public bool HasActiveAnimations => _transitions.Count > 0 || _animations.Count > 0;
+
+    public int ActiveTransitionCount => _transitions.Count;
 
     public void Clear()
     {
@@ -113,12 +116,19 @@ public class AnimationManager
         }
     }
 
+    public bool HasActiveTransition(Element element, string property)
+    {
+        if (_recentlyCompleted.Contains((element, property))) return true;
+        return _transitions.Any(t => t.Element == element && t.Property.PropertyName == property);
+    }
+
     public void TrackPropertyChange(Element element, string property, float oldValue, float newValue, Transition transition)
     {
         if (MathF.Abs(oldValue - newValue) < 1e-6f) return;
 
         _transitions.RemoveAll(t => t.Element == element && t.Property.PropertyName == property);
 
+        var applier = GetFloatApplier(property);
         var activeTransition = new ActiveTransition
         {
             Element = element,
@@ -133,10 +143,14 @@ public class AnimationManager
             TimingFunction = transition.TimingFunction,
             CubicBezier = transition.CubicBezier,
             ElapsedTime = 0,
-            ApplyFloat = GetFloatApplier(property)
+            ApplyFloat = applier
         };
 
         _transitions.Add(activeTransition);
+
+        // 立即应用起始值，避免首帧渲染目标值导致闪烁
+        applier?.Invoke(element, oldValue);
+
         _logger.LogDebug("Transition started: \"{Property}\" {OldValue} -> {NewValue} on <{Tag} id=\"{Id}\">, duration={Duration}s, delay={Delay}s",
             property, oldValue, newValue, element.TagName, element.Id ?? "", transition.Duration, transition.Delay);
     }
@@ -148,6 +162,7 @@ public class AnimationManager
 
         _transitions.RemoveAll(t => t.Element == element && t.Property.PropertyName == property);
 
+        var applier = GetColorApplier(property);
         var activeTransition = new ActiveTransition
         {
             Element = element,
@@ -162,18 +177,20 @@ public class AnimationManager
             TimingFunction = transition.TimingFunction,
             CubicBezier = transition.CubicBezier,
             ElapsedTime = 0,
-            ApplyColor = GetColorApplier(property)
+            ApplyColor = applier
         };
 
         _transitions.Add(activeTransition);
+
+        applier?.Invoke(element, oldColor);
+
         _logger.LogDebug("Color transition started: \"{Property}\" {OldColor} -> {NewColor} on <{Tag} id=\"{Id}\">, duration={Duration}s",
             property, oldColor, newColor, element.TagName, element.Id ?? "", transition.Duration);
     }
 
     public void Update(float deltaTime)
     {
-        // _logger.LogTrace("AnimationManager.Update: deltaTime={DeltaTime}s, transitions={TransitionCount}, animations={AnimationCount}",
-        //     deltaTime, _transitions.Count, _animations.Count);
+        _recentlyCompleted.Clear();
         UpdateTransitions(deltaTime);
         UpdateAnimations(deltaTime);
     }
@@ -206,6 +223,7 @@ public class AnimationManager
 
             if (transition.IsComplete)
             {
+                _recentlyCompleted.Add((transition.Element, transition.Property.PropertyName));
                 _transitions.RemoveAt(i);
                 _logger.LogDebug("Transition completed: \"{Property}\" on <{Tag} id=\"{Id}\">",
                     transition.Property.PropertyName, transition.Element.TagName, transition.Element.Id ?? "");
@@ -416,6 +434,10 @@ public class AnimationManager
             nameof(Style.Opacity) => (e, v) => { e.Style ??= new Style(); e.Style.Opacity = v; },
             nameof(Style.Width) => (e, v) => { e.Style ??= new Style(); e.Style.Width = Length.Px(v); },
             nameof(Style.Height) => (e, v) => { e.Style ??= new Style(); e.Style.Height = Length.Px(v); },
+            nameof(Style.MaxWidth) => (e, v) => { e.Style ??= new Style(); e.Style.MaxWidth = Length.Px(v); },
+            nameof(Style.MaxHeight) => (e, v) => { e.Style ??= new Style(); e.Style.MaxHeight = Length.Px(v); },
+            nameof(Style.MinWidth) => (e, v) => { e.Style ??= new Style(); e.Style.MinWidth = Length.Px(v); },
+            nameof(Style.MinHeight) => (e, v) => { e.Style ??= new Style(); e.Style.MinHeight = Length.Px(v); },
             nameof(Style.MarginTop) => (e, v) => { e.Style ??= new Style(); e.Style.MarginTop = Length.Px(v); },
             nameof(Style.MarginRight) => (e, v) => { e.Style ??= new Style(); e.Style.MarginRight = Length.Px(v); },
             nameof(Style.MarginBottom) => (e, v) => { e.Style ??= new Style(); e.Style.MarginBottom = Length.Px(v); },
@@ -432,6 +454,10 @@ public class AnimationManager
             nameof(Style.BorderWidth) => (e, v) => { e.Style ??= new Style(); e.Style.BorderWidth = Length.Px(v); },
             nameof(Style.FlexGrow) => (e, v) => { e.Style ??= new Style(); e.Style.FlexGrow = v; },
             nameof(Style.FlexShrink) => (e, v) => { e.Style ??= new Style(); e.Style.FlexShrink = v; },
+            nameof(Style.BorderTopLeftRadius) => (e, v) => { e.Style ??= new Style(); e.Style.BorderTopLeftRadius = Length.Px(v); },
+            nameof(Style.BorderTopRightRadius) => (e, v) => { e.Style ??= new Style(); e.Style.BorderTopRightRadius = Length.Px(v); },
+            nameof(Style.BorderBottomRightRadius) => (e, v) => { e.Style ??= new Style(); e.Style.BorderBottomRightRadius = Length.Px(v); },
+            nameof(Style.BorderBottomLeftRadius) => (e, v) => { e.Style ??= new Style(); e.Style.BorderBottomLeftRadius = Length.Px(v); },
             _ => null
         };
     }

--- a/src/Miko/Components/ComponentBase.cs
+++ b/src/Miko/Components/ComponentBase.cs
@@ -1,4 +1,5 @@
 using Miko.Core;
+using Miko.Layout;
 using Miko.Routing;
 
 namespace Miko.Components;
@@ -23,15 +24,67 @@ public abstract class ComponentBase : IComponent
 
     protected void StateHasChanged()
     {
-        if (_rootElement?.Parent == null) return;
+        if (_rootElement == null) return;
+
+        if (_rootElement.Parent == null)
+        {
+            var newElement = BuildNew();
+            ReplaceElementContent(_rootElement, newElement);
+            return;
+        }
 
         var parent = _rootElement.Parent;
         var index = parent.Children.IndexOf(_rootElement);
         if (index < 0) return;
 
-        var newElement = Build();
-        parent.Children[index] = newElement;
-        newElement.SetParent(parent);
-        _rootElement = newElement;
+        var oldElement = _rootElement;
+        var rebuilt = Build();
+        TransferLayoutBox(oldElement, rebuilt);
+        parent.Children[index] = rebuilt;
+        rebuilt.SetParent(parent);
+        _rootElement = rebuilt;
+    }
+
+    private Element BuildNew()
+    {
+        var builder = new RenderTreeBuilder();
+        BuildRenderTree(builder);
+        return builder.Build();
+    }
+
+    private static void ReplaceElementContent(Element target, Element source)
+    {
+        var oldChildren = new List<Element>(target.Children);
+        target.Children.Clear();
+        for (int i = 0; i < source.Children.Count; i++)
+        {
+            var newChild = source.Children[i];
+            target.Children.Add(newChild);
+            newChild.SetParent(target);
+
+            if (i < oldChildren.Count)
+                TransferLayoutBox(oldChildren[i], newChild);
+        }
+        target.Style = source.Style;
+        target.TextContent = source.TextContent;
+        target.Id = source.Id;
+        target.Class = source.Class;
+        target.IsDirty = true;
+    }
+
+    private static void TransferLayoutBox(Element oldElement, Element newElement)
+    {
+        if (oldElement.LayoutBox != null)
+        {
+            newElement.LayoutBox = new LayoutBox
+            {
+                Element = newElement,
+                ComputedStyle = oldElement.LayoutBox.ComputedStyle
+            };
+        }
+
+        int count = Math.Min(oldElement.Children.Count, newElement.Children.Count);
+        for (int i = 0; i < count; i++)
+            TransferLayoutBox(oldElement.Children[i], newElement.Children[i]);
     }
 }

--- a/src/Miko/Core/MikoEngine.cs
+++ b/src/Miko/Core/MikoEngine.cs
@@ -89,8 +89,18 @@ public class MikoEngine
         if (_root == null) throw new InvalidOperationException("Engine not initialized. Call Initialize first.");
 
         _renderEngine.SetCanvas(canvas);
+
+        var oldStyles = CaptureTransitionableStyles(_root);
         var oldLayout = _currentLayout;
         _currentLayout = _layoutEngine.Layout(_root, _styleSheets, _viewportWidth, _viewportHeight);
+
+        bool transitionsTriggered = DetectAndTriggerTransitions(_root, oldStyles);
+        if (transitionsTriggered)
+        {
+            // 重新布局，使用 transition 起始值（已写入 inline style）
+            _currentLayout = _layoutEngine.Layout(_root, _styleSheets, _viewportWidth, _viewportHeight);
+        }
+
         RestoreScrollState(oldLayout, _currentLayout);
         _renderEngine.Render(_currentLayout);
         _dirtyManager.Clear();
@@ -236,6 +246,149 @@ public class MikoEngine
         }
 
         return box.Element;
+    }
+
+    private record struct StyleSnapshot(
+        float MaxWidth, float MaxHeight,
+        float Width, float Height,
+        float PaddingTop, float PaddingRight, float PaddingBottom, float PaddingLeft,
+        float MarginTop, float MarginRight, float MarginBottom, float MarginLeft,
+        float Opacity, float FontSize, float BorderWidth,
+        float BorderTopLeftRadius, float BorderTopRightRadius, float BorderBottomRightRadius, float BorderBottomLeftRadius,
+        Color BackgroundColor, Color Color, Color BorderColor);
+
+    private Dictionary<Element, (StyleSnapshot snapshot, List<Transition> transitions)> CaptureTransitionableStyles(Element root)
+    {
+        var result = new Dictionary<Element, (StyleSnapshot, List<Transition>)>();
+        CaptureRecursive(root, result);
+        return result;
+    }
+
+    private static void CaptureRecursive(Element element, Dictionary<Element, (StyleSnapshot, List<Transition>)> result)
+    {
+        var layoutBox = element.LayoutBox;
+        if (layoutBox != null && layoutBox.ComputedStyle.Transitions.Count > 0)
+        {
+            var cs = layoutBox.ComputedStyle;
+            var snapshot = new StyleSnapshot(
+                cs.MaxWidth.IsAuto ? float.MaxValue : cs.MaxWidth.Value,
+                cs.MaxHeight.IsAuto ? float.MaxValue : cs.MaxHeight.Value,
+                cs.Width.IsAuto ? float.NaN : cs.Width.Value,
+                cs.Height.IsAuto ? float.NaN : cs.Height.Value,
+                cs.PaddingTop.Value, cs.PaddingRight.Value, cs.PaddingBottom.Value, cs.PaddingLeft.Value,
+                cs.MarginTop.Value, cs.MarginRight.Value, cs.MarginBottom.Value, cs.MarginLeft.Value,
+                cs.Opacity, cs.FontSize.Value, cs.BorderTopWidth.Value,
+                cs.BorderTopLeftRadius.Value, cs.BorderTopRightRadius.Value,
+                cs.BorderBottomRightRadius.Value, cs.BorderBottomLeftRadius.Value,
+                cs.BackgroundColor, cs.Color, cs.BorderTopColor);
+            result[element] = (snapshot, cs.Transitions);
+        }
+
+        foreach (var child in element.Children)
+            CaptureRecursive(child, result);
+    }
+
+    private bool DetectAndTriggerTransitions(Element root, Dictionary<Element, (StyleSnapshot snapshot, List<Transition> transitions)> oldStyles)
+    {
+        if (oldStyles.Count == 0) return false;
+        int before = _animationManager.ActiveTransitionCount;
+        DetectTransitionsRecursive(root, oldStyles);
+        return _animationManager.ActiveTransitionCount > before;
+    }
+
+    private void DetectTransitionsRecursive(Element element, Dictionary<Element, (StyleSnapshot snapshot, List<Transition> transitions)> oldStyles)
+    {
+        if (oldStyles.TryGetValue(element, out var old) && element.LayoutBox != null)
+        {
+            var cs = element.LayoutBox.ComputedStyle;
+            var newSnapshot = new StyleSnapshot(
+                cs.MaxWidth.IsAuto ? float.MaxValue : cs.MaxWidth.Value,
+                cs.MaxHeight.IsAuto ? float.MaxValue : cs.MaxHeight.Value,
+                cs.Width.IsAuto ? float.NaN : cs.Width.Value,
+                cs.Height.IsAuto ? float.NaN : cs.Height.Value,
+                cs.PaddingTop.Value, cs.PaddingRight.Value, cs.PaddingBottom.Value, cs.PaddingLeft.Value,
+                cs.MarginTop.Value, cs.MarginRight.Value, cs.MarginBottom.Value, cs.MarginLeft.Value,
+                cs.Opacity, cs.FontSize.Value, cs.BorderTopWidth.Value,
+                cs.BorderTopLeftRadius.Value, cs.BorderTopRightRadius.Value,
+                cs.BorderBottomRightRadius.Value, cs.BorderBottomLeftRadius.Value,
+                cs.BackgroundColor, cs.Color, cs.BorderTopColor);
+
+            foreach (var transition in old.transitions)
+            {
+                TriggerPropertyTransitions(element, transition, old.snapshot, newSnapshot);
+            }
+        }
+
+        foreach (var child in element.Children)
+            DetectTransitionsRecursive(child, oldStyles);
+    }
+
+    private void TriggerPropertyTransitions(Element element, Transition transition, StyleSnapshot oldSnap, StyleSnapshot newSnap)
+    {
+        var prop = transition.Property;
+
+        if (prop == "all" || prop == nameof(Style.MaxHeight))
+            TryTrackFloat(element, nameof(Style.MaxHeight), oldSnap.MaxHeight, newSnap.MaxHeight, transition);
+        if (prop == "all" || prop == nameof(Style.MaxWidth))
+            TryTrackFloat(element, nameof(Style.MaxWidth), oldSnap.MaxWidth, newSnap.MaxWidth, transition);
+        if (prop == "all" || prop == nameof(Style.Width))
+            TryTrackFloat(element, nameof(Style.Width), oldSnap.Width, newSnap.Width, transition);
+        if (prop == "all" || prop == nameof(Style.Height))
+            TryTrackFloat(element, nameof(Style.Height), oldSnap.Height, newSnap.Height, transition);
+        if (prop == "all" || prop == nameof(Style.Opacity))
+            TryTrackFloat(element, nameof(Style.Opacity), oldSnap.Opacity, newSnap.Opacity, transition);
+        if (prop == "all" || prop == nameof(Style.FontSize))
+            TryTrackFloat(element, nameof(Style.FontSize), oldSnap.FontSize, newSnap.FontSize, transition);
+        if (prop == "all" || prop == nameof(Style.BorderWidth))
+            TryTrackFloat(element, nameof(Style.BorderWidth), oldSnap.BorderWidth, newSnap.BorderWidth, transition);
+
+        if (prop == "all" || prop == nameof(Style.PaddingTop) || prop == nameof(Style.Padding))
+            TryTrackFloat(element, nameof(Style.PaddingTop), oldSnap.PaddingTop, newSnap.PaddingTop, transition);
+        if (prop == "all" || prop == nameof(Style.PaddingRight) || prop == nameof(Style.Padding))
+            TryTrackFloat(element, nameof(Style.PaddingRight), oldSnap.PaddingRight, newSnap.PaddingRight, transition);
+        if (prop == "all" || prop == nameof(Style.PaddingBottom) || prop == nameof(Style.Padding))
+            TryTrackFloat(element, nameof(Style.PaddingBottom), oldSnap.PaddingBottom, newSnap.PaddingBottom, transition);
+        if (prop == "all" || prop == nameof(Style.PaddingLeft) || prop == nameof(Style.Padding))
+            TryTrackFloat(element, nameof(Style.PaddingLeft), oldSnap.PaddingLeft, newSnap.PaddingLeft, transition);
+
+        if (prop == "all" || prop == nameof(Style.MarginTop) || prop == nameof(Style.Margin))
+            TryTrackFloat(element, nameof(Style.MarginTop), oldSnap.MarginTop, newSnap.MarginTop, transition);
+        if (prop == "all" || prop == nameof(Style.MarginRight) || prop == nameof(Style.Margin))
+            TryTrackFloat(element, nameof(Style.MarginRight), oldSnap.MarginRight, newSnap.MarginRight, transition);
+        if (prop == "all" || prop == nameof(Style.MarginBottom) || prop == nameof(Style.Margin))
+            TryTrackFloat(element, nameof(Style.MarginBottom), oldSnap.MarginBottom, newSnap.MarginBottom, transition);
+        if (prop == "all" || prop == nameof(Style.MarginLeft) || prop == nameof(Style.Margin))
+            TryTrackFloat(element, nameof(Style.MarginLeft), oldSnap.MarginLeft, newSnap.MarginLeft, transition);
+
+        if (prop == "all" || prop == nameof(Style.BorderTopLeftRadius))
+            TryTrackFloat(element, nameof(Style.BorderTopLeftRadius), oldSnap.BorderTopLeftRadius, newSnap.BorderTopLeftRadius, transition);
+        if (prop == "all" || prop == nameof(Style.BorderTopRightRadius))
+            TryTrackFloat(element, nameof(Style.BorderTopRightRadius), oldSnap.BorderTopRightRadius, newSnap.BorderTopRightRadius, transition);
+        if (prop == "all" || prop == nameof(Style.BorderBottomRightRadius))
+            TryTrackFloat(element, nameof(Style.BorderBottomRightRadius), oldSnap.BorderBottomRightRadius, newSnap.BorderBottomRightRadius, transition);
+        if (prop == "all" || prop == nameof(Style.BorderBottomLeftRadius))
+            TryTrackFloat(element, nameof(Style.BorderBottomLeftRadius), oldSnap.BorderBottomLeftRadius, newSnap.BorderBottomLeftRadius, transition);
+
+        if (prop == "all" || prop == nameof(Style.BackgroundColor))
+            TryTrackColor(element, nameof(Style.BackgroundColor), oldSnap.BackgroundColor, newSnap.BackgroundColor, transition);
+        if (prop == "all" || prop == nameof(Style.Color))
+            TryTrackColor(element, nameof(Style.Color), oldSnap.Color, newSnap.Color, transition);
+        if (prop == "all" || prop == nameof(Style.BorderColor))
+            TryTrackColor(element, nameof(Style.BorderColor), oldSnap.BorderColor, newSnap.BorderColor, transition);
+    }
+
+    private void TryTrackColor(Element element, string property, Color oldColor, Color newColor, Transition transition)
+    {
+        if (_animationManager.HasActiveTransition(element, property)) return;
+        _animationManager.TrackColorChange(element, property, oldColor, newColor, transition);
+    }
+
+    private void TryTrackFloat(Element element, string property, float oldValue, float newValue, Transition transition)
+    {
+        if (float.IsNaN(oldValue) || float.IsNaN(newValue)) return;
+        if (oldValue == float.MaxValue && newValue == float.MaxValue) return;
+        if (_animationManager.HasActiveTransition(element, property)) return;
+        _animationManager.TrackPropertyChange(element, property, oldValue, newValue, transition);
     }
 
     private static void EnsureParentReferences(Element element)

--- a/src/Miko/Rendering/Painter.cs
+++ b/src/Miko/Rendering/Painter.cs
@@ -72,14 +72,23 @@ public class Painter
                 break;
         }
 
+        // 将绘制矩形向内收缩半个边框宽度，使描边完全在 BorderBox 内部
+        float halfWidth = width / 2;
+        var insetRect = new SKRect(
+            rect.Left + halfWidth,
+            rect.Top + halfWidth,
+            rect.Right - halfWidth,
+            rect.Bottom - halfWidth
+        );
+
         if (topLeftRadius > 0 || topRightRadius > 0 || bottomRightRadius > 0 || bottomLeftRadius > 0)
         {
-            using var path = CreateRoundRectPath(rect.ToSKRect(), topLeftRadius, topRightRadius, bottomRightRadius, bottomLeftRadius);
+            using var path = CreateRoundRectPath(insetRect, topLeftRadius, topRightRadius, bottomRightRadius, bottomLeftRadius);
             _canvas.DrawPath(path, paint);
         }
         else
         {
-            _canvas.DrawRect(rect.ToSKRect(), paint);
+            _canvas.DrawRect(insetRect, paint);
         }
     }
 
@@ -100,11 +109,11 @@ public class Painter
             return;
         }
 
-        // 分别绘制每条边
-        DrawTopBorder(rect, top, topLeftRadius, topRightRadius);
-        DrawRightBorder(rect, right, topRightRadius, bottomRightRadius);
-        DrawBottomBorder(rect, bottom, bottomRightRadius, bottomLeftRadius);
-        DrawLeftBorder(rect, left, bottomLeftRadius, topLeftRadius);
+        // 分别绘制每条边（含圆角弧线）
+        DrawTopBorder(rect, top, left, right, topLeftRadius, topRightRadius);
+        DrawRightBorder(rect, right, top, bottom, topRightRadius, bottomRightRadius);
+        DrawBottomBorder(rect, bottom, right, left, bottomRightRadius, bottomLeftRadius);
+        DrawLeftBorder(rect, left, bottom, top, bottomLeftRadius, topLeftRadius);
     }
 
     /// <summary>
@@ -126,30 +135,40 @@ public class Painter
     /// <summary>
     /// 绘制上边框
     /// </summary>
-    private void DrawTopBorder(RectF rect, BorderSide border, float leftRadius, float rightRadius)
+    private void DrawTopBorder(RectF rect, BorderSide border, BorderSide leftBorder, BorderSide rightBorder, float leftRadius, float rightRadius)
     {
         if (!border.IsVisible) return;
 
         using var paint = CreateBorderPaint(border);
         float halfWidth = border.Width.Value / 2;
 
+        float insetTop = rect.Top + halfWidth;
+        float insetLeft = rect.Left + halfWidth;
+        float insetRight = rect.Right - halfWidth;
+
         using var path = new SKPath();
+
         if (leftRadius > 0)
         {
-            path.MoveTo(rect.Left + leftRadius, rect.Top + halfWidth);
+            float arcRadius = Math.Max(0, leftRadius - halfWidth);
+            path.MoveTo(insetLeft + arcRadius, insetTop);
         }
         else
         {
-            path.MoveTo(rect.Left + halfWidth, rect.Top + halfWidth);
+            path.MoveTo(insetLeft, insetTop);
         }
 
         if (rightRadius > 0)
         {
-            path.LineTo(rect.Right - rightRadius, rect.Top + halfWidth);
+            float arcRadius = Math.Max(0, rightRadius - halfWidth);
+            path.LineTo(insetRight - arcRadius, insetTop);
+            path.ArcTo(
+                new SKRect(insetRight - arcRadius * 2, insetTop, insetRight, insetTop + arcRadius * 2),
+                270, 90, false);
         }
         else
         {
-            path.LineTo(rect.Right - halfWidth, rect.Top + halfWidth);
+            path.LineTo(insetRight, insetTop);
         }
 
         _canvas.DrawPath(path, paint);
@@ -158,30 +177,40 @@ public class Painter
     /// <summary>
     /// 绘制右边框
     /// </summary>
-    private void DrawRightBorder(RectF rect, BorderSide border, float topRadius, float bottomRadius)
+    private void DrawRightBorder(RectF rect, BorderSide border, BorderSide topBorder, BorderSide bottomBorder, float topRadius, float bottomRadius)
     {
         if (!border.IsVisible) return;
 
         using var paint = CreateBorderPaint(border);
         float halfWidth = border.Width.Value / 2;
 
+        float insetRight = rect.Right - halfWidth;
+        float insetTop = rect.Top + halfWidth;
+        float insetBottom = rect.Bottom - halfWidth;
+
         using var path = new SKPath();
+
         if (topRadius > 0)
         {
-            path.MoveTo(rect.Right - halfWidth, rect.Top + topRadius);
+            float arcRadius = Math.Max(0, topRadius - halfWidth);
+            path.MoveTo(insetRight, insetTop + arcRadius);
         }
         else
         {
-            path.MoveTo(rect.Right - halfWidth, rect.Top + halfWidth);
+            path.MoveTo(insetRight, insetTop);
         }
 
         if (bottomRadius > 0)
         {
-            path.LineTo(rect.Right - halfWidth, rect.Bottom - bottomRadius);
+            float arcRadius = Math.Max(0, bottomRadius - halfWidth);
+            path.LineTo(insetRight, insetBottom - arcRadius);
+            path.ArcTo(
+                new SKRect(insetRight - arcRadius * 2, insetBottom - arcRadius * 2, insetRight, insetBottom),
+                0, 90, false);
         }
         else
         {
-            path.LineTo(rect.Right - halfWidth, rect.Bottom - halfWidth);
+            path.LineTo(insetRight, insetBottom);
         }
 
         _canvas.DrawPath(path, paint);
@@ -190,30 +219,40 @@ public class Painter
     /// <summary>
     /// 绘制下边框
     /// </summary>
-    private void DrawBottomBorder(RectF rect, BorderSide border, float rightRadius, float leftRadius)
+    private void DrawBottomBorder(RectF rect, BorderSide border, BorderSide rightBorder, BorderSide leftBorder, float rightRadius, float leftRadius)
     {
         if (!border.IsVisible) return;
 
         using var paint = CreateBorderPaint(border);
         float halfWidth = border.Width.Value / 2;
 
+        float insetBottom = rect.Bottom - halfWidth;
+        float insetLeft = rect.Left + halfWidth;
+        float insetRight = rect.Right - halfWidth;
+
         using var path = new SKPath();
+
         if (rightRadius > 0)
         {
-            path.MoveTo(rect.Right - rightRadius, rect.Bottom - halfWidth);
+            float arcRadius = Math.Max(0, rightRadius - halfWidth);
+            path.MoveTo(insetRight - arcRadius, insetBottom);
         }
         else
         {
-            path.MoveTo(rect.Right - halfWidth, rect.Bottom - halfWidth);
+            path.MoveTo(insetRight, insetBottom);
         }
 
         if (leftRadius > 0)
         {
-            path.LineTo(rect.Left + leftRadius, rect.Bottom - halfWidth);
+            float arcRadius = Math.Max(0, leftRadius - halfWidth);
+            path.LineTo(insetLeft + arcRadius, insetBottom);
+            path.ArcTo(
+                new SKRect(insetLeft, insetBottom - arcRadius * 2, insetLeft + arcRadius * 2, insetBottom),
+                90, 90, false);
         }
         else
         {
-            path.LineTo(rect.Left + halfWidth, rect.Bottom - halfWidth);
+            path.LineTo(insetLeft, insetBottom);
         }
 
         _canvas.DrawPath(path, paint);
@@ -222,30 +261,40 @@ public class Painter
     /// <summary>
     /// 绘制左边框
     /// </summary>
-    private void DrawLeftBorder(RectF rect, BorderSide border, float bottomRadius, float topRadius)
+    private void DrawLeftBorder(RectF rect, BorderSide border, BorderSide bottomBorder, BorderSide topBorder, float bottomRadius, float topRadius)
     {
         if (!border.IsVisible) return;
 
         using var paint = CreateBorderPaint(border);
         float halfWidth = border.Width.Value / 2;
 
+        float insetLeft = rect.Left + halfWidth;
+        float insetTop = rect.Top + halfWidth;
+        float insetBottom = rect.Bottom - halfWidth;
+
         using var path = new SKPath();
+
         if (bottomRadius > 0)
         {
-            path.MoveTo(rect.Left + halfWidth, rect.Bottom - bottomRadius);
+            float arcRadius = Math.Max(0, bottomRadius - halfWidth);
+            path.MoveTo(insetLeft, insetBottom - arcRadius);
         }
         else
         {
-            path.MoveTo(rect.Left + halfWidth, rect.Bottom - halfWidth);
+            path.MoveTo(insetLeft, insetBottom);
         }
 
         if (topRadius > 0)
         {
-            path.LineTo(rect.Left + halfWidth, rect.Top + topRadius);
+            float arcRadius = Math.Max(0, topRadius - halfWidth);
+            path.LineTo(insetLeft, insetTop + arcRadius);
+            path.ArcTo(
+                new SKRect(insetLeft, insetTop, insetLeft + arcRadius * 2, insetTop + arcRadius * 2),
+                180, 90, false);
         }
         else
         {
-            path.LineTo(rect.Left + halfWidth, rect.Top + halfWidth);
+            path.LineTo(insetLeft, insetTop);
         }
 
         _canvas.DrawPath(path, paint);

--- a/tests/Miko.Tests/Animation/TransitionTriggerTests.cs
+++ b/tests/Miko.Tests/Animation/TransitionTriggerTests.cs
@@ -1,0 +1,312 @@
+using Miko.Animation;
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Styling;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Animation;
+
+public class TransitionTriggerTests : IDisposable
+{
+    private readonly SKBitmap _bitmap;
+    private readonly SKCanvas _canvas;
+
+    public TransitionTriggerTests()
+    {
+        _bitmap = new SKBitmap(600, 600);
+        _canvas = new SKCanvas(_bitmap);
+        _canvas.Clear(SKColors.White);
+    }
+
+    public void Dispose()
+    {
+        _canvas.Dispose();
+        _bitmap.Dispose();
+    }
+
+    [Fact]
+    public void Transition_ShouldTrigger_WhenComputedStyleChanges()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.Add(new CssObject
+        {
+            [".box"] = new CssObject
+            {
+                Width = Length.Px(100),
+                Height = Length.Px(50),
+                MaxHeight = Length.Px(0),
+                Transitions = [Transition.For(x => x.MaxHeight).Duration(0.5f).Linear()]
+            },
+            [".box.open"] = new CssObject
+            {
+                MaxHeight = Length.Px(200)
+            }
+        });
+
+        var root = new DivElement();
+        root.Style = new Style { Width = Length.Px(500), Height = Length.Px(500) };
+
+        var box = new DivElement { Class = "box" };
+        root.AddChild(box);
+
+        var engine = new MikoEngine();
+        engine.Initialize(root, [styleSheet], _canvas, 600, 600);
+
+        // 初始状态：MaxHeight = 0
+        engine.AnimationManager.HasActiveAnimations.ShouldBeFalse();
+
+        // 改变 class 触发 transition
+        box.Class = "box open";
+        engine.Render(_canvas);
+
+        engine.AnimationManager.HasActiveAnimations.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Transition_ShouldInterpolate_MaxHeight()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.Add(new CssObject
+        {
+            [".box"] = new CssObject
+            {
+                Width = Length.Px(100),
+                Height = Length.Px(50),
+                MaxHeight = Length.Px(0),
+                Transitions = [Transition.For(x => x.MaxHeight).Duration(1f).Linear()]
+            },
+            [".box.open"] = new CssObject
+            {
+                MaxHeight = Length.Px(200)
+            }
+        });
+
+        var root = new DivElement();
+        root.Style = new Style { Width = Length.Px(500), Height = Length.Px(500) };
+
+        var box = new DivElement { Class = "box" };
+        root.AddChild(box);
+
+        var engine = new MikoEngine();
+        engine.Initialize(root, [styleSheet], _canvas, 600, 600);
+
+        // 触发 transition
+        box.Class = "box open";
+        engine.Render(_canvas);
+
+        // 模拟 0.5 秒后（50% 进度，线性插值）
+        engine.AnimationManager.Update(0.5f);
+
+        // MaxHeight 应该在中间值附近
+        box.Style.ShouldNotBeNull();
+        box.Style!.MaxHeight!.Value.Value.ShouldBe(100f, 1f);
+    }
+
+    [Fact]
+    public void Transition_ShouldComplete_AfterDuration()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.Add(new CssObject
+        {
+            [".box"] = new CssObject
+            {
+                Width = Length.Px(100),
+                Height = Length.Px(50),
+                MaxHeight = Length.Px(0),
+                Transitions = [Transition.For(x => x.MaxHeight).Duration(0.5f).Linear()]
+            },
+            [".box.open"] = new CssObject
+            {
+                MaxHeight = Length.Px(200)
+            }
+        });
+
+        var root = new DivElement();
+        root.Style = new Style { Width = Length.Px(500), Height = Length.Px(500) };
+
+        var box = new DivElement { Class = "box" };
+        root.AddChild(box);
+
+        var engine = new MikoEngine();
+        engine.Initialize(root, [styleSheet], _canvas, 600, 600);
+
+        box.Class = "box open";
+        engine.Render(_canvas);
+
+        // 完成 transition
+        engine.AnimationManager.Update(0.6f);
+
+        engine.AnimationManager.HasActiveAnimations.ShouldBeFalse();
+        box.Style!.MaxHeight!.Value.Value.ShouldBe(200f, 1f);
+    }
+
+    [Fact]
+    public void Transition_Padding_ShouldExpandToAllSides()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.Add(new CssObject
+        {
+            [".box"] = new CssObject
+            {
+                Width = Length.Px(100),
+                Height = Length.Px(50),
+                Padding = new Padding(0, 16),
+                Transitions = [Transition.For(x => x.Padding).Duration(1f).Linear()]
+            },
+            [".box.open"] = new CssObject
+            {
+                Padding = 16
+            }
+        });
+
+        var root = new DivElement();
+        root.Style = new Style { Width = Length.Px(500), Height = Length.Px(500) };
+
+        var box = new DivElement { Class = "box" };
+        root.AddChild(box);
+
+        var engine = new MikoEngine();
+        engine.Initialize(root, [styleSheet], _canvas, 600, 600);
+
+        box.Class = "box open";
+        engine.Render(_canvas);
+
+        // PaddingTop 从 0 到 16，应该触发 transition
+        engine.AnimationManager.HasActiveAnimations.ShouldBeTrue();
+
+        engine.AnimationManager.Update(0.5f);
+
+        // PaddingTop 应该在中间值
+        box.Style!.PaddingTop!.Value.Value.ShouldBe(8f, 1f);
+    }
+
+    [Fact]
+    public void Transition_ShouldNotRetrigger_WhileActive()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.Add(new CssObject
+        {
+            [".box"] = new CssObject
+            {
+                Width = Length.Px(100),
+                Height = Length.Px(50),
+                MaxHeight = Length.Px(0),
+                Transitions = [Transition.For(x => x.MaxHeight).Duration(1f).Linear()]
+            },
+            [".box.open"] = new CssObject
+            {
+                MaxHeight = Length.Px(200)
+            }
+        });
+
+        var root = new DivElement();
+        root.Style = new Style { Width = Length.Px(500), Height = Length.Px(500) };
+
+        var box = new DivElement { Class = "box" };
+        root.AddChild(box);
+
+        var engine = new MikoEngine();
+        engine.Initialize(root, [styleSheet], _canvas, 600, 600);
+
+        box.Class = "box open";
+        engine.Render(_canvas);
+
+        // 模拟 0.3 秒
+        engine.AnimationManager.Update(0.3f);
+        float valueAt03 = box.Style!.MaxHeight!.Value.Value;
+
+        // 再次 Render 不应重新触发 transition
+        engine.Render(_canvas);
+        engine.AnimationManager.Update(0.1f);
+
+        // 值应该继续从 0.3s 的位置前进，而不是重新从 0 开始
+        float valueAt04 = box.Style!.MaxHeight!.Value.Value;
+        valueAt04.ShouldBeGreaterThan(valueAt03);
+    }
+
+    [Fact]
+    public void Transition_ShouldNotRetrigger_AfterCompletion()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.Add(new CssObject
+        {
+            [".box"] = new CssObject
+            {
+                Width = Length.Px(100),
+                Height = Length.Px(50),
+                MaxHeight = Length.Px(0),
+                Transitions = [Transition.For(x => x.MaxHeight).Duration(0.5f).Ease()]
+            },
+            [".box.open"] = new CssObject
+            {
+                MaxHeight = Length.Px(300)
+            }
+        });
+
+        var root = new DivElement();
+        root.Style = new Style { Width = Length.Px(500), Height = Length.Px(500) };
+
+        var box = new DivElement { Class = "box" };
+        root.AddChild(box);
+
+        var engine = new MikoEngine();
+        engine.Initialize(root, [styleSheet], _canvas, 600, 600);
+
+        // 触发 transition
+        box.Class = "box open";
+        engine.Render(_canvas);
+        engine.AnimationManager.HasActiveAnimations.ShouldBeTrue();
+
+        // 完成 transition（模拟 MikoApp 的帧循环：先 Update 再 Render）
+        engine.AnimationManager.Update(0.6f);
+        engine.AnimationManager.HasActiveAnimations.ShouldBeFalse();
+
+        // 下一帧 Render 不应触发新的 transition
+        engine.Render(_canvas);
+        engine.AnimationManager.HasActiveAnimations.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Transition_FirstFrame_ShouldRenderStartValue_NotTargetValue()
+    {
+        // 验证触发 transition 的首帧渲染起始值，不会闪烁到目标值
+        var styleSheet = new StyleSheet();
+        styleSheet.Add(new CssObject
+        {
+            [".box"] = new CssObject
+            {
+                Width = Length.Px(100),
+                Height = Length.Px(50),
+                MaxHeight = Length.Px(300),
+                BackgroundColor = Color.FromHex("f3f3f3"),
+                Transitions = [Transition.For(x => x.MaxHeight).Duration(0.5f).Ease()]
+            },
+            [".box.closed"] = new CssObject
+            {
+                MaxHeight = Length.Px(0)
+            }
+        });
+
+        var root = new DivElement();
+        root.Style = new Style { Width = Length.Px(500), Height = Length.Px(500) };
+
+        var box = new DivElement { Class = "box" };
+        root.AddChild(box);
+
+        var engine = new MikoEngine();
+        engine.Initialize(root, [styleSheet], _canvas, 600, 600);
+
+        // 切换到 closed 状态，触发 300 -> 0 的 transition
+        box.Class = "box closed";
+        engine.Render(_canvas);
+
+        // transition 应该已触发
+        engine.AnimationManager.HasActiveAnimations.ShouldBeTrue();
+
+        // 首帧 inline style 应该是起始值 300，不是目标值 0
+        box.Style.ShouldNotBeNull();
+        box.Style!.MaxHeight!.Value.Value.ShouldBe(300f, 1f);
+    }
+}

--- a/tests/Miko.Tests/Components/StateHasChangedTests.cs
+++ b/tests/Miko.Tests/Components/StateHasChangedTests.cs
@@ -1,0 +1,72 @@
+using Miko.Components;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Shouldly;
+
+namespace Miko.Tests.Components;
+
+public class StateHasChangedTests
+{
+    private class CounterComponent : ComponentBase
+    {
+        public int Count { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddContent(1, $"Count: {Count}");
+            builder.CloseElement();
+        }
+
+        public void Increment()
+        {
+            Count++;
+            StateHasChanged();
+        }
+    }
+
+    [Fact]
+    public void StateHasChanged_RootComponent_WithoutParent_ShouldUpdateElement()
+    {
+        var component = new CounterComponent();
+        var element = component.Build();
+
+        // 根组件没有 parent
+        element.Parent.ShouldBeNull();
+        element.TextContent.ShouldBe("Count: 0");
+
+        // 调用 StateHasChanged 应该更新元素内容
+        component.Increment();
+
+        element.TextContent.ShouldBe("Count: 1");
+    }
+
+    [Fact]
+    public void StateHasChanged_RootComponent_ShouldPreserveElementReference()
+    {
+        var component = new CounterComponent();
+        var element = component.Build();
+        var originalRef = element;
+
+        component.Increment();
+
+        // 引擎持有的引用不应改变
+        element.ShouldBeSameAs(originalRef);
+    }
+
+    [Fact]
+    public void StateHasChanged_ChildComponent_WithParent_ShouldReplaceInParent()
+    {
+        var component = new CounterComponent();
+        var element = component.Build();
+
+        // 模拟有 parent 的情况
+        var parent = new DivElement();
+        parent.AddChild(element);
+
+        component.Increment();
+
+        parent.Children.Count.ShouldBe(1);
+        parent.Children[0].TextContent.ShouldBe("Count: 1");
+    }
+}

--- a/tests/Miko.Tests/Rendering/BorderRenderingTests.cs
+++ b/tests/Miko.Tests/Rendering/BorderRenderingTests.cs
@@ -1,0 +1,212 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Rendering;
+using Miko.Styling;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Rendering;
+
+public class BorderRenderingTests : IDisposable
+{
+    private readonly SKBitmap _canvasBitmap;
+    private readonly SKCanvas _canvas;
+    private readonly RenderEngine _renderEngine;
+
+    public BorderRenderingTests()
+    {
+        _canvasBitmap = new SKBitmap(600, 600);
+        _canvas = new SKCanvas(_canvasBitmap);
+        _canvas.Clear(SKColors.White);
+        _renderEngine = new RenderEngine();
+        _renderEngine.SetCanvas(_canvas);
+    }
+
+    public void Dispose()
+    {
+        _canvas.Dispose();
+        _canvasBitmap.Dispose();
+    }
+
+    [Fact]
+    public void AdjacentDivs_WithBorders_ShouldNotOverlap()
+    {
+        // 模拟 issue 中的场景：三个相邻 div 各有 1px 边框
+        // 正常情况下相邻边框之间应该有 2px 宽度（各自 1px）
+        var root = new DivElement();
+        root.Style = new Style
+        {
+            Width = Length.Px(500),
+            Height = Length.Px(500),
+            Padding = Length.Px(10)
+        };
+
+        var div1 = new DivElement { Class = "div-1" };
+        div1.Style = new Style
+        {
+            Width = Length.Percent(100),
+            Height = Length.Px(30),
+            Border = Border.Solid(1, Color.Black)
+        };
+
+        var div2 = new DivElement { Class = "div-2" };
+        div2.Style = new Style
+        {
+            Width = Length.Percent(100),
+            Height = Length.Px(30),
+            Border = Border.Solid(1, Color.Red)
+        };
+        var div3 = new DivElement { Class = "div-3" };
+        div3.Style = new Style
+        {
+            Width = Length.Percent(100),
+            Height = Length.Px(30),
+            Border = Border.Solid(1, Color.Blue)
+        };
+
+        root.AddChild(div1);
+        root.AddChild(div2);
+        root.AddChild(div3);
+
+        RenderElement(root);
+
+        // div1 的 BorderBox 从 y=10 开始（padding=10），高度=30+2(border)=32
+        // div1 底边框应该在 y=41 (10+32-1=41)
+        // div2 的 BorderBox 从 y=42 开始
+        // div2 顶边框应该在 y=42
+        // 在 y=41 和 y=42 之间应该有明确的分界
+
+        // 验证 div1 底边框区域是黑色
+        var div1BottomBorderY = 41;
+        var pixelAtDiv1Bottom = GetPixelColor(250, div1BottomBorderY);
+        pixelAtDiv1Bottom.ShouldBe(SKColors.Black);
+
+        // 验证 div2 顶边框区域是红色
+        var div2TopBorderY = 42;
+        var pixelAtDiv2Top = GetPixelColor(250, div2TopBorderY);
+        pixelAtDiv2Top.ShouldBe(SKColors.Red);
+    }
+
+    [Fact]
+    public void Border_ShouldStayWithinBorderBox()
+    {
+        // 验证边框完全在 BorderBox 内部绘制，不会溢出
+        var root = new DivElement();
+        root.Style = new Style
+        {
+            Width = Length.Px(100),
+            Height = Length.Px(100),
+            Border = Border.Solid(2, Color.Black)
+        };
+
+        RenderElement(root);
+
+        // 边框宽度为 2px，BorderBox 从 (0,0) 到 (103,103)
+        // 边框应该完全在 BorderBox 内部
+        // BorderBox 外部（y=-1 不存在，但 y=0 应该有边框）
+        var topEdge = GetPixelColor(50, 0);
+        topEdge.ShouldBe(SKColors.Black);
+
+        var insideContent = GetPixelColor(50, 50);
+        insideContent.ShouldBe(SKColors.White);
+    }
+
+    [Fact]
+    public void PerSideBorder_WithTopNone_ShouldRenderOtherSidesCorrectly()
+    {
+        // 验证取消上边框后，其他三边仍然正确渲染
+        var root = new DivElement();
+        root.Style = new Style
+        {
+            Width = Length.Px(100),
+            Height = Length.Px(100),
+            BorderLeft = new BorderSide(Length.Px(2), BorderStyle.Solid, Color.Blue),
+            BorderRight = new BorderSide(Length.Px(2), BorderStyle.Solid, Color.Blue),
+            BorderBottom = new BorderSide(Length.Px(2), BorderStyle.Solid, Color.Blue),
+            BorderTop = BorderSide.None
+        };
+
+        RenderElement(root);
+
+        // 上边框区域应该是白色（无边框）
+        var topCenter = GetPixelColor(52, 0);
+        topCenter.ShouldBe(SKColors.White);
+
+        // 左边框应该是蓝色
+        var leftBorder = GetPixelColor(0, 50);
+        leftBorder.ShouldBe(SKColors.Blue);
+
+        // 右边框应该是蓝色
+        var rightBorder = GetPixelColor(103, 50);
+        rightBorder.ShouldBe(SKColors.Blue);
+
+        // 底边框应该是蓝色
+        var bottomBorder = GetPixelColor(52, 101);
+        bottomBorder.ShouldBe(SKColors.Blue);
+    }
+
+    [Fact]
+    public void PerSideBorder_WithTopNone_AndBorderRadius_ShouldRenderBottomCorners()
+    {
+        // 验证取消上边框 + 有圆角时，底部圆角不会缺失
+        var root = new DivElement();
+        root.Style = new Style
+        {
+            Width = Length.Px(100),
+            Height = Length.Px(100),
+            BorderLeft = new BorderSide(Length.Px(2), BorderStyle.Solid, Color.Blue),
+            BorderRight = new BorderSide(Length.Px(2), BorderStyle.Solid, Color.Blue),
+            BorderBottom = new BorderSide(Length.Px(2), BorderStyle.Solid, Color.Blue),
+            BorderTop = BorderSide.None,
+            BorderBottomLeftRadius = Length.Px(8),
+            BorderBottomRightRadius = Length.Px(8)
+        };
+
+        RenderElement(root);
+
+        // 底部中间应该有蓝色边框
+        var bottomCenter = GetPixelColor(52, 101);
+        bottomCenter.ShouldBe(SKColors.Blue);
+
+        // 左下角的直角位置应该是白色（因为有圆角）
+        var cornerPixel = GetPixelColor(1, 101);
+        cornerPixel.ShouldBe(SKColors.White);
+    }
+
+    [Fact]
+    public void UniformBorder_ShouldInsetByHalfWidth()
+    {
+        // 验证统一边框向内收缩半个宽度绘制
+        var root = new DivElement();
+        root.Style = new Style
+        {
+            Width = Length.Px(50),
+            Height = Length.Px(50),
+            Border = Border.Solid(4, Color.Red)
+        };
+
+        RenderElement(root);
+
+        // 4px 边框，BorderBox 从 (0,0) 到 (57,57)
+        // 描边中心线在 (2,2) 到 (55,55)
+        // 描边外边缘在 (0,0)，内边缘在 (4,4)
+        // 所以 (0,0) 应该有红色，(4,4) 也应该有红色边缘
+        var outerEdge = GetPixelColor(0, 28);
+        outerEdge.ShouldBe(SKColors.Red);
+
+        // 内容区域中心应该是白色
+        var center = GetPixelColor(28, 28);
+        center.ShouldBe(SKColors.White);
+    }
+
+    private void RenderElement(Element root)
+    {
+        var engine = new MikoEngine();
+        engine.Initialize(root, [], _canvas, 600, 600);
+        engine.Render(_canvas);
+    }
+
+    private SKColor GetPixelColor(int x, int y) => _canvasBitmap.GetPixel(x, y);
+}


### PR DESCRIPTION
## Summary

- Fix border overlap: inset stroke rect by half border width so adjacent element borders don't visually merge
- Fix corner radius missing when individual border side is set to None (per-side drawing now includes arc segments)
- Fix `StateHasChanged()` ineffective for root components without Layout wrapper (in-place element update preserving engine reference)
- Add automatic transition detection: compare old vs new computed styles on each render and trigger transitions
- Add `MaxHeight`/`MaxWidth`/`Padding`/`BorderRadius` to transition float appliers
- Fix transition re-trigger after completion (track recently completed transitions per frame)
- Fix white flash on transition start by applying start value immediately and re-layouting before first render

## Test plan

- [x] 5 border rendering tests (overlap, inset, per-side with None, corner radius)
- [x] 3 StateHasChanged tests (root without parent, reference preservation, child with parent)
- [x] 7 transition trigger tests (detection, interpolation, completion, padding shorthand, no re-trigger while active, no re-trigger after completion, no flash on first frame)
- [x] Full test suite: 651 tests passing, 0 failures