### PR TITLE
Add core framework enhancements for Bootstrap component support

### DIFF
--- a/src/Miko.Razor.Compiler/Language/Components/ComponentWhitespacePass.cs
+++ b/src/Miko.Razor.Compiler/Language/Components/ComponentWhitespacePass.cs
@@ -155,6 +155,115 @@ internal sealed class ComponentWhitespacePass : ComponentIntermediateNodePassBas
         Backwards
     }
 
+    private static void TrimEdgeWhitespace(IntermediateNodeCollection nodes)
+    {
+        if (nodes.Count == 0)
+        {
+            return;
+        }
+
+        // Trim leading whitespace from the first content token
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            if (TrimLeadingWhitespaceInNode(nodes[i]))
+            {
+                break;
+            }
+        }
+
+        // Trim trailing whitespace from the last content token
+        for (var i = nodes.Count - 1; i >= 0; i--)
+        {
+            if (TrimTrailingWhitespaceInNode(nodes[i]))
+            {
+                break;
+            }
+        }
+    }
+
+    private static bool TrimLeadingWhitespaceInNode(IntermediateNode node)
+    {
+        if (node is HtmlContentIntermediateNode htmlContent)
+        {
+            for (var i = 0; i < htmlContent.Children.Count; i++)
+            {
+                if (htmlContent.Children[i] is IntermediateToken token && token.Content != null)
+                {
+                    var trimmed = token.Content.TrimStart();
+                    if (trimmed.Length == 0)
+                    {
+                        htmlContent.Children.RemoveAt(i);
+                        i--;
+                        continue;
+                    }
+
+                    if (trimmed.Length != token.Content.Length)
+                    {
+                        token.UpdateContent(trimmed);
+                    }
+                    return true;
+                }
+            }
+
+            return htmlContent.Children.Count == 0;
+        }
+
+        if (node is IntermediateToken directToken && directToken.Content != null)
+        {
+            var trimmed = directToken.Content.TrimStart();
+            if (trimmed.Length == 0)
+            {
+                return false;
+            }
+
+            directToken.UpdateContent(trimmed);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TrimTrailingWhitespaceInNode(IntermediateNode node)
+    {
+        if (node is HtmlContentIntermediateNode htmlContent)
+        {
+            for (var i = htmlContent.Children.Count - 1; i >= 0; i--)
+            {
+                if (htmlContent.Children[i] is IntermediateToken token && token.Content != null)
+                {
+                    var trimmed = token.Content.TrimEnd();
+                    if (trimmed.Length == 0)
+                    {
+                        htmlContent.Children.RemoveAt(i);
+                        continue;
+                    }
+
+                    if (trimmed.Length != token.Content.Length)
+                    {
+                        token.UpdateContent(trimmed);
+                    }
+                    return true;
+                }
+            }
+
+            return htmlContent.Children.Count == 0;
+        }
+
+        if (node is IntermediateToken directToken && directToken.Content != null)
+        {
+            var trimmed = directToken.Content.TrimEnd();
+            if (trimmed.Length == 0)
+            {
+                return false;
+            }
+
+            directToken.UpdateContent(trimmed);
+            return true;
+        }
+
+        return false;
+    }
+
     class Visitor : IntermediateNodeWalker
     {
         public override void VisitMethodDeclaration(MethodDeclarationIntermediateNode node)
@@ -168,15 +277,15 @@ internal sealed class ComponentWhitespacePass : ComponentIntermediateNodePassBas
         {
             RemoveContiguousWhitespace(node.Children, TraversalDirection.Forwards);
             RemoveContiguousWhitespace(node.Children, TraversalDirection.Backwards);
+            TrimEdgeWhitespace(node.Children);
             VisitDefault(node);
         }
 
         public override void VisitTagHelperBody(TagHelperBodyIntermediateNode node)
         {
-            // The goal here is to remove leading/trailing whitespace inside component child content. However,
-            // at the time this whitespace pass runs, ComponentChildContent is still TagHelperBody in the tree.
             RemoveContiguousWhitespace(node.Children, TraversalDirection.Forwards);
             RemoveContiguousWhitespace(node.Children, TraversalDirection.Backwards);
+            TrimEdgeWhitespace(node.Children);
             VisitDefault(node);
         }
 

--- a/src/Miko/Components/ComponentBase.cs
+++ b/src/Miko/Components/ComponentBase.cs
@@ -11,11 +11,30 @@ public abstract class ComponentBase : IComponent
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
     private Element? _rootElement;
+    private bool _initialized;
 
     protected virtual void BuildRenderTree(RenderTreeBuilder builder) { }
 
+    /// <summary>
+    /// Method invoked when the component is ready to start, having received its initial parameters.
+    /// </summary>
+    protected virtual void OnInitialized() { }
+
+    /// <summary>
+    /// Method invoked when the component has received parameters from its parent.
+    /// </summary>
+    protected virtual void OnParametersSet() { }
+
     public virtual Element Build()
     {
+        if (!_initialized)
+        {
+            OnInitialized();
+            _initialized = true;
+        }
+
+        OnParametersSet();
+
         var builder = new RenderTreeBuilder();
         BuildRenderTree(builder);
         _rootElement = builder.Build();

--- a/src/Miko/Components/RenderTreeBuilder.cs
+++ b/src/Miko/Components/RenderTreeBuilder.cs
@@ -44,6 +44,8 @@ public class RenderTreeBuilder
         ["tr"] = () => new TrElement(),
         ["th"] = () => new ThElement(),
         ["td"] = () => new TdElement(),
+        ["nav"] = () => new NavElement(),
+        ["strong"] = () => new StrongElement(),
     };
 
     public void OpenElement(int seq, string tagName)

--- a/src/Miko/Core/DomElements/ContainerElements.cs
+++ b/src/Miko/Core/DomElements/ContainerElements.cs
@@ -23,3 +23,19 @@ public class ParagraphElement : Element
 {
     public override string TagName => "p";
 }
+
+/// <summary>
+/// Nav 导航元素
+/// </summary>
+public class NavElement : Element
+{
+    public override string TagName => "nav";
+}
+
+/// <summary>
+/// Strong 加粗元素
+/// </summary>
+public class StrongElement : Element
+{
+    public override string TagName => "strong";
+}

--- a/src/Miko/Styling/ComputedStyle.cs
+++ b/src/Miko/Styling/ComputedStyle.cs
@@ -217,7 +217,7 @@ public class ComputedStyle : Style
             if (style.BackgroundPosition.HasValue) computed.BackgroundPosition = style.BackgroundPosition.Value;
             if (style.Color.HasValue) computed.Color = style.Color.Value;
             if (style.FontFamily != null) computed.FontFamily = style.FontFamily;
-            if (style.FontSize.HasValue) computed.FontSize = style.FontSize.Value;
+            if (style.FontSize.HasValue) computed.FontSize = Length.Px(style.FontSize.Value.ToPixels(0));
             if (style.FontWeight.HasValue) computed.FontWeight = style.FontWeight.Value;
             if (style.TextAlign.HasValue) computed.TextAlign = style.TextAlign.Value;
             if (style.LineHeight.HasValue) computed.LineHeight = style.LineHeight.Value;

--- a/src/Miko/Styling/Selectors/CssSelectorParser.cs
+++ b/src/Miko/Styling/Selectors/CssSelectorParser.cs
@@ -121,6 +121,7 @@ public static class CssSelectorParser
         "last-child" => new LastChildSelector(),
         "first-of-type" => new FirstOfTypeSelector(),
         "last-of-type" => new LastOfTypeSelector(),
+        "empty" => new EmptySelector(),
         _ => throw new ArgumentException($"Unknown pseudo-class: :{name}")
     };
 

--- a/src/Miko/Styling/Selectors/PseudoClassSelectors.cs
+++ b/src/Miko/Styling/Selectors/PseudoClassSelectors.cs
@@ -125,3 +125,14 @@ public class NotSelector : PseudoClassSelector
     public override bool Matches(Element element) => !_inner.Matches(element);
     public override int Specificity => _inner.Specificity;
 }
+
+/// <summary>
+/// :empty 伪类选择器 - 匹配没有子元素且没有文本内容的元素
+/// </summary>
+public class EmptySelector : PseudoClassSelector
+{
+    public override bool Matches(Element element)
+    {
+        return element.Children.Count == 0 && string.IsNullOrEmpty(element.TextContent);
+    }
+}

--- a/src/Miko/Styling/Selectors/SelectorParser.cs
+++ b/src/Miko/Styling/Selectors/SelectorParser.cs
@@ -82,6 +82,11 @@ public static class SelectorParser
         "focus" => new FocusSelector(),
         "disabled" => new DisabledSelector(),
         "enabled" => new EnabledSelector(),
+        "first-child" => new FirstChildSelector(),
+        "last-child" => new LastChildSelector(),
+        "first-of-type" => new FirstOfTypeSelector(),
+        "last-of-type" => new LastOfTypeSelector(),
+        "empty" => new EmptySelector(),
         _ => throw new ArgumentException($"Unknown pseudo-class: {name}")
     };
 }

--- a/src/Miko/Styling/StyleResolver.cs
+++ b/src/Miko/Styling/StyleResolver.cs
@@ -285,6 +285,13 @@ public class StyleResolver
                 style.TextDecoration ??= Common.TextDecoration.Underline;
                 break;
 
+            case "strong":
+            case "b":
+                // Browser default: display: inline, font-weight: bold
+                style.Display ??= Common.Display.Inline;
+                style.FontWeight ??= Common.FontWeight.Bold;
+                break;
+
             case "ul":
                 // Browser default: display: block, margin: 1em 0, padding-left: 40px
                 // list-style-type: disc (not implemented - visual bullets would need Painter support)

--- a/tests/Miko.Tests/Styling/FontSizeTests.cs
+++ b/tests/Miko.Tests/Styling/FontSizeTests.cs
@@ -1,0 +1,48 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Styling;
+using Shouldly;
+
+namespace Miko.Tests.Styling;
+
+public class FontSizeTests
+{
+    [Fact]
+    public void FontSize_Px_ShouldResolveToSameValue()
+    {
+        var element = new DivElement
+        {
+            Style = new Style { FontSize = Length.Px(20) }
+        };
+
+        var computed = new StyleResolver().Resolve(element, []);
+        computed.FontSize.Value.ShouldBe(20f);
+        computed.FontSize.Unit.ShouldBe(LengthUnit.Px);
+    }
+
+    [Fact]
+    public void FontSize_Rem_ShouldConvertToPixels()
+    {
+        var element = new DivElement
+        {
+            Style = new Style { FontSize = Length.Rem(1) }
+        };
+
+        var computed = new StyleResolver().Resolve(element, []);
+        computed.FontSize.Value.ShouldBe(16f);
+        computed.FontSize.Unit.ShouldBe(LengthUnit.Px);
+    }
+
+    [Fact]
+    public void FontSize_Rem_2_ShouldConvertTo32Pixels()
+    {
+        var element = new DivElement
+        {
+            Style = new Style { FontSize = Length.Rem(2) }
+        };
+
+        var computed = new StyleResolver().Resolve(element, []);
+        computed.FontSize.Value.ShouldBe(32f);
+        computed.FontSize.Unit.ShouldBe(LengthUnit.Px);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ComponentBase` lifecycle methods (`OnInitialized`, `OnParametersSet`) for component initialization
- Add `nav` and `strong` HTML element support with default browser styles
- Add `:empty` pseudo-class selector implementation across all selector parsers
- Fix Razor compiler whitespace trimming — text content in components no longer preserves leading/trailing whitespace from indentation
- Fix `FontSize` Rem unit conversion in `ComputedStyle` resolution

## Test plan

- [x] All 668 existing tests pass
- [x] New `FontSizeTests` verify Px and Rem unit conversion
- [x] Solution builds cleanly (`dotnet build miko.slnx`)