### PR TITLE
Fix Transform rendering and pseudo-element transition support

### DIFF
--- a/src/Miko/Animation/AnimationManager.cs
+++ b/src/Miko/Animation/AnimationManager.cs
@@ -29,6 +29,7 @@ internal class ActiveTransition
     public bool IsComplete => ElapsedTime >= Duration + Delay;
     public Action<Element, float>? ApplyFloat { get; set; }
     public Action<Element, Color>? ApplyColor { get; set; }
+    public Action<Element, Transform>? ApplyTransform { get; set; }
 }
 
 internal class ActiveAnimation
@@ -188,6 +189,118 @@ public class AnimationManager
             property, oldColor, newColor, element.TagName, element.Id ?? "", transition.Duration);
     }
 
+    public void TrackTransformChange(Element element, Transform oldTransform, Transform newTransform, Transition transition)
+    {
+        if (oldTransform == newTransform) return;
+
+        _transitions.RemoveAll(t => t.Element == element && t.Property.PropertyName == nameof(Style.Transform));
+
+        var activeTransition = new ActiveTransition
+        {
+            Element = element,
+            Property = new AnimatedProperty
+            {
+                PropertyName = nameof(Style.Transform),
+                StartTransform = oldTransform,
+                EndTransform = newTransform
+            },
+            Duration = transition.Duration,
+            Delay = transition.Delay,
+            TimingFunction = transition.TimingFunction,
+            CubicBezier = transition.CubicBezier,
+            ElapsedTime = 0,
+            ApplyTransform = (e, t) => { e.Style ??= new Style(); e.Style.Transform = t; }
+        };
+
+        _transitions.Add(activeTransition);
+        activeTransition.ApplyTransform?.Invoke(element, oldTransform);
+
+        _logger.LogDebug("Transform transition started on <{Tag} id=\"{Id}\">, duration={Duration}s",
+            element.TagName, element.Id ?? "", transition.Duration);
+    }
+
+    public void TrackPropertyChangeWithApplier(Element element, string property, float oldValue, float newValue, Transition transition, Action<Element, float> applier)
+    {
+        if (MathF.Abs(oldValue - newValue) < 1e-6f) return;
+
+        _transitions.RemoveAll(t => t.Element == element && t.Property.PropertyName == property);
+
+        var activeTransition = new ActiveTransition
+        {
+            Element = element,
+            Property = new AnimatedProperty
+            {
+                PropertyName = property,
+                StartValue = oldValue,
+                EndValue = newValue
+            },
+            Duration = transition.Duration,
+            Delay = transition.Delay,
+            TimingFunction = transition.TimingFunction,
+            CubicBezier = transition.CubicBezier,
+            ElapsedTime = 0,
+            ApplyFloat = applier
+        };
+
+        _transitions.Add(activeTransition);
+        applier(element, oldValue);
+    }
+
+    public void TrackColorChangeWithApplier(Element element, string property, Color oldColor, Color newColor, Transition transition, Action<Element, Color> applier)
+    {
+        if (oldColor.R == newColor.R && oldColor.G == newColor.G &&
+            oldColor.B == newColor.B && oldColor.A == newColor.A) return;
+
+        _transitions.RemoveAll(t => t.Element == element && t.Property.PropertyName == property);
+
+        var activeTransition = new ActiveTransition
+        {
+            Element = element,
+            Property = new AnimatedProperty
+            {
+                PropertyName = property,
+                StartColor = oldColor,
+                EndColor = newColor
+            },
+            Duration = transition.Duration,
+            Delay = transition.Delay,
+            TimingFunction = transition.TimingFunction,
+            CubicBezier = transition.CubicBezier,
+            ElapsedTime = 0,
+            ApplyColor = applier
+        };
+
+        _transitions.Add(activeTransition);
+        applier(element, oldColor);
+    }
+
+    public void TrackTransformChangeWithApplier(Element element, string property, Transform oldTransform, Transform newTransform, Transition transition, Action<Element, Transform> applier)
+    {
+        if (oldTransform == newTransform) return;
+
+        _transitions.RemoveAll(t => t.Element == element && t.Property.PropertyName == property);
+
+        var activeTransition = new ActiveTransition
+        {
+            Element = element,
+            Property = new AnimatedProperty
+            {
+                PropertyName = property,
+                StartTransform = oldTransform,
+                EndTransform = newTransform
+            },
+            Duration = transition.Duration,
+            Delay = transition.Delay,
+            TimingFunction = transition.TimingFunction,
+            CubicBezier = transition.CubicBezier,
+            ElapsedTime = 0,
+            ApplyTransform = applier
+        };
+
+        _transitions.Add(activeTransition);
+        applier(element, oldTransform);
+    }
+
     public void Update(float deltaTime)
     {
         _recentlyCompleted.Clear();
@@ -217,6 +330,11 @@ public class AnimationManager
             {
                 var color = LerpColor(transition.Property.StartColor.Value, transition.Property.EndColor.Value, easedProgress);
                 transition.ApplyColor(transition.Element, color);
+            }
+            else if (transition.ApplyTransform != null && transition.Property.StartTransform != null && transition.Property.EndTransform != null)
+            {
+                var transform = LerpTransform(transition.Property.StartTransform, transition.Property.EndTransform, easedProgress);
+                transition.ApplyTransform(transition.Element, transform);
             }
 
             transition.Element.IsDirty = true;
@@ -404,6 +522,13 @@ public class AnimationManager
             var toColor = to.BorderColor ?? Color.Transparent;
             element.Style.BorderColor = LerpColor(fromColor, toColor, progress);
         }
+
+        if (from.Transform != null || to.Transform != null)
+        {
+            var fromTransform = from.Transform ?? Transform.None;
+            var toTransform = to.Transform ?? Transform.None;
+            element.Style.Transform = LerpTransform(fromTransform, toTransform, progress);
+        }
     }
 
     private static void InterpolateLengthProperty(Element element, Length? from, Length? to, float progress, Action<Style, Length> setter)
@@ -425,6 +550,76 @@ public class AnimationManager
             (byte)(a.B + (b.B - a.B) * t),
             (byte)(a.A + (b.A - a.A) * t)
         );
+    }
+
+    internal static Transform LerpTransform(Transform from, Transform to, float t)
+    {
+        var result = new Transform();
+        int count = Math.Max(from.Functions.Count, to.Functions.Count);
+
+        for (int i = 0; i < count; i++)
+        {
+            var fromFn = i < from.Functions.Count ? from.Functions[i] : GetIdentity(to.Functions[i]);
+            var toFn = i < to.Functions.Count ? to.Functions[i] : GetIdentity(from.Functions[i]);
+            result.Functions.Add(LerpFunction(fromFn, toFn, t));
+        }
+
+        return result;
+    }
+
+    private static TransformFunction GetIdentity(TransformFunction reference)
+    {
+        return reference switch
+        {
+            TransformFunction.Translate tr => new TransformFunction.Translate(
+                new Length(0, tr.X.Unit), new Length(0, tr.Y.Unit)),
+            TransformFunction.TranslateX tx => new TransformFunction.TranslateX(
+                new Length(0, tx.X.Unit)),
+            TransformFunction.TranslateY ty => new TransformFunction.TranslateY(
+                new Length(0, ty.Y.Unit)),
+            TransformFunction.Scale => new TransformFunction.Scale(1f, 1f),
+            TransformFunction.ScaleX => new TransformFunction.ScaleX(1f),
+            TransformFunction.ScaleY => new TransformFunction.ScaleY(1f),
+            TransformFunction.Rotate => new TransformFunction.Rotate(0f),
+            TransformFunction.SkewX => new TransformFunction.SkewX(0f),
+            TransformFunction.SkewY => new TransformFunction.SkewY(0f),
+            TransformFunction.Skew => new TransformFunction.Skew(0f, 0f),
+            TransformFunction.Matrix => new TransformFunction.Matrix(1, 0, 0, 1, 0, 0),
+            _ => new TransformFunction.Rotate(0f)
+        };
+    }
+
+    private static TransformFunction LerpFunction(TransformFunction from, TransformFunction to, float t)
+    {
+        return (from, to) switch
+        {
+            (TransformFunction.Rotate a, TransformFunction.Rotate b) =>
+                new TransformFunction.Rotate(Lerp(a.Degrees, b.Degrees, t)),
+            (TransformFunction.Scale a, TransformFunction.Scale b) =>
+                new TransformFunction.Scale(Lerp(a.X, b.X, t), Lerp(a.Y, b.Y, t)),
+            (TransformFunction.ScaleX a, TransformFunction.ScaleX b) =>
+                new TransformFunction.ScaleX(Lerp(a.X, b.X, t)),
+            (TransformFunction.ScaleY a, TransformFunction.ScaleY b) =>
+                new TransformFunction.ScaleY(Lerp(a.Y, b.Y, t)),
+            (TransformFunction.Translate a, TransformFunction.Translate b)
+                when a.X.Unit == b.X.Unit && a.Y.Unit == b.Y.Unit =>
+                new TransformFunction.Translate(
+                    new Length(Lerp(a.X.Value, b.X.Value, t), a.X.Unit),
+                    new Length(Lerp(a.Y.Value, b.Y.Value, t), a.Y.Unit)),
+            (TransformFunction.TranslateX a, TransformFunction.TranslateX b)
+                when a.X.Unit == b.X.Unit =>
+                new TransformFunction.TranslateX(new Length(Lerp(a.X.Value, b.X.Value, t), a.X.Unit)),
+            (TransformFunction.TranslateY a, TransformFunction.TranslateY b)
+                when a.Y.Unit == b.Y.Unit =>
+                new TransformFunction.TranslateY(new Length(Lerp(a.Y.Value, b.Y.Value, t), a.Y.Unit)),
+            (TransformFunction.SkewX a, TransformFunction.SkewX b) =>
+                new TransformFunction.SkewX(Lerp(a.Degrees, b.Degrees, t)),
+            (TransformFunction.SkewY a, TransformFunction.SkewY b) =>
+                new TransformFunction.SkewY(Lerp(a.Degrees, b.Degrees, t)),
+            (TransformFunction.Skew a, TransformFunction.Skew b) =>
+                new TransformFunction.Skew(Lerp(a.DegreesX, b.DegreesX, t), Lerp(a.DegreesY, b.DegreesY, t)),
+            _ => t < 0.5f ? from : to
+        };
     }
 
     private static Action<Element, float>? GetFloatApplier(string property)

--- a/src/Miko/Components/ComponentBase.cs
+++ b/src/Miko/Components/ComponentBase.cs
@@ -79,7 +79,8 @@ public abstract class ComponentBase : IComponent
             newElement.LayoutBox = new LayoutBox
             {
                 Element = newElement,
-                ComputedStyle = oldElement.LayoutBox.ComputedStyle
+                ComputedStyle = oldElement.LayoutBox.ComputedStyle,
+                Children = oldElement.LayoutBox.Children
             };
         }
 

--- a/src/Miko/Core/DomElements/PseudoElement.cs
+++ b/src/Miko/Core/DomElements/PseudoElement.cs
@@ -1,6 +1,9 @@
+using Miko.Styling;
+
 namespace Miko.Core.DomElements;
 
 public class PseudoElement : Element
 {
     public override string TagName => "::pseudo";
+    public PseudoElementType Type { get; set; }
 }

--- a/src/Miko/Core/Element.cs
+++ b/src/Miko/Core/Element.cs
@@ -21,6 +21,8 @@ public abstract class Element
     public Style? Style { get; set; }
     public string? TextContent { get; set; }
 
+    internal Dictionary<PseudoElementType, Style>? PseudoElementStyles { get; set; }
+
     // 布局后的盒子模型引用
     internal LayoutBox? LayoutBox { get; set; }
 

--- a/src/Miko/Core/MikoEngine.cs
+++ b/src/Miko/Core/MikoEngine.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Miko.Animation;
 using Miko.Common;
+using Miko.Core.DomElements;
 using Miko.Events;
 using Miko.Layout;
 using Miko.Rendering;
@@ -51,6 +52,12 @@ public class MikoEngine
 
     public void Initialize(Element root, List<StyleSheet> styleSheets, SKCanvas canvas, float viewportWidth, float viewportHeight)
     {
+        // Transfer old LayoutBox references to new elements for transition detection
+        if (_root != null)
+        {
+            MapElementIdentityRecursive(_root, root);
+        }
+
         _root = root;
         _styleSheets = styleSheets;
         _viewportWidth = viewportWidth;
@@ -61,10 +68,37 @@ public class MikoEngine
         _renderEngine.SetCanvas(canvas);
 
         _logger.LogInformation("Engine initialized with viewport {Width}x{Height}", viewportWidth, viewportHeight);
-        _currentLayout = _layoutEngine.Layout(root, _styleSheets, viewportWidth, viewportHeight);
-        _renderEngine.Render(_currentLayout);
 
+        // Capture old styles from transferred LayoutBoxes (before layout replaces them)
+        var oldStyles = CaptureTransitionableStyles(root);
+
+        _currentLayout = _layoutEngine.Layout(root, _styleSheets, viewportWidth, viewportHeight);
+
+        if (oldStyles.Elements.Count > 0 || oldStyles.PseudoElements.Count > 0)
+        {
+            bool transitionsTriggered = DetectAndTriggerTransitions(root, oldStyles);
+            if (transitionsTriggered)
+            {
+                _currentLayout = _layoutEngine.Layout(root, _styleSheets, viewportWidth, viewportHeight);
+            }
+        }
+
+        _renderEngine.Render(_currentLayout);
         ScanAndStartAnimations(root);
+    }
+
+    private static void MapElementIdentityRecursive(Element oldElement, Element newElement)
+    {
+        if (oldElement.LayoutBox != null)
+        {
+            newElement.LayoutBox = oldElement.LayoutBox;
+        }
+
+        int count = Math.Min(oldElement.Children.Count, newElement.Children.Count);
+        for (int i = 0; i < count; i++)
+        {
+            MapElementIdentityRecursive(oldElement.Children[i], newElement.Children[i]);
+        }
     }
 
     public void Update(SKCanvas canvas)
@@ -255,67 +289,94 @@ public class MikoEngine
         float MarginTop, float MarginRight, float MarginBottom, float MarginLeft,
         float Opacity, float FontSize, float BorderWidth,
         float BorderTopLeftRadius, float BorderTopRightRadius, float BorderBottomRightRadius, float BorderBottomLeftRadius,
-        Color BackgroundColor, Color Color, Color BorderColor);
+        Color BackgroundColor, Color Color, Color BorderColor,
+        Transform Transform);
 
-    private Dictionary<Element, (StyleSnapshot snapshot, List<Transition> transitions)> CaptureTransitionableStyles(Element root)
+    private record TransitionCapture(
+        Dictionary<Element, (StyleSnapshot snapshot, List<Transition> transitions)> Elements,
+        Dictionary<(Element parent, PseudoElementType type), (StyleSnapshot snapshot, List<Transition> transitions)> PseudoElements);
+
+    private TransitionCapture CaptureTransitionableStyles(Element root)
     {
-        var result = new Dictionary<Element, (StyleSnapshot, List<Transition>)>();
-        CaptureRecursive(root, result);
-        return result;
+        var elements = new Dictionary<Element, (StyleSnapshot, List<Transition>)>();
+        var pseudos = new Dictionary<(Element, PseudoElementType), (StyleSnapshot, List<Transition>)>();
+        CaptureRecursive(root, elements, pseudos);
+        return new TransitionCapture(elements, pseudos);
     }
 
-    private static void CaptureRecursive(Element element, Dictionary<Element, (StyleSnapshot, List<Transition>)> result)
+    private static void CaptureRecursive(Element element,
+        Dictionary<Element, (StyleSnapshot, List<Transition>)> elements,
+        Dictionary<(Element, PseudoElementType), (StyleSnapshot, List<Transition>)> pseudos)
     {
         var layoutBox = element.LayoutBox;
         if (layoutBox != null && layoutBox.ComputedStyle.Transitions.Count > 0)
         {
-            var cs = layoutBox.ComputedStyle;
-            var snapshot = new StyleSnapshot(
-                cs.MaxWidth.IsAuto ? float.MaxValue : cs.MaxWidth.Value,
-                cs.MaxHeight.IsAuto ? float.MaxValue : cs.MaxHeight.Value,
-                cs.Width.IsAuto ? float.NaN : cs.Width.Value,
-                cs.Height.IsAuto ? float.NaN : cs.Height.Value,
-                cs.PaddingTop.Value, cs.PaddingRight.Value, cs.PaddingBottom.Value, cs.PaddingLeft.Value,
-                cs.MarginTop.Value, cs.MarginRight.Value, cs.MarginBottom.Value, cs.MarginLeft.Value,
-                cs.Opacity, cs.FontSize.Value, cs.BorderTopWidth.Value,
-                cs.BorderTopLeftRadius.Value, cs.BorderTopRightRadius.Value,
-                cs.BorderBottomRightRadius.Value, cs.BorderBottomLeftRadius.Value,
-                cs.BackgroundColor, cs.Color, cs.BorderTopColor);
-            result[element] = (snapshot, cs.Transitions);
+            elements[element] = (CaptureSnapshot(layoutBox.ComputedStyle), layoutBox.ComputedStyle.Transitions);
+        }
+
+        if (layoutBox != null)
+        {
+            foreach (var child in layoutBox.Children)
+            {
+                if (child.Element is PseudoElement pseudo && child.ComputedStyle.Transitions.Count > 0)
+                {
+                    pseudos[(element, pseudo.Type)] = (CaptureSnapshot(child.ComputedStyle), child.ComputedStyle.Transitions);
+                }
+            }
         }
 
         foreach (var child in element.Children)
-            CaptureRecursive(child, result);
+            CaptureRecursive(child, elements, pseudos);
     }
 
-    private bool DetectAndTriggerTransitions(Element root, Dictionary<Element, (StyleSnapshot snapshot, List<Transition> transitions)> oldStyles)
+    private static StyleSnapshot CaptureSnapshot(ComputedStyle cs)
     {
-        if (oldStyles.Count == 0) return false;
+        return new StyleSnapshot(
+            cs.MaxWidth.IsAuto ? float.MaxValue : cs.MaxWidth.Value,
+            cs.MaxHeight.IsAuto ? float.MaxValue : cs.MaxHeight.Value,
+            cs.Width.IsAuto ? float.NaN : cs.Width.Value,
+            cs.Height.IsAuto ? float.NaN : cs.Height.Value,
+            cs.PaddingTop.Value, cs.PaddingRight.Value, cs.PaddingBottom.Value, cs.PaddingLeft.Value,
+            cs.MarginTop.Value, cs.MarginRight.Value, cs.MarginBottom.Value, cs.MarginLeft.Value,
+            cs.Opacity, cs.FontSize.Value, cs.BorderTopWidth.Value,
+            cs.BorderTopLeftRadius.Value, cs.BorderTopRightRadius.Value,
+            cs.BorderBottomRightRadius.Value, cs.BorderBottomLeftRadius.Value,
+            cs.BackgroundColor, cs.Color, cs.BorderTopColor,
+            cs.Transform);
+    }
+
+    private bool DetectAndTriggerTransitions(Element root, TransitionCapture oldStyles)
+    {
+        if (oldStyles.Elements.Count == 0 && oldStyles.PseudoElements.Count == 0) return false;
         int before = _animationManager.ActiveTransitionCount;
         DetectTransitionsRecursive(root, oldStyles);
         return _animationManager.ActiveTransitionCount > before;
     }
 
-    private void DetectTransitionsRecursive(Element element, Dictionary<Element, (StyleSnapshot snapshot, List<Transition> transitions)> oldStyles)
+    private void DetectTransitionsRecursive(Element element, TransitionCapture oldStyles)
     {
-        if (oldStyles.TryGetValue(element, out var old) && element.LayoutBox != null)
+        if (oldStyles.Elements.TryGetValue(element, out var old) && element.LayoutBox != null)
         {
-            var cs = element.LayoutBox.ComputedStyle;
-            var newSnapshot = new StyleSnapshot(
-                cs.MaxWidth.IsAuto ? float.MaxValue : cs.MaxWidth.Value,
-                cs.MaxHeight.IsAuto ? float.MaxValue : cs.MaxHeight.Value,
-                cs.Width.IsAuto ? float.NaN : cs.Width.Value,
-                cs.Height.IsAuto ? float.NaN : cs.Height.Value,
-                cs.PaddingTop.Value, cs.PaddingRight.Value, cs.PaddingBottom.Value, cs.PaddingLeft.Value,
-                cs.MarginTop.Value, cs.MarginRight.Value, cs.MarginBottom.Value, cs.MarginLeft.Value,
-                cs.Opacity, cs.FontSize.Value, cs.BorderTopWidth.Value,
-                cs.BorderTopLeftRadius.Value, cs.BorderTopRightRadius.Value,
-                cs.BorderBottomRightRadius.Value, cs.BorderBottomLeftRadius.Value,
-                cs.BackgroundColor, cs.Color, cs.BorderTopColor);
-
+            var newSnapshot = CaptureSnapshot(element.LayoutBox.ComputedStyle);
             foreach (var transition in old.transitions)
             {
                 TriggerPropertyTransitions(element, transition, old.snapshot, newSnapshot);
+            }
+        }
+
+        if (element.LayoutBox != null)
+        {
+            foreach (var child in element.LayoutBox.Children)
+            {
+                if (child.Element is PseudoElement pseudo &&
+                    oldStyles.PseudoElements.TryGetValue((element, pseudo.Type), out var oldPseudo))
+                {
+                    var newSnapshot = CaptureSnapshot(child.ComputedStyle);
+                    foreach (var transition in oldPseudo.transitions)
+                    {
+                        TriggerPseudoElementTransitions(element, pseudo.Type, transition, oldPseudo.snapshot, newSnapshot);
+                    }
+                }
             }
         }
 
@@ -375,6 +436,103 @@ public class MikoEngine
             TryTrackColor(element, nameof(Style.Color), oldSnap.Color, newSnap.Color, transition);
         if (prop == "all" || prop == nameof(Style.BorderColor))
             TryTrackColor(element, nameof(Style.BorderColor), oldSnap.BorderColor, newSnap.BorderColor, transition);
+
+        if (prop == "all" || prop == nameof(Style.Transform))
+            TryTrackTransform(element, oldSnap.Transform, newSnap.Transform, transition);
+    }
+
+    private void TriggerPseudoElementTransitions(Element parent, PseudoElementType pseudoType, Transition transition, StyleSnapshot oldSnap, StyleSnapshot newSnap)
+    {
+        var prop = transition.Property;
+
+        if (prop == "all" || prop == nameof(Style.Transform))
+        {
+            if (!TransformEquals(oldSnap.Transform, newSnap.Transform))
+            {
+                string key = $"::pseudo({pseudoType}).Transform";
+                if (!_animationManager.HasActiveTransition(parent, key))
+                {
+                    _animationManager.TrackTransformChangeWithApplier(
+                        parent, key, oldSnap.Transform, newSnap.Transform, transition,
+                        (e, t) =>
+                        {
+                            e.PseudoElementStyles ??= new();
+                            if (!e.PseudoElementStyles.TryGetValue(pseudoType, out var s))
+                            {
+                                s = new Style();
+                                e.PseudoElementStyles[pseudoType] = s;
+                            }
+                            s.Transform = t;
+                        });
+                }
+            }
+        }
+
+        if (prop == "all" || prop == nameof(Style.Opacity))
+        {
+            TryTrackPseudoFloat(parent, pseudoType, nameof(Style.Opacity), oldSnap.Opacity, newSnap.Opacity, transition,
+                (s, v) => s.Opacity = v);
+        }
+
+        if (prop == "all" || prop == nameof(Style.BackgroundColor))
+        {
+            TryTrackPseudoColor(parent, pseudoType, nameof(Style.BackgroundColor), oldSnap.BackgroundColor, newSnap.BackgroundColor, transition,
+                (s, c) => s.BackgroundColor = c);
+        }
+
+        if (prop == "all" || prop == nameof(Style.Color))
+        {
+            TryTrackPseudoColor(parent, pseudoType, nameof(Style.Color), oldSnap.Color, newSnap.Color, transition,
+                (s, c) => s.Color = c);
+        }
+    }
+
+    private void TryTrackPseudoFloat(Element parent, PseudoElementType pseudoType, string property, float oldValue, float newValue, Transition transition, Action<Style, float> setter)
+    {
+        if (float.IsNaN(oldValue) || float.IsNaN(newValue)) return;
+        if (MathF.Abs(oldValue - newValue) < 1e-6f) return;
+
+        string key = $"::pseudo({pseudoType}).{property}";
+        if (_animationManager.HasActiveTransition(parent, key)) return;
+
+        _animationManager.TrackPropertyChangeWithApplier(parent, key, oldValue, newValue, transition,
+            (e, v) =>
+            {
+                e.PseudoElementStyles ??= new();
+                if (!e.PseudoElementStyles.TryGetValue(pseudoType, out var s))
+                {
+                    s = new Style();
+                    e.PseudoElementStyles[pseudoType] = s;
+                }
+                setter(s, v);
+            });
+    }
+
+    private void TryTrackPseudoColor(Element parent, PseudoElementType pseudoType, string property, Color oldColor, Color newColor, Transition transition, Action<Style, Color> setter)
+    {
+        if (oldColor.R == newColor.R && oldColor.G == newColor.G &&
+            oldColor.B == newColor.B && oldColor.A == newColor.A) return;
+
+        string key = $"::pseudo({pseudoType}).{property}";
+        if (_animationManager.HasActiveTransition(parent, key)) return;
+
+        _animationManager.TrackColorChangeWithApplier(parent, key, oldColor, newColor, transition,
+            (e, c) =>
+            {
+                e.PseudoElementStyles ??= new();
+                if (!e.PseudoElementStyles.TryGetValue(pseudoType, out var s))
+                {
+                    s = new Style();
+                    e.PseudoElementStyles[pseudoType] = s;
+                }
+                setter(s, c);
+            });
+    }
+
+    private void TryTrackTransform(Element element, Transform oldTransform, Transform newTransform, Transition transition)
+    {
+        if (_animationManager.HasActiveTransition(element, nameof(Style.Transform))) return;
+        _animationManager.TrackTransformChange(element, oldTransform, newTransform, transition);
     }
 
     private void TryTrackColor(Element element, string property, Color oldColor, Color newColor, Transition transition)
@@ -389,6 +547,17 @@ public class MikoEngine
         if (oldValue == float.MaxValue && newValue == float.MaxValue) return;
         if (_animationManager.HasActiveTransition(element, property)) return;
         _animationManager.TrackPropertyChange(element, property, oldValue, newValue, transition);
+    }
+
+    private static bool TransformEquals(Transform a, Transform b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a.Functions.Count != b.Functions.Count) return false;
+        for (int i = 0; i < a.Functions.Count; i++)
+        {
+            if (!a.Functions[i].Equals(b.Functions[i])) return false;
+        }
+        return true;
     }
 
     private static void EnsureParentReferences(Element element)

--- a/src/Miko/Layout/LayoutEngine.cs
+++ b/src/Miko/Layout/LayoutEngine.cs
@@ -135,7 +135,15 @@ public class LayoutEngine
 
         if (matchedStyle == null) return null;
 
-        var pseudoElement = new PseudoElement { TextContent = matchedStyle.Content };
+        if (element.PseudoElementStyles != null &&
+            element.PseudoElementStyles.TryGetValue(type, out var overrideStyle))
+        {
+            var merged = overrideStyle.Clone();
+            merged.Merge(matchedStyle);
+            matchedStyle = merged;
+        }
+
+        var pseudoElement = new PseudoElement { TextContent = matchedStyle.Content, Type = type };
         var computedStyle = ComputedStyle.FromStyle(matchedStyle);
 
         pseudoElement.LayoutBox = new LayoutBox

--- a/src/Miko/Rendering/Painter.cs
+++ b/src/Miko/Rendering/Painter.cs
@@ -866,4 +866,26 @@ public class Painter
     {
         _canvas.Translate(dx, dy);
     }
+
+    public void Rotate(float degrees)
+    {
+        _canvas.RotateDegrees(degrees);
+    }
+
+    public void Scale(float sx, float sy)
+    {
+        _canvas.Scale(sx, sy);
+    }
+
+    public void Skew(float degreesX, float degreesY)
+    {
+        float tanX = MathF.Tan(degreesX * MathF.PI / 180f);
+        float tanY = MathF.Tan(degreesY * MathF.PI / 180f);
+        _canvas.Skew(tanX, tanY);
+    }
+
+    public void Concat(SKMatrix matrix)
+    {
+        _canvas.Concat(ref matrix);
+    }
 }

--- a/src/Miko/Rendering/RenderEngine.cs
+++ b/src/Miko/Rendering/RenderEngine.cs
@@ -1,3 +1,4 @@
+using Miko.Animation;
 using Miko.Common;
 using Miko.Core.DomElements;
 using Miko.Layout;
@@ -89,6 +90,13 @@ public class RenderEngine
             _painter.SaveLayerAlpha(alpha);
         }
 
+        bool hasTransform = box.ComputedStyle.Transform.Functions.Count > 0;
+        if (hasTransform)
+        {
+            _painter.Save();
+            ApplyTransform(box);
+        }
+
         // 1. 绘制背景
         RenderBackground(box);
 
@@ -102,6 +110,7 @@ public class RenderEngine
         // SelectElement 的子元素（Option）不参与正常树渲染，由 overlay pass 统一绘制下拉层
         if (box.Element is SelectElement)
         {
+            if (hasTransform) _painter.Restore();
             if (hasOpacity) _painter.Restore();
             return;
         }
@@ -125,7 +134,79 @@ public class RenderEngine
         // 5. 绘制滚动条（在裁剪区域之外）
         RenderScrollbars(box);
 
+        if (hasTransform) _painter.Restore();
         if (hasOpacity) _painter.Restore();
+    }
+
+    private void ApplyTransform(LayoutBox box)
+    {
+        if (_painter == null) return;
+
+        var borderBox = box.BoxModel.BorderBox;
+        var origin = box.ComputedStyle.TransformOrigin;
+
+        float originX = origin.X.Unit == LengthUnit.Percent
+            ? borderBox.X + borderBox.Width * origin.X.Value / 100f
+            : borderBox.X + origin.X.Value;
+        float originY = origin.Y.Unit == LengthUnit.Percent
+            ? borderBox.Y + borderBox.Height * origin.Y.Value / 100f
+            : borderBox.Y + origin.Y.Value;
+
+        _painter.Translate(originX, originY);
+
+        foreach (var fn in box.ComputedStyle.Transform.Functions)
+        {
+            switch (fn)
+            {
+                case TransformFunction.Translate t:
+                    float tx = t.X.Unit == LengthUnit.Percent
+                        ? borderBox.Width * t.X.Value / 100f : t.X.Value;
+                    float ty = t.Y.Unit == LengthUnit.Percent
+                        ? borderBox.Height * t.Y.Value / 100f : t.Y.Value;
+                    _painter.Translate(tx, ty);
+                    break;
+                case TransformFunction.TranslateX t:
+                    float txVal = t.X.Unit == LengthUnit.Percent
+                        ? borderBox.Width * t.X.Value / 100f : t.X.Value;
+                    _painter.Translate(txVal, 0);
+                    break;
+                case TransformFunction.TranslateY t:
+                    float tyVal = t.Y.Unit == LengthUnit.Percent
+                        ? borderBox.Height * t.Y.Value / 100f : t.Y.Value;
+                    _painter.Translate(0, tyVal);
+                    break;
+                case TransformFunction.Rotate r:
+                    _painter.Rotate(r.Degrees);
+                    break;
+                case TransformFunction.Scale s:
+                    _painter.Scale(s.X, s.Y);
+                    break;
+                case TransformFunction.ScaleX s:
+                    _painter.Scale(s.X, 1f);
+                    break;
+                case TransformFunction.ScaleY s:
+                    _painter.Scale(1f, s.Y);
+                    break;
+                case TransformFunction.SkewX s:
+                    _painter.Skew(s.Degrees, 0);
+                    break;
+                case TransformFunction.SkewY s:
+                    _painter.Skew(0, s.Degrees);
+                    break;
+                case TransformFunction.Skew s:
+                    _painter.Skew(s.DegreesX, s.DegreesY);
+                    break;
+                case TransformFunction.Matrix m:
+                    var matrix = new SKMatrix(
+                        m.A, m.C, m.Tx,
+                        m.B, m.D, m.Ty,
+                        0, 0, 1);
+                    _painter.Concat(matrix);
+                    break;
+            }
+        }
+
+        _painter.Translate(-originX, -originY);
     }
 
     /// <summary>

--- a/tests/Miko.Tests/Animation/AnimationManagerTests.cs
+++ b/tests/Miko.Tests/Animation/AnimationManagerTests.cs
@@ -260,4 +260,104 @@ public class AnimationManagerTests
         element.Style!.BackgroundColor!.Value.R.ShouldBeInRange((byte)120, (byte)135);
         element.Style!.BackgroundColor!.Value.B.ShouldBeInRange((byte)120, (byte)135);
     }
+
+    [Fact]
+    public void TrackTransformChange_ShouldCreateTransition()
+    {
+        var element = new DivElement { Style = new Style() };
+        var transition = Transition.For(nameof(Style.Transform), 1f, TimingFunction.Linear);
+        var from = Transform.None;
+        var to = Transform.FromRotate(180f);
+
+        _manager.TrackTransformChange(element, from, to, transition);
+
+        _manager.HasActiveAnimations.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TrackTransformChange_ShouldInterpolateRotation()
+    {
+        var element = new DivElement { Style = new Style() };
+        var transition = Transition.For(nameof(Style.Transform), 1f, TimingFunction.Linear);
+        var from = Transform.FromRotate(0f);
+        var to = Transform.FromRotate(180f);
+
+        _manager.TrackTransformChange(element, from, to, transition);
+
+        _manager.Update(0.5f);
+
+        var transform = element.Style!.Transform!;
+        transform.Functions.Count.ShouldBe(1);
+        var rotate = transform.Functions[0].ShouldBeOfType<TransformFunction.Rotate>();
+        rotate.Degrees.ShouldBe(90f, 1f);
+    }
+
+    [Fact]
+    public void TrackTransformChange_ShouldCompleteAtEndValue()
+    {
+        var element = new DivElement { Style = new Style() };
+        var transition = Transition.For(nameof(Style.Transform), 1f, TimingFunction.Linear);
+        var from = Transform.FromRotate(0f);
+        var to = Transform.FromRotate(-180f);
+
+        _manager.TrackTransformChange(element, from, to, transition);
+
+        _manager.Update(1f);
+
+        var transform = element.Style!.Transform!;
+        var rotate = transform.Functions[0].ShouldBeOfType<TransformFunction.Rotate>();
+        rotate.Degrees.ShouldBe(-180f, 0.1f);
+        _manager.HasActiveAnimations.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LerpTransform_ShouldInterpolateScale()
+    {
+        var from = Transform.FromScale(1f, 1f);
+        var to = Transform.FromScale(2f, 3f);
+
+        var result = AnimationManager.LerpTransform(from, to, 0.5f);
+
+        result.Functions.Count.ShouldBe(1);
+        var scale = result.Functions[0].ShouldBeOfType<TransformFunction.Scale>();
+        scale.X.ShouldBe(1.5f, 0.01f);
+        scale.Y.ShouldBe(2f, 0.01f);
+    }
+
+    [Fact]
+    public void LerpTransform_FromNone_ShouldInterpolateFromIdentity()
+    {
+        var from = Transform.None;
+        var to = Transform.FromRotate(-180f);
+
+        var result = AnimationManager.LerpTransform(from, to, 0.5f);
+
+        result.Functions.Count.ShouldBe(1);
+        var rotate = result.Functions[0].ShouldBeOfType<TransformFunction.Rotate>();
+        rotate.Degrees.ShouldBe(-90f, 0.01f);
+    }
+
+    [Fact]
+    public void TrackTransformChangeWithApplier_ShouldInterpolate()
+    {
+        var element = new DivElement { Style = new Style() };
+        var transition = Transition.For("Transform", 1f, TimingFunction.Linear);
+        var from = Transform.None;
+        var to = Transform.FromRotate(-180f);
+
+        Transform? applied = null;
+        _manager.TrackTransformChangeWithApplier(element, "test.Transform", from, to, transition,
+            (e, t) => { applied = t; });
+
+        // Initial apply should be the start value
+        applied.ShouldNotBeNull();
+        applied!.Functions.Count.ShouldBe(0);
+
+        _manager.Update(0.5f);
+
+        applied.ShouldNotBeNull();
+        applied!.Functions.Count.ShouldBe(1);
+        var rotate = applied.Functions[0].ShouldBeOfType<TransformFunction.Rotate>();
+        rotate.Degrees.ShouldBe(-90f, 1f);
+    }
 }

--- a/tests/Miko.Tests/Rendering/TransformRenderingTests.cs
+++ b/tests/Miko.Tests/Rendering/TransformRenderingTests.cs
@@ -1,0 +1,332 @@
+using Miko.Animation;
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Rendering;
+using Miko.Styling;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Rendering;
+
+public class TransformRenderingTests : IDisposable
+{
+    private readonly SKBitmap _canvasBitmap;
+    private readonly SKCanvas _canvas;
+    private readonly RenderEngine _renderEngine;
+
+    public TransformRenderingTests()
+    {
+        _canvasBitmap = new SKBitmap(200, 200);
+        _canvas = new SKCanvas(_canvasBitmap);
+        _canvas.Clear(SKColors.White);
+        _renderEngine = new RenderEngine();
+        _renderEngine.SetCanvas(_canvas);
+    }
+
+    public void Dispose()
+    {
+        _canvas.Dispose();
+        _canvasBitmap.Dispose();
+    }
+
+    [Fact]
+    public void Rotate180_ShouldFlipElement()
+    {
+        var root = new DivElement();
+        root.Style = new Style
+        {
+            Width = Length.Px(100),
+            Height = Length.Px(100),
+            BackgroundColor = Color.Red,
+            Transform = Transform.FromRotate(180),
+        };
+
+        RenderElement(root);
+
+        // A 100x100 red box at (0,0) rotated 180 degrees around its center (50,50)
+        // maps the box to (-100,-100)-(0,0) relative to center, so it stays at (0,0)-(100,100)
+        // but the pixel at (10,10) in the original maps to (90,90) after rotation
+        // The center pixel should still be red
+        GetPixelColor(50, 50).ShouldBe(SKColors.Red);
+    }
+
+    [Fact]
+    public void Scale2x_ShouldEnlargeElement()
+    {
+        var root = new DivElement();
+        root.Style = new Style
+        {
+            Width = Length.Px(200),
+            Height = Length.Px(200),
+        };
+
+        var child = new DivElement();
+        child.Style = new Style
+        {
+            Width = Length.Px(40),
+            Height = Length.Px(40),
+            BackgroundColor = Color.Blue,
+            Transform = Transform.FromScale(2f, 2f),
+            TransformOrigin = TransformOrigin.TopLeft,
+        };
+        root.AddChild(child);
+
+        RenderElement(root);
+
+        // Scaled 2x from top-left: 40x40 becomes 80x80
+        GetPixelColor(10, 10).ShouldBe(SKColors.Blue);
+        GetPixelColor(70, 70).ShouldBe(SKColors.Blue);
+    }
+
+    [Fact]
+    public void TranslateTransform_ShouldMoveElement()
+    {
+        var root = new DivElement();
+        root.Style = new Style
+        {
+            Width = Length.Px(200),
+            Height = Length.Px(200),
+        };
+
+        var child = new DivElement();
+        child.Style = new Style
+        {
+            Width = Length.Px(40),
+            Height = Length.Px(40),
+            BackgroundColor = Color.Blue,
+            Transform = Transform.FromTranslate(Length.Px(50), Length.Px(50)),
+            TransformOrigin = TransformOrigin.TopLeft,
+        };
+        root.AddChild(child);
+
+        RenderElement(root);
+
+        // Element at (0,0) translated by (50,50) => drawn at (50,50)
+        GetPixelColor(60, 60).ShouldBe(SKColors.Blue);
+        // Original position should be empty (white)
+        GetPixelColor(5, 5).ShouldBe(SKColors.White);
+    }
+
+    [Fact]
+    public void NoTransform_ShouldRenderNormally()
+    {
+        var root = new DivElement();
+        root.Style = new Style
+        {
+            Width = Length.Px(100),
+            Height = Length.Px(100),
+            BackgroundColor = Color.Red,
+        };
+
+        RenderElement(root);
+
+        GetPixelColor(50, 50).ShouldBe(SKColors.Red);
+    }
+
+    private void RenderElement(Element root)
+    {
+        var engine = new MikoEngine();
+        engine.Initialize(root, [], _canvas, 200, 200);
+        engine.Render(_canvas);
+    }
+
+    [Fact]
+    public void PseudoElement_Transition_ShouldTriggerOnTransformChange()
+    {
+        var root = new DivElement { Class = "panel" };
+        root.Style = new Style
+        {
+            Width = Length.Px(100),
+            Height = Length.Px(100),
+        };
+
+        var afterStyle = new Style
+        {
+            Width = Length.Px(20),
+            Height = Length.Px(20),
+            BackgroundColor = Color.Red,
+            Transitions = [Transition.For(nameof(Style.Transform), 1f, TimingFunction.Linear)],
+        };
+
+        var styleSheet = new StyleSheet();
+        styleSheet.PseudoElementRules.Add(new PseudoElementRule
+        {
+            Selector = new Miko.Styling.Selectors.ClassSelector("panel"),
+            Type = PseudoElementType.After,
+            Style = afterStyle
+        });
+
+        var engine = new MikoEngine();
+        engine.Initialize(root, [styleSheet], _canvas, 200, 200);
+
+        // Now mutate the style to add Transform
+        afterStyle.Transform = Transform.FromRotate(-180);
+
+        root.IsDirty = true;
+        engine.Render(_canvas);
+
+        // Transition should have been triggered
+        engine.AnimationManager.HasActiveAnimations.ShouldBeTrue();
+
+        // After half the duration, the transform should be interpolated
+        engine.AnimationManager.Update(0.5f);
+
+        root.PseudoElementStyles.ShouldNotBeNull();
+        root.PseudoElementStyles!.ContainsKey(PseudoElementType.After).ShouldBeTrue();
+        var pseudoStyle = root.PseudoElementStyles[PseudoElementType.After];
+        pseudoStyle.Transform.ShouldNotBeNull();
+        pseudoStyle.Transform!.Functions.Count.ShouldBeGreaterThan(0);
+        var rotate = pseudoStyle.Transform.Functions[0]
+            .ShouldBeOfType<TransformFunction.Rotate>();
+        rotate.Degrees.ShouldBe(-90f, 1f);
+    }
+
+    [Fact]
+    public void PseudoElement_Transition_DirectApplier_ShouldWork()
+    {
+        var manager = new AnimationManager();
+        var parent = new DivElement { Style = new Style() };
+        var transition = Transition.For(nameof(Style.Transform), 1f, TimingFunction.Linear);
+        var from = Transform.None;
+        var to = Transform.FromRotate(-180f);
+
+        manager.TrackTransformChangeWithApplier(parent, "::pseudo(After).Transform", from, to, transition,
+            (e, t) =>
+            {
+                e.PseudoElementStyles ??= new();
+                if (!e.PseudoElementStyles.TryGetValue(PseudoElementType.After, out var s))
+                {
+                    s = new Style();
+                    e.PseudoElementStyles[PseudoElementType.After] = s;
+                }
+                s.Transform = t;
+            });
+
+        manager.HasActiveAnimations.ShouldBeTrue();
+
+        manager.Update(0.5f);
+
+        parent.PseudoElementStyles.ShouldNotBeNull();
+        var style = parent.PseudoElementStyles![PseudoElementType.After];
+        style.Transform.ShouldNotBeNull();
+        style.Transform!.Functions.Count.ShouldBe(1);
+        var r = style.Transform.Functions[0].ShouldBeOfType<TransformFunction.Rotate>();
+        r.Degrees.ShouldBe(-90f, 1f);
+    }
+
+    [Fact]
+    public void PseudoElement_Transition_ShouldTriggerOnReinitialize()
+    {
+        // Simulates Razor flow: Initialize is called with a new DOM tree on each StateHasChanged
+        var styleSheet = new StyleSheet();
+        styleSheet.PseudoElementRules.Add(new PseudoElementRule
+        {
+            Selector = new Miko.Styling.Selectors.ClassSelector("panel"),
+            Type = PseudoElementType.After,
+            Style = new Style
+            {
+                Width = Length.Px(20),
+                Height = Length.Px(20),
+                BackgroundColor = Color.Red,
+                Transitions = [Transition.For(nameof(Style.Transform), 1f, TimingFunction.Linear)],
+            }
+        });
+        styleSheet.PseudoElementRules.Add(new PseudoElementRule
+        {
+            Selector = new Miko.Styling.Selectors.ClassSelector("open"),
+            Type = PseudoElementType.After,
+            Style = new Style
+            {
+                Transform = Transform.FromRotate(-180),
+            }
+        });
+
+        // First Initialize: class="panel" (no .open, so no Transform)
+        var root1 = new DivElement { Class = "panel" };
+        root1.Style = new Style { Width = Length.Px(100), Height = Length.Px(100) };
+
+        var engine = new MikoEngine();
+        engine.Initialize(root1, [styleSheet], _canvas, 200, 200);
+
+        // Second Initialize: class="panel open" (now .open matches, Transform applied)
+        var root2 = new DivElement { Class = "panel open" };
+        root2.Style = new Style { Width = Length.Px(100), Height = Length.Px(100) };
+
+        engine.Initialize(root2, [styleSheet], _canvas, 200, 200);
+
+        // Transition should have been triggered
+        engine.AnimationManager.HasActiveAnimations.ShouldBeTrue();
+        engine.AnimationManager.ActiveTransitionCount.ShouldBeGreaterThan(0);
+
+        // After half the duration
+        engine.AnimationManager.Update(0.5f);
+
+        root2.PseudoElementStyles.ShouldNotBeNull();
+        root2.PseudoElementStyles!.ContainsKey(PseudoElementType.After).ShouldBeTrue();
+        var pseudoStyle = root2.PseudoElementStyles[PseudoElementType.After];
+        pseudoStyle.Transform.ShouldNotBeNull();
+        pseudoStyle.Transform!.Functions.Count.ShouldBeGreaterThan(0);
+        var rotate = pseudoStyle.Transform.Functions[0]
+            .ShouldBeOfType<TransformFunction.Rotate>();
+        rotate.Degrees.ShouldBe(-90f, 1f);
+    }
+
+    [Fact]
+    public void PseudoElement_Transition_ShouldTriggerOnClassChange()
+    {
+        // Simulates StateHasChanged flow: DOM is mutated in place, then Render is called
+        var styleSheet = new StyleSheet();
+        styleSheet.PseudoElementRules.Add(new PseudoElementRule
+        {
+            Selector = new Miko.Styling.Selectors.ClassSelector("panel"),
+            Type = PseudoElementType.After,
+            Style = new Style
+            {
+                Width = Length.Px(20),
+                Height = Length.Px(20),
+                Transitions = [Transition.For(nameof(Style.Transform), 1f, TimingFunction.Linear)],
+            }
+        });
+        styleSheet.PseudoElementRules.Add(new PseudoElementRule
+        {
+            Selector = new Miko.Styling.Selectors.ClassSelector("open"),
+            Type = PseudoElementType.After,
+            Style = new Style
+            {
+                Transform = Transform.FromRotate(-180),
+            }
+        });
+
+        var panel = new DivElement { Class = "panel" };
+        panel.Style = new Style { Width = Length.Px(100), Height = Length.Px(100) };
+        var root = new DivElement();
+        root.Style = new Style { Width = Length.Px(200), Height = Length.Px(200) };
+        root.AddChild(panel);
+
+        var engine = new MikoEngine();
+        engine.Initialize(root, [styleSheet], _canvas, 200, 200);
+
+        // Simulate StateHasChanged: change class in place
+        panel.Class = "panel open";
+        panel.IsDirty = true;
+
+        engine.Render(_canvas);
+
+        // Transition should have been triggered
+        engine.AnimationManager.HasActiveAnimations.ShouldBeTrue();
+
+        engine.AnimationManager.Update(0.5f);
+
+        panel.PseudoElementStyles.ShouldNotBeNull();
+        var pseudoStyle = panel.PseudoElementStyles![PseudoElementType.After];
+        pseudoStyle.Transform.ShouldNotBeNull();
+        pseudoStyle.Transform!.Functions.Count.ShouldBeGreaterThan(0);
+        var rotate = pseudoStyle.Transform.Functions[0]
+            .ShouldBeOfType<TransformFunction.Rotate>();
+        rotate.Degrees.ShouldBe(-90f, 1f);
+    }
+
+    private SKColor GetPixelColor(int x, int y) => _canvasBitmap.GetPixel(x, y);
+}


### PR DESCRIPTION
## Summary
- Apply Transform (Rotate/Scale/Translate/Skew/Matrix) to SkiaSharp canvas during rendering
- Add Transform interpolation for transitions with identity fallback for mismatched function counts
- Support Transition detection for `::before`/`::after` pseudo-elements across DOM rebuilds
- Fix `ComponentBase.TransferLayoutBox` to preserve pseudo-element children for `StateHasChanged` flow
- Preserve transition state across `Initialize` calls for navigation rebuild scenarios

## Changes
- **Painter.cs**: Add `Rotate`, `Scale`, `Skew`, `Concat` canvas methods
- **RenderEngine.cs**: Apply Transform in `RenderBox` with TransformOrigin support
- **AnimationManager.cs**: Add `LerpTransform`, `TrackTransformChangeWithApplier` and custom applier variants
- **MikoEngine.cs**: Refactor transition capture/detect to handle pseudo-elements; add `MapElementIdentityRecursive` for Initialize; add `TransformEquals` content comparison
- **LayoutEngine.cs**: Apply `PseudoElementStyles` override during pseudo-element creation; set `PseudoElement.Type`
- **ComponentBase.cs**: Transfer `LayoutBox.Children` in `TransferLayoutBox`
- **Element.cs**: Add `PseudoElementStyles` dictionary
- **PseudoElement.cs**: Add `Type` property

## Test plan
- [x] Transform rendering tests (Rotate, Scale, Translate)
- [x] Transform transition interpolation tests
- [x] Pseudo-element transition via direct applier
- [x] Pseudo-element transition via class change (StateHasChanged flow)
- [x] Pseudo-element transition via re-initialize (navigation flow)
- [x] All 665 existing tests pass with no regressions