### PR TITLE
Add CSS custom properties (variables) with StyleProperty<T> union type

### DIFF
--- a/examples/MikoApp1/Components/BootstrapStyles.cs
+++ b/examples/MikoApp1/Components/BootstrapStyles.cs
@@ -68,7 +68,7 @@ public static class BootstrapStyles
                 Display = Display.InlineBlock,
                 Padding = new Padding(6, 12),
                 Margin = new Margin(0, 10, 10, 0),
-                FontSize = 14,
+                FontSize = Length.Px(14),
                 FontWeight = FontWeight.Normal,
                 Border = new Border(1, BorderStyle.Solid, Color.Transparent),
                 BorderRadius = new BorderRadius(4),
@@ -395,7 +395,7 @@ public static class BootstrapStyles
                 Display = Display.Flex,
                 FlexGrow = 1,
                 FlexShrink = 1,
-                FlexBasis = 0
+                FlexBasis = Length.Px(0)
             }
         );
 
@@ -447,7 +447,7 @@ public static class BootstrapStyles
                 Display = Display.Block,
                 FlexGrow = 1,
                 FlexShrink = 1,
-                FlexBasis = 0,
+                FlexBasis = Length.Px(0),
                 PaddingRight = Length.Px(15),
                 PaddingLeft = Length.Px(15)
             }
@@ -645,7 +645,7 @@ public static class BootstrapStyles
                 Display = Display.Block,
                 FlexGrow = 1,
                 FlexShrink = 1,
-                FlexBasis = 0,
+                FlexBasis = Length.Px(0),
                 PaddingTop = Length.Px(12),
                 PaddingRight = Length.Px(12),
                 PaddingBottom = Length.Px(12),
@@ -663,7 +663,7 @@ public static class BootstrapStyles
                 Display = Display.Block,
                 FlexGrow = 1,
                 FlexShrink = 1,
-                FlexBasis = 0,
+                FlexBasis = Length.Px(0),
                 PaddingTop = Length.Px(12),
                 PaddingRight = Length.Px(12),
                 PaddingBottom = Length.Px(12),

--- a/src/Miko.Bootstrap/Components/Badge/BadgeStyles.cs
+++ b/src/Miko.Bootstrap/Components/Badge/BadgeStyles.cs
@@ -54,7 +54,7 @@ internal static class BadgeStyles
                 Padding = new Padding(t.BadgePaddingY, t.BadgePaddingX),
                 FontSize = t.BadgeFontSize,
                 FontWeight = t.BadgeFontWeight,
-                LineHeight = 1,
+                LineHeight = Length.Px(1),
                 Color = t.BadgeColor,
                 TextAlign = TextAlign.Center,
                 // NOTE: white-space: nowrap not supported in CssObject

--- a/src/Miko.Bootstrap/Components/Button/ButtonStyles.cs
+++ b/src/Miko.Bootstrap/Components/Button/ButtonStyles.cs
@@ -163,7 +163,7 @@ internal static class ButtonStyles
                 Padding = new Padding(t.BtnPaddingY, t.BtnPaddingX),
                 FontSize = t.BtnFontSize,
                 FontWeight = t.BtnFontWeight,
-                LineHeight = t.BtnLineHeight,
+                LineHeight = Length.Px(t.BtnLineHeight),
                 Color = t.BtnColor,
                 TextAlign = TextAlign.Center,
                 // NOTE: white-space, vertical-align, cursor, user-select not supported

--- a/src/Miko.Bootstrap/Components/Card/CardStyles.cs
+++ b/src/Miko.Bootstrap/Components/Card/CardStyles.cs
@@ -83,8 +83,8 @@ internal static class CardStyles
 
                 ["&:first-child"] = new()
                 {
-                    BorderTopLeftRadius = t.CardInnerBorderRadius,
-                    BorderTopRightRadius = t.CardInnerBorderRadius
+                    BorderTopLeftRadius = Length.Px(t.CardInnerBorderRadius),
+                    BorderTopRightRadius = Length.Px(t.CardInnerBorderRadius)
                 }
             },
 
@@ -96,8 +96,8 @@ internal static class CardStyles
 
                 ["&:last-child"] = new()
                 {
-                    BorderBottomLeftRadius = t.CardInnerBorderRadius,
-                    BorderBottomRightRadius = t.CardInnerBorderRadius
+                    BorderBottomLeftRadius = Length.Px(t.CardInnerBorderRadius),
+                    BorderBottomRightRadius = Length.Px(t.CardInnerBorderRadius)
                 }
             },
 
@@ -108,14 +108,14 @@ internal static class CardStyles
 
             [".card-img, .card-img-top"] = new()
             {
-                BorderTopLeftRadius = t.CardInnerBorderRadius,
-                BorderTopRightRadius = t.CardInnerBorderRadius
+                BorderTopLeftRadius = Length.Px(t.CardInnerBorderRadius),
+                BorderTopRightRadius = Length.Px(t.CardInnerBorderRadius)
             },
 
             [".card-img, .card-img-bottom"] = new()
             {
-                BorderBottomLeftRadius = t.CardInnerBorderRadius,
-                BorderBottomRightRadius = t.CardInnerBorderRadius
+                BorderBottomLeftRadius = Length.Px(t.CardInnerBorderRadius),
+                BorderBottomRightRadius = Length.Px(t.CardInnerBorderRadius)
             }
         };
     }

--- a/src/Miko.Bootstrap/Components/Form/FormStyles.cs
+++ b/src/Miko.Bootstrap/Components/Form/FormStyles.cs
@@ -124,7 +124,7 @@ internal static class FormStyles
                 Width = Length.Percent(100),
                 Padding = new Padding(t.InputPaddingY, t.InputPaddingX),
                 FontSize = t.InputFontSize,
-                LineHeight = t.InputLineHeight,
+                LineHeight = Length.Px(t.InputLineHeight),
                 Color = t.InputColor,
                 BackgroundColor = t.InputBg,
                 Border = new Border(Length.Px(t.InputBorderWidth), BorderStyle.Solid, t.InputBorderColor),
@@ -165,7 +165,7 @@ internal static class FormStyles
                 Width = Length.Percent(100),
                 Padding = new Padding(t.InputPaddingY, Length.Rem(2.25f), t.InputPaddingY, t.InputPaddingX),
                 FontSize = t.InputFontSize,
-                LineHeight = t.InputLineHeight,
+                LineHeight = Length.Px(t.InputLineHeight),
                 Color = t.InputColor,
                 BackgroundColor = t.InputBg,
                 Border = new Border(Length.Px(t.InputBorderWidth), BorderStyle.Solid, t.InputBorderColor),
@@ -259,7 +259,7 @@ internal static class FormStyles
                 {
                     Position = Position.Relative,
                     FlexGrow = 1,
-                    FlexBasis = 0,
+                    FlexBasis = Length.Px(0),
                     MinWidth = Length.Px(0)
                 },
 
@@ -267,7 +267,7 @@ internal static class FormStyles
                 {
                     Position = Position.Relative,
                     FlexGrow = 1,
-                    FlexBasis = 0,
+                    FlexBasis = Length.Px(0),
                     MinWidth = Length.Px(0)
                 }
             },

--- a/src/Miko.Bootstrap/Components/Grid/GridStyles.cs
+++ b/src/Miko.Bootstrap/Components/Grid/GridStyles.cs
@@ -50,7 +50,7 @@ internal static class GridStyles
             [".col"] = new()
             {
                 FlexGrow = 1,
-                FlexBasis = 0,
+                FlexBasis = Length.Px(0),
                 MaxWidth = Length.Percent(100),
                 PaddingRight = t.ContainerPaddingX,
                 PaddingLeft = t.ContainerPaddingX

--- a/src/Miko.Bootstrap/Components/List/ListStyles.cs
+++ b/src/Miko.Bootstrap/Components/List/ListStyles.cs
@@ -61,14 +61,14 @@ internal static class ListStyles
 
                 ["&:first-child"] = new()
                 {
-                    BorderTopLeftRadius = t.ListGroupBorderRadius,
-                    BorderTopRightRadius = t.ListGroupBorderRadius
+                    BorderTopLeftRadius = Length.Px(t.ListGroupBorderRadius),
+                    BorderTopRightRadius = Length.Px(t.ListGroupBorderRadius)
                 },
 
                 ["&:last-child"] = new()
                 {
-                    BorderBottomLeftRadius = t.ListGroupBorderRadius,
-                    BorderBottomRightRadius = t.ListGroupBorderRadius
+                    BorderBottomLeftRadius = Length.Px(t.ListGroupBorderRadius),
+                    BorderBottomRightRadius = Length.Px(t.ListGroupBorderRadius)
                 }
             },
 

--- a/src/Miko.Bootstrap/Components/Pagination/PaginationStyles.cs
+++ b/src/Miko.Bootstrap/Components/Pagination/PaginationStyles.cs
@@ -84,14 +84,14 @@ internal static class PaginationStyles
 
             [".page-item:first-child .page-link"] = new()
             {
-                BorderTopLeftRadius = t.PaginationBorderRadius,
-                BorderBottomLeftRadius = t.PaginationBorderRadius
+                BorderTopLeftRadius = Length.Px(t.PaginationBorderRadius),
+                BorderBottomLeftRadius = Length.Px(t.PaginationBorderRadius)
             },
 
             [".page-item:last-child .page-link"] = new()
             {
-                BorderTopRightRadius = t.PaginationBorderRadius,
-                BorderBottomRightRadius = t.PaginationBorderRadius
+                BorderTopRightRadius = Length.Px(t.PaginationBorderRadius),
+                BorderBottomRightRadius = Length.Px(t.PaginationBorderRadius)
             }
         };
     }

--- a/src/Miko.Bootstrap/Components/Tab/TabStyles.cs
+++ b/src/Miko.Bootstrap/Components/Tab/TabStyles.cs
@@ -71,8 +71,8 @@ internal static class TabStyles
             {
                 MarginBottom = Length.Px(-t.NavTabsBorderWidth),
                 Border = new Border(Length.Px(t.NavTabsBorderWidth), BorderStyle.Solid, Color.Transparent),
-                BorderTopLeftRadius = t.NavTabsBorderRadius,
-                BorderTopRightRadius = t.NavTabsBorderRadius
+                BorderTopLeftRadius = Length.Px(t.NavTabsBorderRadius),
+                BorderTopRightRadius = Length.Px(t.NavTabsBorderRadius)
             },
 
             [".nav-tabs .nav-link.active"] = new()

--- a/src/Miko.Bootstrap/Styles/RebootStyles.cs
+++ b/src/Miko.Bootstrap/Styles/RebootStyles.cs
@@ -33,7 +33,7 @@ internal static class RebootStyles
             {
                 FontSize = Length.Px(40),
                 FontWeight = FontWeight.Medium,
-                LineHeight = 1.2f,
+                LineHeight = Length.Px(1.2f),
                 MarginTop = Length.Px(0),
                 MarginBottom = Length.Rem(0.5f),
                 Color = t.HeadingColor
@@ -42,7 +42,7 @@ internal static class RebootStyles
             {
                 FontSize = Length.Px(32),
                 FontWeight = FontWeight.Medium,
-                LineHeight = 1.2f,
+                LineHeight = Length.Px(1.2f),
                 MarginTop = Length.Px(0),
                 MarginBottom = Length.Rem(0.5f),
                 Color = t.HeadingColor
@@ -51,7 +51,7 @@ internal static class RebootStyles
             {
                 FontSize = Length.Px(28),
                 FontWeight = FontWeight.Medium,
-                LineHeight = 1.2f,
+                LineHeight = Length.Px(1.2f),
                 MarginTop = Length.Px(0),
                 MarginBottom = Length.Rem(0.5f),
                 Color = t.HeadingColor
@@ -60,7 +60,7 @@ internal static class RebootStyles
             {
                 FontSize = Length.Px(24),
                 FontWeight = FontWeight.Medium,
-                LineHeight = 1.2f,
+                LineHeight = Length.Px(1.2f),
                 MarginTop = Length.Px(0),
                 MarginBottom = Length.Rem(0.5f),
                 Color = t.HeadingColor
@@ -69,7 +69,7 @@ internal static class RebootStyles
             {
                 FontSize = Length.Px(20),
                 FontWeight = FontWeight.Medium,
-                LineHeight = 1.2f,
+                LineHeight = Length.Px(1.2f),
                 MarginTop = Length.Px(0),
                 MarginBottom = Length.Rem(0.5f),
                 Color = t.HeadingColor
@@ -78,7 +78,7 @@ internal static class RebootStyles
             {
                 FontSize = Length.Px(16),
                 FontWeight = FontWeight.Medium,
-                LineHeight = 1.2f,
+                LineHeight = Length.Px(1.2f),
                 MarginTop = Length.Px(0),
                 MarginBottom = Length.Rem(0.5f),
                 Color = t.HeadingColor
@@ -162,7 +162,7 @@ internal static class RebootStyles
             ["input, button, select, textarea"] = new()
             {
                 Margin = new Margin(0),
-                LineHeight = 1.5f
+                LineHeight = Length.Px(1.5f)
             },
         };
     }

--- a/src/Miko.Bootstrap/Styles/UtilitiesStyle.cs
+++ b/src/Miko.Bootstrap/Styles/UtilitiesStyle.cs
@@ -209,10 +209,10 @@ internal static class UtilitiesStyle
             [".fw-bolder"] = new() { FontWeight = FontWeight.Bolder },
 
             // Line height
-            [".lh-1"] = new() { LineHeight = 1f },
-            [".lh-sm"] = new() { LineHeight = 1.25f },
-            [".lh-base"] = new() { LineHeight = 1.5f },
-            [".lh-lg"] = new() { LineHeight = 2f },
+            [".lh-1"] = new() { LineHeight = Length.Px(1f) },
+            [".lh-sm"] = new() { LineHeight = Length.Px(1.25f) },
+            [".lh-base"] = new() { LineHeight = Length.Px(1.5f) },
+            [".lh-lg"] = new() { LineHeight = Length.Px(2f) },
 
             // Text color
             [".text-primary"] = new() { Color = t.Primary },
@@ -274,31 +274,31 @@ internal static class UtilitiesStyle
             [".rounded-pill"] = new() { BorderRadius = t.BorderRadiusPill },
             [".rounded-top"] = new()
             {
-                BorderTopLeftRadius = t.BorderRadius,
-                BorderTopRightRadius = t.BorderRadius,
-                BorderBottomLeftRadius = 0,
-                BorderBottomRightRadius = 0
+                BorderTopLeftRadius = Length.Px(t.BorderRadius),
+                BorderTopRightRadius = Length.Px(t.BorderRadius),
+                BorderBottomLeftRadius = Length.Px(0),
+                BorderBottomRightRadius = Length.Px(0)
             },
             [".rounded-end"] = new()
             {
-                BorderTopRightRadius = t.BorderRadius,
-                BorderBottomRightRadius = t.BorderRadius,
-                BorderTopLeftRadius = 0,
-                BorderBottomLeftRadius = 0
+                BorderTopRightRadius = Length.Px(t.BorderRadius),
+                BorderBottomRightRadius = Length.Px(t.BorderRadius),
+                BorderTopLeftRadius = Length.Px(0),
+                BorderBottomLeftRadius = Length.Px(0)
             },
             [".rounded-bottom"] = new()
             {
-                BorderBottomLeftRadius = t.BorderRadius,
-                BorderBottomRightRadius = t.BorderRadius,
-                BorderTopLeftRadius = 0,
-                BorderTopRightRadius = 0
+                BorderBottomLeftRadius = Length.Px(t.BorderRadius),
+                BorderBottomRightRadius = Length.Px(t.BorderRadius),
+                BorderTopLeftRadius = Length.Px(0),
+                BorderTopRightRadius = Length.Px(0)
             },
             [".rounded-start"] = new()
             {
-                BorderTopLeftRadius = t.BorderRadius,
-                BorderBottomLeftRadius = t.BorderRadius,
-                BorderTopRightRadius = 0,
-                BorderBottomRightRadius = 0
+                BorderTopLeftRadius = Length.Px(t.BorderRadius),
+                BorderBottomLeftRadius = Length.Px(t.BorderRadius),
+                BorderTopRightRadius = Length.Px(0),
+                BorderBottomRightRadius = Length.Px(0)
             },
 
             // User select

--- a/src/Miko/Animation/AnimationManager.cs
+++ b/src/Miko/Animation/AnimationManager.cs
@@ -456,28 +456,15 @@ public class AnimationManager
     {
         element.Style ??= new Style();
 
-        if (from.Opacity.HasValue || to.Opacity.HasValue)
+        if (from.Opacity != null || to.Opacity != null)
         {
-            float fromVal = from.Opacity ?? 1f;
-            float toVal = to.Opacity ?? 1f;
+            float fromVal = from.Opacity?.Value ?? 1f;
+            float toVal = to.Opacity?.Value ?? 1f;
             element.Style.Opacity = Lerp(fromVal, toVal, progress);
         }
 
-        if (from.Width.HasValue || to.Width.HasValue)
-        {
-            var fromVal = from.Width ?? Length.Px(0);
-            var toVal = to.Width ?? Length.Px(0);
-            if (fromVal.Unit == toVal.Unit && !fromVal.IsAuto && !toVal.IsAuto)
-                element.Style.Width = new Length(Lerp(fromVal.Value, toVal.Value, progress), fromVal.Unit);
-        }
-
-        if (from.Height.HasValue || to.Height.HasValue)
-        {
-            var fromVal = from.Height ?? Length.Px(0);
-            var toVal = to.Height ?? Length.Px(0);
-            if (fromVal.Unit == toVal.Unit && !fromVal.IsAuto && !toVal.IsAuto)
-                element.Style.Height = new Length(Lerp(fromVal.Value, toVal.Value, progress), fromVal.Unit);
-        }
+        InterpolateLengthProperty(element, from.Width, to.Width, progress, (s, v) => s.Width = v);
+        InterpolateLengthProperty(element, from.Height, to.Height, progress, (s, v) => s.Height = v);
 
         InterpolateLengthProperty(element, from.MarginTop, to.MarginTop, progress, (s, v) => s.MarginTop = v);
         InterpolateLengthProperty(element, from.MarginRight, to.MarginRight, progress, (s, v) => s.MarginRight = v);
@@ -502,24 +489,24 @@ public class AnimationManager
         InterpolateLengthProperty(element, from.BorderBottomRightRadius, to.BorderBottomRightRadius, progress, (s, v) => s.BorderBottomRightRadius = v);
         InterpolateLengthProperty(element, from.BorderBottomLeftRadius, to.BorderBottomLeftRadius, progress, (s, v) => s.BorderBottomLeftRadius = v);
 
-        if (from.BackgroundColor.HasValue || to.BackgroundColor.HasValue)
+        if (from.BackgroundColor != null || to.BackgroundColor != null)
         {
-            var fromColor = from.BackgroundColor ?? Color.Transparent;
-            var toColor = to.BackgroundColor ?? Color.Transparent;
+            var fromColor = from.BackgroundColor?.Value ?? Color.Transparent;
+            var toColor = to.BackgroundColor?.Value ?? Color.Transparent;
             element.Style.BackgroundColor = LerpColor(fromColor, toColor, progress);
         }
 
-        if (from.Color.HasValue || to.Color.HasValue)
+        if (from.Color != null || to.Color != null)
         {
-            var fromColor = from.Color ?? Color.Black;
-            var toColor = to.Color ?? Color.Black;
+            var fromColor = from.Color?.Value ?? Color.Black;
+            var toColor = to.Color?.Value ?? Color.Black;
             element.Style.Color = LerpColor(fromColor, toColor, progress);
         }
 
-        if (from.BorderColor.HasValue || to.BorderColor.HasValue)
+        if (from.BorderColor != null || to.BorderColor != null)
         {
-            var fromColor = from.BorderColor ?? Color.Transparent;
-            var toColor = to.BorderColor ?? Color.Transparent;
+            var fromColor = from.BorderColor?.Value ?? Color.Transparent;
+            var toColor = to.BorderColor?.Value ?? Color.Transparent;
             element.Style.BorderColor = LerpColor(fromColor, toColor, progress);
         }
 
@@ -531,11 +518,11 @@ public class AnimationManager
         }
     }
 
-    private static void InterpolateLengthProperty(Element element, Length? from, Length? to, float progress, Action<Style, Length> setter)
+    private static void InterpolateLengthProperty(Element element, StyleProperty<Length>? from, StyleProperty<Length>? to, float progress, Action<Style, Length> setter)
     {
-        if (!from.HasValue && !to.HasValue) return;
-        var fromVal = from ?? Length.Px(0);
-        var toVal = to ?? Length.Px(0);
+        if (from == null && to == null) return;
+        var fromVal = from?.Value ?? Length.Px(0);
+        var toVal = to?.Value ?? Length.Px(0);
         if (fromVal.Unit != toVal.Unit || fromVal.IsAuto || toVal.IsAuto) return;
         setter(element.Style!, new Length(Lerp(fromVal.Value, toVal.Value, progress), fromVal.Unit));
     }

--- a/src/Miko/Layout/LayoutEngine.cs
+++ b/src/Miko/Layout/LayoutEngine.cs
@@ -43,9 +43,10 @@ public class LayoutEngine
     /// <summary>
     /// 计算所有元素的样式
     /// </summary>
-    private void ComputeStyles(Element element, List<StyleSheet> styleSheets, ViewportInfo viewport)
+    private void ComputeStyles(Element element, List<StyleSheet> styleSheets, ViewportInfo viewport,
+        CustomPropertyScope? parentScope = null)
     {
-        var computedStyle = _styleResolver.Resolve(element, styleSheets, viewport);
+        var computedStyle = _styleResolver.Resolve(element, styleSheets, viewport, parentScope);
 
         // 创建布局盒子并关联
         element.LayoutBox = new LayoutBox
@@ -54,10 +55,11 @@ public class LayoutEngine
             ComputedStyle = computedStyle
         };
 
-        // 递归处理子元素
+        // 递归处理子元素，传递当前元素的自定义属性作用域
+        var childScope = computedStyle.CustomPropertyScope;
         foreach (var child in element.Children)
         {
-            ComputeStyles(child, styleSheets, viewport);
+            ComputeStyles(child, styleSheets, viewport, childScope);
         }
     }
 

--- a/src/Miko/Styling/ComputedStyle.cs
+++ b/src/Miko/Styling/ComputedStyle.cs
@@ -106,6 +106,8 @@ public class ComputedStyle : Style
 
     public new string? Content { get; set; }
 
+    internal CustomPropertyScope? CustomPropertyScope { get; set; }
+
     /// <summary>
     /// 从样式对象创建计算样式
     /// </summary>
@@ -115,136 +117,136 @@ public class ComputedStyle : Style
 
         if (style != null)
         {
-            if (style.Display.HasValue) computed.Display = style.Display.Value;
-            if (style.BoxSizing.HasValue) computed.BoxSizing = style.BoxSizing.Value;
-            if (style.FlexDirection.HasValue) computed.FlexDirection = style.FlexDirection.Value;
-            if (style.JustifyContent.HasValue) computed.JustifyContent = style.JustifyContent.Value;
-            if (style.AlignItems.HasValue) computed.AlignItems = style.AlignItems.Value;
+            if (style.Display?.TryGetValue(out var display) == true) computed.Display = display;
+            if (style.BoxSizing?.TryGetValue(out var boxSizing) == true) computed.BoxSizing = boxSizing;
+            if (style.FlexDirection?.TryGetValue(out var flexDirection) == true) computed.FlexDirection = flexDirection;
+            if (style.JustifyContent?.TryGetValue(out var justifyContent) == true) computed.JustifyContent = justifyContent;
+            if (style.AlignItems?.TryGetValue(out var alignItems) == true) computed.AlignItems = alignItems;
 
-            if (style.FlexGrow.HasValue) computed.FlexGrow = style.FlexGrow.Value;
-            if (style.FlexShrink.HasValue) computed.FlexShrink = style.FlexShrink.Value;
-            if (style.FlexBasis.HasValue) computed.FlexBasis = style.FlexBasis.Value;
+            if (style.FlexGrow?.TryGetValue(out var flexGrow) == true) computed.FlexGrow = flexGrow;
+            if (style.FlexShrink?.TryGetValue(out var flexShrink) == true) computed.FlexShrink = flexShrink;
+            if (style.FlexBasis?.TryGetValue(out var flexBasis) == true) computed.FlexBasis = flexBasis;
 
-            if (style.Width.HasValue) computed.Width = style.Width.Value;
-            if (style.Height.HasValue) computed.Height = style.Height.Value;
-            if (style.MinWidth.HasValue) computed.MinWidth = style.MinWidth.Value;
-            if (style.MinHeight.HasValue) computed.MinHeight = style.MinHeight.Value;
-            if (style.MaxWidth.HasValue) computed.MaxWidth = style.MaxWidth.Value;
-            if (style.MaxHeight.HasValue) computed.MaxHeight = style.MaxHeight.Value;
+            if (style.Width?.TryGetValue(out var width) == true) computed.Width = width;
+            if (style.Height?.TryGetValue(out var height) == true) computed.Height = height;
+            if (style.MinWidth?.TryGetValue(out var minWidth) == true) computed.MinWidth = minWidth;
+            if (style.MinHeight?.TryGetValue(out var minHeight) == true) computed.MinHeight = minHeight;
+            if (style.MaxWidth?.TryGetValue(out var maxWidth) == true) computed.MaxWidth = maxWidth;
+            if (style.MaxHeight?.TryGetValue(out var maxHeight) == true) computed.MaxHeight = maxHeight;
 
-            if (style.PaddingTop.HasValue) computed.PaddingTop = style.PaddingTop.Value;
-            if (style.PaddingRight.HasValue) computed.PaddingRight = style.PaddingRight.Value;
-            if (style.PaddingBottom.HasValue) computed.PaddingBottom = style.PaddingBottom.Value;
-            if (style.PaddingLeft.HasValue) computed.PaddingLeft = style.PaddingLeft.Value;
+            if (style.PaddingTop?.TryGetValue(out var paddingTop) == true) computed.PaddingTop = paddingTop;
+            if (style.PaddingRight?.TryGetValue(out var paddingRight) == true) computed.PaddingRight = paddingRight;
+            if (style.PaddingBottom?.TryGetValue(out var paddingBottom) == true) computed.PaddingBottom = paddingBottom;
+            if (style.PaddingLeft?.TryGetValue(out var paddingLeft) == true) computed.PaddingLeft = paddingLeft;
 
-            if (style.MarginTop.HasValue) computed.MarginTop = style.MarginTop.Value;
-            if (style.MarginRight.HasValue) computed.MarginRight = style.MarginRight.Value;
-            if (style.MarginBottom.HasValue) computed.MarginBottom = style.MarginBottom.Value;
-            if (style.MarginLeft.HasValue) computed.MarginLeft = style.MarginLeft.Value;
+            if (style.MarginTop?.TryGetValue(out var marginTop) == true) computed.MarginTop = marginTop;
+            if (style.MarginRight?.TryGetValue(out var marginRight) == true) computed.MarginRight = marginRight;
+            if (style.MarginBottom?.TryGetValue(out var marginBottom) == true) computed.MarginBottom = marginBottom;
+            if (style.MarginLeft?.TryGetValue(out var marginLeft) == true) computed.MarginLeft = marginLeft;
 
             // 边框宽度：单边属性 > 统一属性 > 默认值
-            if (style.BorderTopWidth.HasValue)
-                computed.BorderTopWidth = style.BorderTopWidth.Value;
-            else if (style.BorderWidth.HasValue)
-                computed.BorderTopWidth = style.BorderWidth.Value;
+            if (style.BorderTopWidth?.TryGetValue(out var borderTopWidth) == true)
+                computed.BorderTopWidth = borderTopWidth;
+            else if (style.BorderWidth?.TryGetValue(out var bwTop) == true)
+                computed.BorderTopWidth = bwTop;
 
-            if (style.BorderRightWidth.HasValue)
-                computed.BorderRightWidth = style.BorderRightWidth.Value;
-            else if (style.BorderWidth.HasValue)
-                computed.BorderRightWidth = style.BorderWidth.Value;
+            if (style.BorderRightWidth?.TryGetValue(out var borderRightWidth) == true)
+                computed.BorderRightWidth = borderRightWidth;
+            else if (style.BorderWidth?.TryGetValue(out var bwRight) == true)
+                computed.BorderRightWidth = bwRight;
 
-            if (style.BorderBottomWidth.HasValue)
-                computed.BorderBottomWidth = style.BorderBottomWidth.Value;
-            else if (style.BorderWidth.HasValue)
-                computed.BorderBottomWidth = style.BorderWidth.Value;
+            if (style.BorderBottomWidth?.TryGetValue(out var borderBottomWidth) == true)
+                computed.BorderBottomWidth = borderBottomWidth;
+            else if (style.BorderWidth?.TryGetValue(out var bwBottom) == true)
+                computed.BorderBottomWidth = bwBottom;
 
-            if (style.BorderLeftWidth.HasValue)
-                computed.BorderLeftWidth = style.BorderLeftWidth.Value;
-            else if (style.BorderWidth.HasValue)
-                computed.BorderLeftWidth = style.BorderWidth.Value;
+            if (style.BorderLeftWidth?.TryGetValue(out var borderLeftWidth) == true)
+                computed.BorderLeftWidth = borderLeftWidth;
+            else if (style.BorderWidth?.TryGetValue(out var bwLeft) == true)
+                computed.BorderLeftWidth = bwLeft;
 
             // 边框颜色：单边属性 > 统一属性 > 默认值
-            if (style.BorderTopColor.HasValue)
-                computed.BorderTopColor = style.BorderTopColor.Value;
-            else if (style.BorderColor.HasValue)
-                computed.BorderTopColor = style.BorderColor.Value;
+            if (style.BorderTopColor?.TryGetValue(out var borderTopColor) == true)
+                computed.BorderTopColor = borderTopColor;
+            else if (style.BorderColor?.TryGetValue(out var bcTop) == true)
+                computed.BorderTopColor = bcTop;
 
-            if (style.BorderRightColor.HasValue)
-                computed.BorderRightColor = style.BorderRightColor.Value;
-            else if (style.BorderColor.HasValue)
-                computed.BorderRightColor = style.BorderColor.Value;
+            if (style.BorderRightColor?.TryGetValue(out var borderRightColor) == true)
+                computed.BorderRightColor = borderRightColor;
+            else if (style.BorderColor?.TryGetValue(out var bcRight) == true)
+                computed.BorderRightColor = bcRight;
 
-            if (style.BorderBottomColor.HasValue)
-                computed.BorderBottomColor = style.BorderBottomColor.Value;
-            else if (style.BorderColor.HasValue)
-                computed.BorderBottomColor = style.BorderColor.Value;
+            if (style.BorderBottomColor?.TryGetValue(out var borderBottomColor) == true)
+                computed.BorderBottomColor = borderBottomColor;
+            else if (style.BorderColor?.TryGetValue(out var bcBottom) == true)
+                computed.BorderBottomColor = bcBottom;
 
-            if (style.BorderLeftColor.HasValue)
-                computed.BorderLeftColor = style.BorderLeftColor.Value;
-            else if (style.BorderColor.HasValue)
-                computed.BorderLeftColor = style.BorderColor.Value;
+            if (style.BorderLeftColor?.TryGetValue(out var borderLeftColor) == true)
+                computed.BorderLeftColor = borderLeftColor;
+            else if (style.BorderColor?.TryGetValue(out var bcLeft) == true)
+                computed.BorderLeftColor = bcLeft;
 
             // 边框样式：单边属性 > 统一属性 > 默认值
-            if (style.BorderTopStyle.HasValue)
-                computed.BorderTopStyle = style.BorderTopStyle.Value;
-            else if (style.BorderStyle.HasValue)
-                computed.BorderTopStyle = style.BorderStyle.Value;
+            if (style.BorderTopStyle?.TryGetValue(out var borderTopStyle) == true)
+                computed.BorderTopStyle = borderTopStyle;
+            else if (style.BorderStyle?.TryGetValue(out var bsTop) == true)
+                computed.BorderTopStyle = bsTop;
 
-            if (style.BorderRightStyle.HasValue)
-                computed.BorderRightStyle = style.BorderRightStyle.Value;
-            else if (style.BorderStyle.HasValue)
-                computed.BorderRightStyle = style.BorderStyle.Value;
+            if (style.BorderRightStyle?.TryGetValue(out var borderRightStyle) == true)
+                computed.BorderRightStyle = borderRightStyle;
+            else if (style.BorderStyle?.TryGetValue(out var bsRight) == true)
+                computed.BorderRightStyle = bsRight;
 
-            if (style.BorderBottomStyle.HasValue)
-                computed.BorderBottomStyle = style.BorderBottomStyle.Value;
-            else if (style.BorderStyle.HasValue)
-                computed.BorderBottomStyle = style.BorderStyle.Value;
+            if (style.BorderBottomStyle?.TryGetValue(out var borderBottomStyle) == true)
+                computed.BorderBottomStyle = borderBottomStyle;
+            else if (style.BorderStyle?.TryGetValue(out var bsBottom) == true)
+                computed.BorderBottomStyle = bsBottom;
 
-            if (style.BorderLeftStyle.HasValue)
-                computed.BorderLeftStyle = style.BorderLeftStyle.Value;
-            else if (style.BorderStyle.HasValue)
-                computed.BorderLeftStyle = style.BorderStyle.Value;
+            if (style.BorderLeftStyle?.TryGetValue(out var borderLeftStyle) == true)
+                computed.BorderLeftStyle = borderLeftStyle;
+            else if (style.BorderStyle?.TryGetValue(out var bsLeft) == true)
+                computed.BorderLeftStyle = bsLeft;
 
-            if (style.BorderTopLeftRadius.HasValue) computed.BorderTopLeftRadius = style.BorderTopLeftRadius.Value;
-            if (style.BorderTopRightRadius.HasValue) computed.BorderTopRightRadius = style.BorderTopRightRadius.Value;
-            if (style.BorderBottomRightRadius.HasValue) computed.BorderBottomRightRadius = style.BorderBottomRightRadius.Value;
-            if (style.BorderBottomLeftRadius.HasValue) computed.BorderBottomLeftRadius = style.BorderBottomLeftRadius.Value;
+            if (style.BorderTopLeftRadius?.TryGetValue(out var btlr) == true) computed.BorderTopLeftRadius = btlr;
+            if (style.BorderTopRightRadius?.TryGetValue(out var btrr) == true) computed.BorderTopRightRadius = btrr;
+            if (style.BorderBottomRightRadius?.TryGetValue(out var bbrr) == true) computed.BorderBottomRightRadius = bbrr;
+            if (style.BorderBottomLeftRadius?.TryGetValue(out var bblr) == true) computed.BorderBottomLeftRadius = bblr;
 
-            if (style.BackgroundColor.HasValue) computed.BackgroundColor = style.BackgroundColor.Value;
+            if (style.BackgroundColor?.TryGetValue(out var bgColor) == true) computed.BackgroundColor = bgColor;
             if (style.BackgroundImage != null) computed.BackgroundImage = style.BackgroundImage;
-            if (style.BackgroundRepeat.HasValue) computed.BackgroundRepeat = style.BackgroundRepeat.Value;
-            if (style.BackgroundSize.HasValue) computed.BackgroundSize = style.BackgroundSize.Value;
-            if (style.BackgroundPosition.HasValue) computed.BackgroundPosition = style.BackgroundPosition.Value;
-            if (style.Color.HasValue) computed.Color = style.Color.Value;
+            if (style.BackgroundRepeat?.TryGetValue(out var bgRepeat) == true) computed.BackgroundRepeat = bgRepeat;
+            if (style.BackgroundSize?.TryGetValue(out var bgSize) == true) computed.BackgroundSize = bgSize;
+            if (style.BackgroundPosition?.TryGetValue(out var bgPos) == true) computed.BackgroundPosition = bgPos;
+            if (style.Color?.TryGetValue(out var color) == true) computed.Color = color;
             if (style.FontFamily != null) computed.FontFamily = style.FontFamily;
-            if (style.FontSize.HasValue) computed.FontSize = Length.Px(style.FontSize.Value.ToPixels(0));
-            if (style.FontWeight.HasValue) computed.FontWeight = style.FontWeight.Value;
-            if (style.TextAlign.HasValue) computed.TextAlign = style.TextAlign.Value;
-            if (style.LineHeight.HasValue) computed.LineHeight = style.LineHeight.Value;
+            if (style.FontSize?.TryGetValue(out var fontSize) == true) computed.FontSize = Length.Px(fontSize.ToPixels(0));
+            if (style.FontWeight?.TryGetValue(out var fontWeight) == true) computed.FontWeight = fontWeight;
+            if (style.TextAlign?.TryGetValue(out var textAlign) == true) computed.TextAlign = textAlign;
+            if (style.LineHeight?.TryGetValue(out var lineHeight) == true) computed.LineHeight = lineHeight;
 
-            if (style.Position.HasValue) computed.Position = style.Position.Value;
-            if (style.Top.HasValue) computed.Top = style.Top.Value;
-            if (style.Right.HasValue) computed.Right = style.Right.Value;
-            if (style.Bottom.HasValue) computed.Bottom = style.Bottom.Value;
-            if (style.Left.HasValue) computed.Left = style.Left.Value;
+            if (style.Position?.TryGetValue(out var position) == true) computed.Position = position;
+            if (style.Top?.TryGetValue(out var top) == true) computed.Top = top;
+            if (style.Right?.TryGetValue(out var right) == true) computed.Right = right;
+            if (style.Bottom?.TryGetValue(out var bottom) == true) computed.Bottom = bottom;
+            if (style.Left?.TryGetValue(out var left) == true) computed.Left = left;
 
-            if (style.TextDecoration.HasValue) computed.TextDecoration = style.TextDecoration.Value;
-            if (style.TextTransform.HasValue) computed.TextTransform = style.TextTransform.Value;
-            if (style.FontStyle.HasValue) computed.FontStyle = style.FontStyle.Value;
-            if (style.WhiteSpace.HasValue) computed.WhiteSpace = style.WhiteSpace.Value;
-            if (style.Visibility.HasValue) computed.Visibility = style.Visibility.Value;
-            if (style.FlexWrap.HasValue) computed.FlexWrap = style.FlexWrap.Value;
-            if (style.AlignSelf.HasValue) computed.AlignSelf = style.AlignSelf.Value;
-            if (style.AlignContent.HasValue) computed.AlignContent = style.AlignContent.Value;
+            if (style.TextDecoration?.TryGetValue(out var textDecoration) == true) computed.TextDecoration = textDecoration;
+            if (style.TextTransform?.TryGetValue(out var textTransform) == true) computed.TextTransform = textTransform;
+            if (style.FontStyle?.TryGetValue(out var fontStyle) == true) computed.FontStyle = fontStyle;
+            if (style.WhiteSpace?.TryGetValue(out var whiteSpace) == true) computed.WhiteSpace = whiteSpace;
+            if (style.Visibility?.TryGetValue(out var visibility) == true) computed.Visibility = visibility;
+            if (style.FlexWrap?.TryGetValue(out var flexWrap) == true) computed.FlexWrap = flexWrap;
+            if (style.AlignSelf?.TryGetValue(out var alignSelf) == true) computed.AlignSelf = alignSelf;
+            if (style.AlignContent?.TryGetValue(out var alignContent) == true) computed.AlignContent = alignContent;
 
-            if (style.Opacity.HasValue) computed.Opacity = style.Opacity.Value;
-            if (style.ZIndex.HasValue) computed.ZIndex = style.ZIndex.Value;
+            if (style.Opacity?.TryGetValue(out var opacity) == true) computed.Opacity = opacity;
+            if (style.ZIndex?.TryGetValue(out var zIndex) == true) computed.ZIndex = zIndex;
 
-            if (style.OverflowX.HasValue) computed.OverflowX = style.OverflowX.Value;
-            if (style.OverflowY.HasValue) computed.OverflowY = style.OverflowY.Value;
+            if (style.OverflowX?.TryGetValue(out var overflowX) == true) computed.OverflowX = overflowX;
+            if (style.OverflowY?.TryGetValue(out var overflowY) == true) computed.OverflowY = overflowY;
 
             if (style.Transform != null) computed.Transform = style.Transform;
-            if (style.TransformOrigin.HasValue) computed.TransformOrigin = style.TransformOrigin.Value;
+            if (style.TransformOrigin?.TryGetValue(out var transformOrigin) == true) computed.TransformOrigin = transformOrigin;
             if (style.Transitions != null) computed.Transitions = style.Transitions;
             if (style.Animations != null) computed.Animations = style.Animations;
 

--- a/src/Miko/Styling/CssObjectResolver.cs
+++ b/src/Miko/Styling/CssObjectResolver.cs
@@ -167,6 +167,7 @@ internal static class CssObjectResolver
                style.AlignContent != null || style.Gap != null || style.RowGap != null ||
                style.ColumnGap != null || style.BoxShadow != null || style.OverflowX != null ||
                style.OverflowY != null || style.Transform != null || style.TransformOrigin != null ||
-               style.Transitions != null || style.Animations != null || style.Content != null;
+               style.Transitions != null || style.Animations != null || style.Content != null ||
+               style.CustomProperties?.Count > 0;
     }
 }

--- a/src/Miko/Styling/CustomProperty.cs
+++ b/src/Miko/Styling/CustomProperty.cs
@@ -1,0 +1,34 @@
+namespace Miko.Styling;
+
+/// <summary>
+/// 变量引用，等同于 CSS var(--name, fallback?)
+/// </summary>
+public readonly record struct VarReference(string Name, object? Fallback = null);
+
+/// <summary>
+/// 自定义属性作用域，通过链式结构实现变量继承（零装箱）
+/// </summary>
+public class CustomPropertyScope
+{
+    private readonly Dictionary<string, StyleValue> _values = new();
+    private readonly CustomPropertyScope? _parent;
+
+    public CustomPropertyScope(CustomPropertyScope? parent = null) => _parent = parent;
+
+    public void Set(string name, StyleValue value) => _values[name] = value;
+
+    public StyleValue? Get(string name)
+    {
+        if (_values.TryGetValue(name, out var v))
+            return v;
+        return _parent?.Get(name);
+    }
+
+    public T? Get<T>(string name) where T : struct
+    {
+        var sv = Get(name);
+        return sv?.Get<T>();
+    }
+
+    public CustomPropertyScope CreateChild() => new(this);
+}

--- a/src/Miko/Styling/Style.cs
+++ b/src/Miko/Styling/Style.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using Miko.Animation;
 using Miko.Common;
 using Miko.Core;
@@ -12,30 +12,30 @@ namespace Miko.Styling;
 public class Style
 {
     // 布局属性
-    public Display? Display { get; set; }
-    public FlexDirection? FlexDirection { get; set; }
-    public JustifyContent? JustifyContent { get; set; }
-    public AlignItems? AlignItems { get; set; }
+    public StyleProperty<Display>? Display { get; set; }
+    public StyleProperty<FlexDirection>? FlexDirection { get; set; }
+    public StyleProperty<JustifyContent>? JustifyContent { get; set; }
+    public StyleProperty<AlignItems>? AlignItems { get; set; }
 
     // Flex 子元素属性
-    public float? FlexGrow { get; set; }
-    public float? FlexShrink { get; set; }
-    public Length? FlexBasis { get; set; }
+    public StyleProperty<float>? FlexGrow { get; set; }
+    public StyleProperty<float>? FlexShrink { get; set; }
+    public StyleProperty<Length>? FlexBasis { get; set; }
 
     // 盒子模型
-    public BoxSizing? BoxSizing { get; set; }
-    public Length? Width { get; set; }
-    public Length? Height { get; set; }
-    public Length? MinWidth { get; set; }
-    public Length? MinHeight { get; set; }
-    public Length? MaxWidth { get; set; }
-    public Length? MaxHeight { get; set; }
+    public StyleProperty<BoxSizing>? BoxSizing { get; set; }
+    public StyleProperty<Length>? Width { get; set; }
+    public StyleProperty<Length>? Height { get; set; }
+    public StyleProperty<Length>? MinWidth { get; set; }
+    public StyleProperty<Length>? MinHeight { get; set; }
+    public StyleProperty<Length>? MaxWidth { get; set; }
+    public StyleProperty<Length>? MaxHeight { get; set; }
 
     // 内边距
-    public Length? PaddingTop { get; set; }
-    public Length? PaddingRight { get; set; }
-    public Length? PaddingBottom { get; set; }
-    public Length? PaddingLeft { get; set; }
+    public StyleProperty<Length>? PaddingTop { get; set; }
+    public StyleProperty<Length>? PaddingRight { get; set; }
+    public StyleProperty<Length>? PaddingBottom { get; set; }
+    public StyleProperty<Length>? PaddingLeft { get; set; }
 
     /// <summary>
     /// 内边距简写属性
@@ -43,10 +43,10 @@ public class Style
     public Padding Padding
     {
         get => new Padding(
-            PaddingTop ?? Length.Px(0),
-            PaddingRight ?? Length.Px(0),
-            PaddingBottom ?? Length.Px(0),
-            PaddingLeft ?? Length.Px(0));
+            PaddingTop?.Value ?? Length.Px(0),
+            PaddingRight?.Value ?? Length.Px(0),
+            PaddingBottom?.Value ?? Length.Px(0),
+            PaddingLeft?.Value ?? Length.Px(0));
         set
         {
             PaddingTop = value.Top;
@@ -57,10 +57,10 @@ public class Style
     }
 
     // 外边距
-    public Length? MarginTop { get; set; }
-    public Length? MarginRight { get; set; }
-    public Length? MarginBottom { get; set; }
-    public Length? MarginLeft { get; set; }
+    public StyleProperty<Length>? MarginTop { get; set; }
+    public StyleProperty<Length>? MarginRight { get; set; }
+    public StyleProperty<Length>? MarginBottom { get; set; }
+    public StyleProperty<Length>? MarginLeft { get; set; }
 
     /// <summary>
     /// 外边距简写属性
@@ -68,10 +68,10 @@ public class Style
     public Margin Margin
     {
         get => new Margin(
-            MarginTop ?? Length.Px(0),
-            MarginRight ?? Length.Px(0),
-            MarginBottom ?? Length.Px(0),
-            MarginLeft ?? Length.Px(0));
+            MarginTop?.Value ?? Length.Px(0),
+            MarginRight?.Value ?? Length.Px(0),
+            MarginBottom?.Value ?? Length.Px(0),
+            MarginLeft?.Value ?? Length.Px(0));
         set
         {
             MarginTop = value.Top;
@@ -82,27 +82,27 @@ public class Style
     }
 
     // 边框（统一属性，作为各边的后备值）
-    public Length? BorderWidth { get; set; }
-    public Color? BorderColor { get; set; }
-    public BorderStyle? BorderStyle { get; set; }
+    public StyleProperty<Length>? BorderWidth { get; set; }
+    public StyleProperty<Color>? BorderColor { get; set; }
+    public StyleProperty<BorderStyle>? BorderStyle { get; set; }
 
     // 边框宽度（每边单独设置）
-    public Length? BorderTopWidth { get; set; }
-    public Length? BorderRightWidth { get; set; }
-    public Length? BorderBottomWidth { get; set; }
-    public Length? BorderLeftWidth { get; set; }
+    public StyleProperty<Length>? BorderTopWidth { get; set; }
+    public StyleProperty<Length>? BorderRightWidth { get; set; }
+    public StyleProperty<Length>? BorderBottomWidth { get; set; }
+    public StyleProperty<Length>? BorderLeftWidth { get; set; }
 
     // 边框颜色（每边单独设置）
-    public Color? BorderTopColor { get; set; }
-    public Color? BorderRightColor { get; set; }
-    public Color? BorderBottomColor { get; set; }
-    public Color? BorderLeftColor { get; set; }
+    public StyleProperty<Color>? BorderTopColor { get; set; }
+    public StyleProperty<Color>? BorderRightColor { get; set; }
+    public StyleProperty<Color>? BorderBottomColor { get; set; }
+    public StyleProperty<Color>? BorderLeftColor { get; set; }
 
     // 边框样式（每边单独设置）
-    public BorderStyle? BorderTopStyle { get; set; }
-    public BorderStyle? BorderRightStyle { get; set; }
-    public BorderStyle? BorderBottomStyle { get; set; }
-    public BorderStyle? BorderLeftStyle { get; set; }
+    public StyleProperty<BorderStyle>? BorderTopStyle { get; set; }
+    public StyleProperty<BorderStyle>? BorderRightStyle { get; set; }
+    public StyleProperty<BorderStyle>? BorderBottomStyle { get; set; }
+    public StyleProperty<BorderStyle>? BorderLeftStyle { get; set; }
 
     /// <summary>
     /// 边框简写属性（设置所有边）
@@ -110,15 +110,14 @@ public class Style
     public Border Border
     {
         get => new Border(
-            BorderWidth ?? Length.Px(0),
-            BorderStyle ?? Common.BorderStyle.None,
-            BorderColor ?? Common.Color.Transparent);
+            BorderWidth?.Value ?? Length.Px(0),
+            BorderStyle?.Value ?? Common.BorderStyle.None,
+            BorderColor?.Value ?? Common.Color.Transparent);
         set
         {
             BorderWidth = value.Width;
             BorderColor = value.Color;
             BorderStyle = value.Style;
-            // 清除单边覆盖值
             BorderTopWidth = BorderRightWidth = BorderBottomWidth = BorderLeftWidth = null;
             BorderTopColor = BorderRightColor = BorderBottomColor = BorderLeftColor = null;
             BorderTopStyle = BorderRightStyle = BorderBottomStyle = BorderLeftStyle = null;
@@ -131,9 +130,9 @@ public class Style
     public BorderSide BorderTop
     {
         get => new BorderSide(
-            BorderTopWidth ?? BorderWidth ?? Length.Px(0),
-            BorderTopStyle ?? BorderStyle ?? Common.BorderStyle.None,
-            BorderTopColor ?? BorderColor ?? Common.Color.Transparent);
+            BorderTopWidth?.Value ?? BorderWidth?.Value ?? Length.Px(0),
+            BorderTopStyle?.Value ?? BorderStyle?.Value ?? Common.BorderStyle.None,
+            BorderTopColor?.Value ?? BorderColor?.Value ?? Common.Color.Transparent);
         set
         {
             BorderTopWidth = value.Width;
@@ -148,9 +147,9 @@ public class Style
     public BorderSide BorderRight
     {
         get => new BorderSide(
-            BorderRightWidth ?? BorderWidth ?? Length.Px(0),
-            BorderRightStyle ?? BorderStyle ?? Common.BorderStyle.None,
-            BorderRightColor ?? BorderColor ?? Common.Color.Transparent);
+            BorderRightWidth?.Value ?? BorderWidth?.Value ?? Length.Px(0),
+            BorderRightStyle?.Value ?? BorderStyle?.Value ?? Common.BorderStyle.None,
+            BorderRightColor?.Value ?? BorderColor?.Value ?? Common.Color.Transparent);
         set
         {
             BorderRightWidth = value.Width;
@@ -165,9 +164,9 @@ public class Style
     public BorderSide BorderBottom
     {
         get => new BorderSide(
-            BorderBottomWidth ?? BorderWidth ?? Length.Px(0),
-            BorderBottomStyle ?? BorderStyle ?? Common.BorderStyle.None,
-            BorderBottomColor ?? BorderColor ?? Common.Color.Transparent);
+            BorderBottomWidth?.Value ?? BorderWidth?.Value ?? Length.Px(0),
+            BorderBottomStyle?.Value ?? BorderStyle?.Value ?? Common.BorderStyle.None,
+            BorderBottomColor?.Value ?? BorderColor?.Value ?? Common.Color.Transparent);
         set
         {
             BorderBottomWidth = value.Width;
@@ -182,9 +181,9 @@ public class Style
     public BorderSide BorderLeft
     {
         get => new BorderSide(
-            BorderLeftWidth ?? BorderWidth ?? Length.Px(0),
-            BorderLeftStyle ?? BorderStyle ?? Common.BorderStyle.None,
-            BorderLeftColor ?? BorderColor ?? Common.Color.Transparent);
+            BorderLeftWidth?.Value ?? BorderWidth?.Value ?? Length.Px(0),
+            BorderLeftStyle?.Value ?? BorderStyle?.Value ?? Common.BorderStyle.None,
+            BorderLeftColor?.Value ?? BorderColor?.Value ?? Common.Color.Transparent);
         set
         {
             BorderLeftWidth = value.Width;
@@ -194,18 +193,18 @@ public class Style
     }
 
     // 圆角
-    public Length? BorderTopLeftRadius { get; set; }
-    public Length? BorderTopRightRadius { get; set; }
-    public Length? BorderBottomRightRadius { get; set; }
-    public Length? BorderBottomLeftRadius { get; set; }
+    public StyleProperty<Length>? BorderTopLeftRadius { get; set; }
+    public StyleProperty<Length>? BorderTopRightRadius { get; set; }
+    public StyleProperty<Length>? BorderBottomRightRadius { get; set; }
+    public StyleProperty<Length>? BorderBottomLeftRadius { get; set; }
 
     public BorderRadius BorderRadius
     {
         get => new BorderRadius(
-            BorderTopLeftRadius ?? 0,
-            BorderTopRightRadius ?? 0,
-            BorderBottomLeftRadius ?? 0,
-            BorderBottomRightRadius ?? 0);
+            BorderTopLeftRadius?.Value ?? 0,
+            BorderTopRightRadius?.Value ?? 0,
+            BorderBottomLeftRadius?.Value ?? 0,
+            BorderBottomRightRadius?.Value ?? 0);
         set
         {
             BorderTopLeftRadius = value.TopLeft;
@@ -216,60 +215,63 @@ public class Style
     }
 
     // 视觉属性
-    public Color? BackgroundColor { get; set; }
+    public StyleProperty<Color>? BackgroundColor { get; set; }
     public BackgroundImage? BackgroundImage { get; set; }
-    public BackgroundRepeat? BackgroundRepeat { get; set; }
-    public BackgroundSize? BackgroundSize { get; set; }
-    public BackgroundPosition? BackgroundPosition { get; set; }
-    public Color? Color { get; set; }
+    public StyleProperty<BackgroundRepeat>? BackgroundRepeat { get; set; }
+    public StyleProperty<BackgroundSize>? BackgroundSize { get; set; }
+    public StyleProperty<BackgroundPosition>? BackgroundPosition { get; set; }
+    public StyleProperty<Color>? Color { get; set; }
     public string? FontFamily { get; set; }
-    public Length? FontSize { get; set; }
-    public FontWeight? FontWeight { get; set; }
-    public TextAlign? TextAlign { get; set; }
-    public Length? LineHeight { get; set; }
+    public StyleProperty<Length>? FontSize { get; set; }
+    public StyleProperty<FontWeight>? FontWeight { get; set; }
+    public StyleProperty<TextAlign>? TextAlign { get; set; }
+    public StyleProperty<Length>? LineHeight { get; set; }
 
     // 定位
-    public Position? Position { get; set; }
-    public Length? Top { get; set; }
-    public Length? Right { get; set; }
-    public Length? Bottom { get; set; }
-    public Length? Left { get; set; }
+    public StyleProperty<Position>? Position { get; set; }
+    public StyleProperty<Length>? Top { get; set; }
+    public StyleProperty<Length>? Right { get; set; }
+    public StyleProperty<Length>? Bottom { get; set; }
+    public StyleProperty<Length>? Left { get; set; }
 
-    public TextDecoration? TextDecoration { get; set; }
-    public TextTransform? TextTransform { get; set; }
-    public FontStyle? FontStyle { get; set; }
-    public WhiteSpace? WhiteSpace { get; set; }
-    public Length? LetterSpacing { get; set; }
-    public VerticalAlign? VerticalAlign { get; set; }
+    public StyleProperty<TextDecoration>? TextDecoration { get; set; }
+    public StyleProperty<TextTransform>? TextTransform { get; set; }
+    public StyleProperty<FontStyle>? FontStyle { get; set; }
+    public StyleProperty<WhiteSpace>? WhiteSpace { get; set; }
+    public StyleProperty<Length>? LetterSpacing { get; set; }
+    public StyleProperty<VerticalAlign>? VerticalAlign { get; set; }
 
-    public float? Opacity { get; set; }
-    public int? ZIndex { get; set; }
-    public Visibility? Visibility { get; set; }
-    public Cursor? Cursor { get; set; }
-    public UserSelect? UserSelect { get; set; }
+    public StyleProperty<float>? Opacity { get; set; }
+    public StyleProperty<int>? ZIndex { get; set; }
+    public StyleProperty<Visibility>? Visibility { get; set; }
+    public StyleProperty<Cursor>? Cursor { get; set; }
+    public StyleProperty<UserSelect>? UserSelect { get; set; }
 
     // Flex extras
-    public FlexWrap? FlexWrap { get; set; }
-    public AlignSelf? AlignSelf { get; set; }
-    public AlignContent? AlignContent { get; set; }
-    public Length? Gap { get; set; }
-    public Length? RowGap { get; set; }
-    public Length? ColumnGap { get; set; }
+    public StyleProperty<FlexWrap>? FlexWrap { get; set; }
+    public StyleProperty<AlignSelf>? AlignSelf { get; set; }
+    public StyleProperty<AlignContent>? AlignContent { get; set; }
+    public StyleProperty<Length>? Gap { get; set; }
+    public StyleProperty<Length>? RowGap { get; set; }
+    public StyleProperty<Length>? ColumnGap { get; set; }
 
     public BoxShadow? BoxShadow { get; set; }
 
     // 溢出
-    public Overflow? OverflowX { get; set; }
-    public Overflow? OverflowY { get; set; }
+    public StyleProperty<Overflow>? OverflowX { get; set; }
+    public StyleProperty<Overflow>? OverflowY { get; set; }
 
     // 动画与过渡
     public Transform? Transform { get; set; }
-    public TransformOrigin? TransformOrigin { get; set; }
+    public StyleProperty<TransformOrigin>? TransformOrigin { get; set; }
     public List<Transition>? Transitions { get; set; }
     public List<KeyframeAnimation>? Animations { get; set; }
 
     // 伪元素
     public string? Content { get; set; }
+
+    // 自定义属性（CSS 变量定义）
+    public Dictionary<string, StyleValue>? CustomProperties { get; set; }
 
     /// <summary>
     /// 溢出简写属性（同时设置 X 和 Y）
@@ -388,6 +390,13 @@ public class Style
         Animations ??= other.Animations;
 
         Content ??= other.Content;
+
+        if (other.CustomProperties != null)
+        {
+            CustomProperties ??= new();
+            foreach (var (key, value) in other.CustomProperties)
+                CustomProperties.TryAdd(key, value);
+        }
     }
 
     /// <summary>
@@ -395,7 +404,10 @@ public class Style
     /// </summary>
     public Style Clone()
     {
-        return (Style)MemberwiseClone();
+        var clone = (Style)MemberwiseClone();
+        if (CustomProperties != null)
+            clone.CustomProperties = new Dictionary<string, StyleValue>(CustomProperties);
+        return clone;
     }
 
     private static readonly ConcurrentDictionary<Type, string> _tagNameCache = new();

--- a/src/Miko/Styling/StyleProperty.cs
+++ b/src/Miko/Styling/StyleProperty.cs
@@ -1,0 +1,55 @@
+namespace Miko.Styling;
+
+/// <summary>
+/// 样式属性的 union 类型，支持具体值或 CSS 变量引用
+/// </summary>
+public struct StyleProperty<T>
+{
+    private readonly byte _index; // 0=Value, 1=VarReference
+    private readonly T _value;
+    private readonly VarReference _var;
+
+    public StyleProperty(T value)
+    {
+        _index = 0;
+        _value = value;
+        _var = default;
+    }
+
+    public StyleProperty(VarReference var)
+    {
+        _index = 1;
+        _value = default!;
+        _var = var;
+    }
+
+    public bool IsVar => _index == 1;
+
+    public T Value => _value;
+
+    public VarReference Var => _var;
+
+    public bool TryGetValue(out T value)
+    {
+        if (_index == 0)
+        {
+            value = _value;
+            return true;
+        }
+        value = default!;
+        return false;
+    }
+
+    public static implicit operator StyleProperty<T>(T value) => new(value);
+    public static implicit operator StyleProperty<T>(VarReference var) => new(var);
+
+    public override string ToString() => IsVar ? $"var({_var.Name})" : _value?.ToString() ?? "null";
+}
+
+/// <summary>
+/// 全局入口：Var("--name") 创建变量引用
+/// </summary>
+public static class StyleVar
+{
+    public static VarReference Var(string name) => new(name);
+}

--- a/src/Miko/Styling/StyleResolver.cs
+++ b/src/Miko/Styling/StyleResolver.cs
@@ -12,7 +12,8 @@ public class StyleResolver
     /// <summary>
     /// 解析元素的最终样式
     /// </summary>
-    public ComputedStyle Resolve(Element element, List<StyleSheet> styleSheets, ViewportInfo? viewport = null)
+    public ComputedStyle Resolve(Element element, List<StyleSheet> styleSheets, ViewportInfo? viewport = null,
+        CustomPropertyScope? parentScope = null)
     {
         // 1. 收集所有匹配的规则（带有定义顺序索引）
         var matchedRules = new List<(StyleRule rule, int specificity, int index)>();
@@ -70,6 +71,12 @@ public class StyleResolver
             baseStyle.Merge(rule.Style);
         }
 
+        // 5.5 构建自定义属性作用域
+        var scope = BuildCustomPropertyScope(baseStyle, parentScope);
+
+        // 5.6 解析变量引用
+        ResolveVarBindings(baseStyle, scope);
+
         // 6. 从父元素继承可继承属性
         if (element.Parent != null && element.Parent.LayoutBox?.ComputedStyle != null)
         {
@@ -80,7 +87,9 @@ public class StyleResolver
         ApplyDefaultStyles(element, baseStyle);
 
         // 8. 转换为计算样式
-        return ComputedStyle.FromStyle(baseStyle);
+        var computed = ComputedStyle.FromStyle(baseStyle);
+        computed.CustomPropertyScope = scope;
+        return computed;
     }
 
     /// <summary>
@@ -89,12 +98,12 @@ public class StyleResolver
     private void InheritFromParent(Style style, ComputedStyle parentStyle)
     {
         // 可继承的属性
-        style.Color ??= parentStyle.Color;
+        style.Color ??= (StyleProperty<Color>)parentStyle.Color;
         style.FontFamily ??= parentStyle.FontFamily;
-        style.FontSize ??= parentStyle.FontSize;
-        style.FontWeight ??= parentStyle.FontWeight;
-        style.TextAlign ??= parentStyle.TextAlign;
-        style.LineHeight ??= parentStyle.LineHeight;
+        style.FontSize ??= (StyleProperty<Length>)parentStyle.FontSize;
+        style.FontWeight ??= (StyleProperty<FontWeight>)parentStyle.FontWeight;
+        style.TextAlign ??= (StyleProperty<TextAlign>)parentStyle.TextAlign;
+        style.LineHeight ??= (StyleProperty<Length>)parentStyle.LineHeight;
     }
 
     /// <summary>
@@ -293,10 +302,8 @@ public class StyleResolver
                 break;
 
             case "ul":
-                // Browser default: display: block, margin: 1em 0, padding-left: 40px
-                // list-style-type: disc (not implemented - visual bullets would need Painter support)
                 style.Display ??= Common.Display.Block;
-                style.MarginTop ??= Common.Length.Px(16);     // 1em at 16px
+                style.MarginTop ??= Common.Length.Px(16);
                 style.MarginBottom ??= Common.Length.Px(16);
                 style.MarginLeft ??= Common.Length.Px(0);
                 style.MarginRight ??= Common.Length.Px(0);
@@ -307,10 +314,8 @@ public class StyleResolver
                 break;
 
             case "ol":
-                // Browser default: display: block, margin: 1em 0, padding-left: 40px
-                // list-style-type: decimal (not implemented - numbers would need Painter support)
                 style.Display ??= Common.Display.Block;
-                style.MarginTop ??= Common.Length.Px(16);     // 1em at 16px
+                style.MarginTop ??= Common.Length.Px(16);
                 style.MarginBottom ??= Common.Length.Px(16);
                 style.MarginLeft ??= Common.Length.Px(0);
                 style.MarginRight ??= Common.Length.Px(0);
@@ -321,23 +326,17 @@ public class StyleResolver
                 break;
 
             case "li":
-                // Browser default: display: list-item (using block as list-item not supported)
-                // List markers (bullets/numbers) would need separate Painter implementation
                 style.Display ??= Common.Display.Block;
                 break;
 
             case "table":
-                // Browser default: display: table (using block for now), border-collapse: separate
-                // border-spacing: 2px, border-color: gray
                 style.Display ??= Common.Display.Block;
                 style.BoxSizing ??= Common.BoxSizing.BorderBox;
                 style.BorderWidth ??= Common.Length.Px(0);
                 style.BorderStyle ??= Common.BorderStyle.None;
-                // Note: border-collapse and border-spacing not yet implemented
                 break;
 
             case "caption":
-                // Browser default: display: table-caption (using block), text-align: center
                 style.Display ??= Common.Display.Block;
                 style.TextAlign ??= Common.TextAlign.Center;
                 style.PaddingTop ??= Common.Length.Px(2);
@@ -347,28 +346,19 @@ public class StyleResolver
             case "thead":
             case "tbody":
             case "tfoot":
-                // Browser default: display: table-row-group (using block for now)
-                // vertical-align: middle, border-color: inherit
                 style.Display ??= Common.Display.Block;
                 break;
 
             case "colgroup":
             case "col":
-                // Browser default: display: table-column-group / table-column
-                // These are typically not rendered but affect table layout
                 style.Display ??= Common.Display.None;
                 break;
 
             case "tr":
-                // Browser default: display: table-row (using block for now)
-                // vertical-align: inherit, border-color: inherit
                 style.Display ??= Common.Display.Block;
                 break;
 
             case "th":
-                // Browser default: display: table-cell (using inline-block for now)
-                // font-weight: bold, text-align: center, vertical-align: inherit
-                // padding: 1px
                 style.Display ??= Common.Display.InlineBlock;
                 style.FontWeight ??= Common.FontWeight.Bold;
                 style.TextAlign ??= Common.TextAlign.Center;
@@ -379,9 +369,6 @@ public class StyleResolver
                 break;
 
             case "td":
-                // Browser default: display: table-cell (using inline-block for now)
-                // vertical-align: inherit, text-align: left
-                // padding: 1px
                 style.Display ??= Common.Display.InlineBlock;
                 style.TextAlign ??= Common.TextAlign.Left;
                 style.PaddingTop ??= Common.Length.Px(1);
@@ -395,27 +382,17 @@ public class StyleResolver
     /// <summary>
     /// 应用输入框元素的默认样式（根据 InputType 不同设置不同的样式）
     /// </summary>
-    /// <remarks>
-    /// Based on browser default behavior:
-    /// - Text/Password: Similar to input fields with padding, border, and default dimensions
-    /// - Checkbox/Radio: Fixed 13x13px size (browser default), no padding/border in layout
-    /// - Range: Fixed height with default width
-    /// </remarks>
     private void ApplyInputDefaultStyles(Element element, Style style)
     {
-        // Common style for all input types
         style.Display ??= Display.InlineBlock;
         style.BoxSizing ??= BoxSizing.BorderBox;
 
-        // Check if it's an InputElement to get the type
         if (element is InputElement inputElement)
         {
             switch (inputElement.Type)
             {
                 case InputType.Checkbox:
                 case InputType.Radio:
-                    // Browser default: checkbox/radio are 13x13px
-                    // No padding or border in layout (visuals are drawn separately)
                     style.Width ??= Length.Px(13);
                     style.Height ??= Length.Px(13);
                     style.PaddingTop ??= Length.Px(0);
@@ -423,11 +400,10 @@ public class StyleResolver
                     style.PaddingBottom ??= Length.Px(0);
                     style.PaddingLeft ??= Length.Px(0);
                     style.BorderWidth ??= Length.Px(0);
-                    style.BorderStyle ??= BorderStyle.None;
+                    style.BorderStyle ??= Common.BorderStyle.None;
                     break;
 
                 case InputType.Range:
-                    // Browser default: Range has fixed height ~21px and width ~129px (Chrome)
                     style.Width ??= Length.Px(129);
                     style.Height ??= Length.Px(21);
                     style.PaddingTop ??= Length.Px(0);
@@ -435,14 +411,12 @@ public class StyleResolver
                     style.PaddingBottom ??= Length.Px(0);
                     style.PaddingLeft ??= Length.Px(0);
                     style.BorderWidth ??= Length.Px(0);
-                    style.BorderStyle ??= BorderStyle.None;
+                    style.BorderStyle ??= Common.BorderStyle.None;
                     break;
 
                 case InputType.Text:
                 case InputType.Password:
                 default:
-                    // Browser default: text input has padding, border, and default dimensions
-                    // Default width: ~173px (Chrome), height: ~21px (including padding/border)
                     style.Width ??= Length.Px(173);
                     style.Height ??= Length.Px(21);
                     style.PaddingTop ??= Length.Px(1);
@@ -450,14 +424,13 @@ public class StyleResolver
                     style.PaddingBottom ??= Length.Px(1);
                     style.PaddingLeft ??= Length.Px(2);
                     style.BorderWidth ??= Length.Px(1);
-                    style.BorderStyle ??= BorderStyle.Solid;
+                    style.BorderStyle ??= Common.BorderStyle.Solid;
                     style.BorderColor ??= Color.Gray;
                     break;
             }
         }
         else
         {
-            // Fallback for generic input elements (treat as text input)
             style.Width ??= Length.Px(173);
             style.Height ??= Length.Px(21);
             style.PaddingTop ??= Length.Px(1);
@@ -465,8 +438,128 @@ public class StyleResolver
             style.PaddingBottom ??= Length.Px(1);
             style.PaddingLeft ??= Length.Px(2);
             style.BorderWidth ??= Length.Px(1);
-            style.BorderStyle ??= BorderStyle.Solid;
+            style.BorderStyle ??= Common.BorderStyle.Solid;
             style.BorderColor ??= Color.Gray;
         }
+    }
+
+    private static CustomPropertyScope BuildCustomPropertyScope(Style mergedStyle, CustomPropertyScope? parentScope)
+    {
+        if (mergedStyle.CustomProperties == null || mergedStyle.CustomProperties.Count == 0)
+            return parentScope ?? new CustomPropertyScope();
+
+        var scope = parentScope?.CreateChild() ?? new CustomPropertyScope();
+        foreach (var (name, value) in mergedStyle.CustomProperties)
+            scope.Set(name, value);
+        return scope;
+    }
+
+    private static StyleProperty<T>? ResolveVar<T>(StyleProperty<T>? prop, CustomPropertyScope scope) where T : struct
+    {
+        if (prop is { IsVar: true } sp)
+        {
+            var resolved = scope.Get<T>(sp.Var.Name);
+            if (resolved.HasValue)
+                return new StyleProperty<T>(resolved.Value);
+            if (sp.Var.Fallback is T fallback)
+                return new StyleProperty<T>(fallback);
+            return null;
+        }
+        return prop;
+    }
+
+    private static void ResolveVarBindings(Style style, CustomPropertyScope scope)
+    {
+        style.Display = ResolveVar(style.Display, scope);
+        style.FlexDirection = ResolveVar(style.FlexDirection, scope);
+        style.JustifyContent = ResolveVar(style.JustifyContent, scope);
+        style.AlignItems = ResolveVar(style.AlignItems, scope);
+
+        style.FlexGrow = ResolveVar(style.FlexGrow, scope);
+        style.FlexShrink = ResolveVar(style.FlexShrink, scope);
+        style.FlexBasis = ResolveVar(style.FlexBasis, scope);
+
+        style.BoxSizing = ResolveVar(style.BoxSizing, scope);
+        style.Width = ResolveVar(style.Width, scope);
+        style.Height = ResolveVar(style.Height, scope);
+        style.MinWidth = ResolveVar(style.MinWidth, scope);
+        style.MinHeight = ResolveVar(style.MinHeight, scope);
+        style.MaxWidth = ResolveVar(style.MaxWidth, scope);
+        style.MaxHeight = ResolveVar(style.MaxHeight, scope);
+
+        style.PaddingTop = ResolveVar(style.PaddingTop, scope);
+        style.PaddingRight = ResolveVar(style.PaddingRight, scope);
+        style.PaddingBottom = ResolveVar(style.PaddingBottom, scope);
+        style.PaddingLeft = ResolveVar(style.PaddingLeft, scope);
+
+        style.MarginTop = ResolveVar(style.MarginTop, scope);
+        style.MarginRight = ResolveVar(style.MarginRight, scope);
+        style.MarginBottom = ResolveVar(style.MarginBottom, scope);
+        style.MarginLeft = ResolveVar(style.MarginLeft, scope);
+
+        style.BorderWidth = ResolveVar(style.BorderWidth, scope);
+        style.BorderColor = ResolveVar(style.BorderColor, scope);
+        style.BorderStyle = ResolveVar(style.BorderStyle, scope);
+
+        style.BorderTopWidth = ResolveVar(style.BorderTopWidth, scope);
+        style.BorderRightWidth = ResolveVar(style.BorderRightWidth, scope);
+        style.BorderBottomWidth = ResolveVar(style.BorderBottomWidth, scope);
+        style.BorderLeftWidth = ResolveVar(style.BorderLeftWidth, scope);
+
+        style.BorderTopColor = ResolveVar(style.BorderTopColor, scope);
+        style.BorderRightColor = ResolveVar(style.BorderRightColor, scope);
+        style.BorderBottomColor = ResolveVar(style.BorderBottomColor, scope);
+        style.BorderLeftColor = ResolveVar(style.BorderLeftColor, scope);
+
+        style.BorderTopStyle = ResolveVar(style.BorderTopStyle, scope);
+        style.BorderRightStyle = ResolveVar(style.BorderRightStyle, scope);
+        style.BorderBottomStyle = ResolveVar(style.BorderBottomStyle, scope);
+        style.BorderLeftStyle = ResolveVar(style.BorderLeftStyle, scope);
+
+        style.BorderTopLeftRadius = ResolveVar(style.BorderTopLeftRadius, scope);
+        style.BorderTopRightRadius = ResolveVar(style.BorderTopRightRadius, scope);
+        style.BorderBottomRightRadius = ResolveVar(style.BorderBottomRightRadius, scope);
+        style.BorderBottomLeftRadius = ResolveVar(style.BorderBottomLeftRadius, scope);
+
+        style.BackgroundColor = ResolveVar(style.BackgroundColor, scope);
+        style.BackgroundRepeat = ResolveVar(style.BackgroundRepeat, scope);
+        style.BackgroundSize = ResolveVar(style.BackgroundSize, scope);
+        style.BackgroundPosition = ResolveVar(style.BackgroundPosition, scope);
+        style.Color = ResolveVar(style.Color, scope);
+        style.FontSize = ResolveVar(style.FontSize, scope);
+        style.FontWeight = ResolveVar(style.FontWeight, scope);
+        style.TextAlign = ResolveVar(style.TextAlign, scope);
+        style.LineHeight = ResolveVar(style.LineHeight, scope);
+
+        style.Position = ResolveVar(style.Position, scope);
+        style.Top = ResolveVar(style.Top, scope);
+        style.Right = ResolveVar(style.Right, scope);
+        style.Bottom = ResolveVar(style.Bottom, scope);
+        style.Left = ResolveVar(style.Left, scope);
+
+        style.TextDecoration = ResolveVar(style.TextDecoration, scope);
+        style.TextTransform = ResolveVar(style.TextTransform, scope);
+        style.FontStyle = ResolveVar(style.FontStyle, scope);
+        style.WhiteSpace = ResolveVar(style.WhiteSpace, scope);
+        style.LetterSpacing = ResolveVar(style.LetterSpacing, scope);
+        style.VerticalAlign = ResolveVar(style.VerticalAlign, scope);
+
+        style.Opacity = ResolveVar(style.Opacity, scope);
+        style.ZIndex = ResolveVar(style.ZIndex, scope);
+        style.Visibility = ResolveVar(style.Visibility, scope);
+        style.Cursor = ResolveVar(style.Cursor, scope);
+        style.UserSelect = ResolveVar(style.UserSelect, scope);
+
+        style.FlexWrap = ResolveVar(style.FlexWrap, scope);
+        style.AlignSelf = ResolveVar(style.AlignSelf, scope);
+        style.AlignContent = ResolveVar(style.AlignContent, scope);
+        style.Gap = ResolveVar(style.Gap, scope);
+        style.RowGap = ResolveVar(style.RowGap, scope);
+        style.ColumnGap = ResolveVar(style.ColumnGap, scope);
+
+        style.OverflowX = ResolveVar(style.OverflowX, scope);
+        style.OverflowY = ResolveVar(style.OverflowY, scope);
+
+        style.TransformOrigin = ResolveVar(style.TransformOrigin, scope);
     }
 }

--- a/src/Miko/Styling/StyleValue.cs
+++ b/src/Miko/Styling/StyleValue.cs
@@ -1,0 +1,55 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Miko.Common;
+
+namespace Miko.Styling;
+
+/// <summary>
+/// CSS 变量值的无装箱存储，支持所有 Style 属性值类型
+/// </summary>
+[StructLayout(LayoutKind.Explicit)]
+public struct StyleValue
+{
+    [FieldOffset(0)] private byte _type;
+    [FieldOffset(4)] private Length _length;
+    [FieldOffset(4)] private Color _color;
+    [FieldOffset(4)] private float _float;
+    [FieldOffset(4)] private int _int;
+
+    private StyleValue(byte type) { _type = type; }
+
+    public static implicit operator StyleValue(Length v) => new(1) { _length = v };
+    public static implicit operator StyleValue(Color v) => new(2) { _color = v };
+    public static implicit operator StyleValue(float v) => new(3) { _float = v };
+    public static implicit operator StyleValue(int v) => new(4) { _int = v };
+
+    /// <summary>
+    /// 尝试获取指定类型的值，类型不匹配时返回 null（零装箱）
+    /// </summary>
+    public T? Get<T>() where T : struct
+    {
+        if (typeof(T) == typeof(Length) && _type == 1)
+            return Unsafe.As<Length, T>(ref _length);
+        if (typeof(T) == typeof(Color) && _type == 2)
+            return Unsafe.As<Color, T>(ref _color);
+        if (typeof(T) == typeof(float) && _type == 3)
+            return Unsafe.As<float, T>(ref _float);
+        if (typeof(T) == typeof(int) && _type == 4)
+            return Unsafe.As<int, T>(ref _int);
+
+        // 枚举类型统一用 int 存储
+        if (typeof(T).IsEnum && _type == 4)
+            return Unsafe.As<int, T>(ref _int);
+
+        return null;
+    }
+
+    public override string ToString() => _type switch
+    {
+        1 => _length.ToString(),
+        2 => _color.ToString(),
+        3 => _float.ToString(),
+        4 => _int.ToString(),
+        _ => "unset"
+    };
+}

--- a/tests/Miko.Tests/Animation/AnimationManagerTests.cs
+++ b/tests/Miko.Tests/Animation/AnimationManagerTests.cs
@@ -37,10 +37,10 @@ public class AnimationManagerTests
         _manager.TrackPropertyChange(element, nameof(Style.Opacity), 1f, 0f, transition);
 
         _manager.Update(0.5f);
-        element.Style!.Opacity!.Value.ShouldBe(0.5f, 0.01f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(0.5f, 0.01f);
 
         _manager.Update(0.5f);
-        element.Style!.Opacity!.Value.ShouldBe(0f, 0.01f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(0f, 0.01f);
     }
 
     [Fact]
@@ -52,10 +52,10 @@ public class AnimationManagerTests
         _manager.TrackPropertyChange(element, nameof(Style.Opacity), 1f, 0f, transition);
 
         _manager.Update(0.3f);
-        element.Style!.Opacity!.Value.ShouldBe(1f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(1f);
 
         _manager.Update(0.7f);
-        element.Style!.Opacity!.Value.ShouldBe(0.5f, 0.05f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(0.5f, 0.05f);
     }
 
     [Fact]
@@ -67,9 +67,9 @@ public class AnimationManagerTests
         _manager.TrackColorChange(element, nameof(Style.BackgroundColor), Color.Black, Color.White, transition);
 
         _manager.Update(0.5f);
-        element.Style!.BackgroundColor!.Value.R.ShouldBeInRange((byte)120, (byte)135);
-        element.Style!.BackgroundColor!.Value.G.ShouldBeInRange((byte)120, (byte)135);
-        element.Style!.BackgroundColor!.Value.B.ShouldBeInRange((byte)120, (byte)135);
+        element.Style!.BackgroundColor!.Value.Value.R.ShouldBeInRange((byte)120, (byte)135);
+        element.Style!.BackgroundColor!.Value.Value.G.ShouldBeInRange((byte)120, (byte)135);
+        element.Style!.BackgroundColor!.Value.Value.B.ShouldBeInRange((byte)120, (byte)135);
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class AnimationManagerTests
         _manager.TrackPropertyChange(element, nameof(Style.Opacity), 1f, 0f, transition);
         _manager.Update(1f);
 
-        element.Style!.Opacity!.Value.ShouldBe(0f, 0.01f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(0f, 0.01f);
         _manager.HasActiveAnimations.ShouldBeFalse();
     }
 
@@ -118,7 +118,7 @@ public class AnimationManagerTests
         _manager.StartAnimation(element, animation);
         _manager.Update(0.5f);
 
-        element.Style!.Opacity!.Value.ShouldBe(0.5f, 0.05f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(0.5f, 0.05f);
     }
 
     [Fact]
@@ -137,13 +137,13 @@ public class AnimationManagerTests
         _manager.StartAnimation(element, animation);
 
         _manager.Update(0.25f);
-        element.Style!.Opacity!.Value.ShouldBe(0.5f, 0.05f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(0.5f, 0.05f);
 
         _manager.Update(0.25f);
-        element.Style!.Opacity!.Value.ShouldBe(1f, 0.05f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(1f, 0.05f);
 
         _manager.Update(0.25f);
-        element.Style!.Opacity!.Value.ShouldBe(0.5f, 0.05f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(0.5f, 0.05f);
     }
 
     [Fact]
@@ -165,7 +165,7 @@ public class AnimationManagerTests
         _manager.HasActiveAnimations.ShouldBeTrue();
 
         _manager.Update(0.5f);
-        element.Style!.Opacity!.Value.ShouldBe(0.5f, 0.05f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(0.5f, 0.05f);
     }
 
     [Fact]
@@ -185,10 +185,10 @@ public class AnimationManagerTests
         _manager.StartAnimation(element, animation);
 
         _manager.Update(1f);
-        element.Style!.Opacity!.Value.ShouldBe(1f, 0.05f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(1f, 0.05f);
 
         _manager.Update(0.5f);
-        element.Style!.Opacity!.Value.ShouldBe(0.5f, 0.05f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(0.5f, 0.05f);
     }
 
     [Fact]
@@ -220,7 +220,7 @@ public class AnimationManagerTests
         _manager.TrackPropertyChange(element, nameof(Style.Opacity), 0.5f, 0f, transition);
 
         _manager.Update(1f);
-        element.Style!.Opacity!.Value.ShouldBe(0f, 0.01f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(0f, 0.01f);
     }
 
     [Fact]
@@ -239,7 +239,7 @@ public class AnimationManagerTests
         _manager.StartAnimation(element, animation);
         _manager.Update(1f);
 
-        element.Style!.Opacity!.Value.ShouldBe(1f, 0.01f);
+        element.Style!.Opacity!.Value.Value.ShouldBe(1f, 0.01f);
     }
 
     [Fact]
@@ -257,8 +257,8 @@ public class AnimationManagerTests
         _manager.StartAnimation(element, animation);
         _manager.Update(0.5f);
 
-        element.Style!.BackgroundColor!.Value.R.ShouldBeInRange((byte)120, (byte)135);
-        element.Style!.BackgroundColor!.Value.B.ShouldBeInRange((byte)120, (byte)135);
+        element.Style!.BackgroundColor!.Value.Value.R.ShouldBeInRange((byte)120, (byte)135);
+        element.Style!.BackgroundColor!.Value.Value.B.ShouldBeInRange((byte)120, (byte)135);
     }
 
     [Fact]

--- a/tests/Miko.Tests/Animation/TransitionTests.cs
+++ b/tests/Miko.Tests/Animation/TransitionTests.cs
@@ -55,7 +55,7 @@ public class TransitionTests
     [Fact]
     public void FluentApi_ShouldCreateTransitionWithExpression()
     {
-        Transition transition = Transition.For<float?>(x => x.Opacity).Duration(0.5f).Linear().Delay(0.1f);
+        Transition transition = Transition.For<StyleProperty<float>?>(x => x.Opacity).Duration(0.5f).Linear().Delay(0.1f);
 
         transition.Property.ShouldBe(nameof(Style.Opacity));
         transition.Duration.ShouldBe(0.5f);
@@ -66,7 +66,7 @@ public class TransitionTests
     [Fact]
     public void FluentApi_ShouldSupportColorProperty()
     {
-        Transition transition = Transition.For<Color?>(x => x.BackgroundColor).Duration(1f).EaseInOut();
+        Transition transition = Transition.For<StyleProperty<Color>?>(x => x.BackgroundColor).Duration(1f).EaseInOut();
 
         transition.Property.ShouldBe(nameof(Style.BackgroundColor));
         transition.TimingFunction.ShouldBe(TimingFunction.EaseInOut);
@@ -75,7 +75,7 @@ public class TransitionTests
     [Fact]
     public void FluentApi_ShouldSupportCubicBezier()
     {
-        Transition transition = Transition.For<float?>(x => x.Opacity).Duration(0.3f).CubicBezier(0.25f, 0.1f, 0.25f, 1f);
+        Transition transition = Transition.For<StyleProperty<float>?>(x => x.Opacity).Duration(0.3f).CubicBezier(0.25f, 0.1f, 0.25f, 1f);
 
         transition.TimingFunction.ShouldBe(TimingFunction.CubicBezier);
         transition.CubicBezier.ShouldNotBeNull();
@@ -85,7 +85,7 @@ public class TransitionTests
     [Fact]
     public void FluentApi_ShouldSupportImplicitConversion()
     {
-        Transition transition = Transition.For<Length?>(x => x.Width).Duration(0.5f);
+        Transition transition = Transition.For<StyleProperty<Length>?>(x => x.Width).Duration(0.5f);
 
         transition.Property.ShouldBe(nameof(Style.Width));
         transition.Duration.ShouldBe(0.5f);

--- a/tests/Miko.Tests/Animation/TransitionTriggerTests.cs
+++ b/tests/Miko.Tests/Animation/TransitionTriggerTests.cs
@@ -101,7 +101,7 @@ public class TransitionTriggerTests : IDisposable
 
         // MaxHeight 应该在中间值附近
         box.Style.ShouldNotBeNull();
-        box.Style!.MaxHeight!.Value.Value.ShouldBe(100f, 1f);
+        box.Style!.MaxHeight!.Value.Value.Value.ShouldBe(100f, 1f);
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class TransitionTriggerTests : IDisposable
         engine.AnimationManager.Update(0.6f);
 
         engine.AnimationManager.HasActiveAnimations.ShouldBeFalse();
-        box.Style!.MaxHeight!.Value.Value.ShouldBe(200f, 1f);
+        box.Style!.MaxHeight!.Value.Value.Value.ShouldBe(200f, 1f);
     }
 
     [Fact]
@@ -179,7 +179,7 @@ public class TransitionTriggerTests : IDisposable
         engine.AnimationManager.Update(0.5f);
 
         // PaddingTop 应该在中间值
-        box.Style!.PaddingTop!.Value.Value.ShouldBe(8f, 1f);
+        box.Style!.PaddingTop!.Value.Value.Value.ShouldBe(8f, 1f);
     }
 
     [Fact]
@@ -215,14 +215,14 @@ public class TransitionTriggerTests : IDisposable
 
         // 模拟 0.3 秒
         engine.AnimationManager.Update(0.3f);
-        float valueAt03 = box.Style!.MaxHeight!.Value.Value;
+        float valueAt03 = box.Style!.MaxHeight!.Value.Value.Value;
 
         // 再次 Render 不应重新触发 transition
         engine.Render(_canvas);
         engine.AnimationManager.Update(0.1f);
 
         // 值应该继续从 0.3s 的位置前进，而不是重新从 0 开始
-        float valueAt04 = box.Style!.MaxHeight!.Value.Value;
+        float valueAt04 = box.Style!.MaxHeight!.Value.Value.Value;
         valueAt04.ShouldBeGreaterThan(valueAt03);
     }
 
@@ -307,6 +307,6 @@ public class TransitionTriggerTests : IDisposable
 
         // 首帧 inline style 应该是起始值 300，不是目标值 0
         box.Style.ShouldNotBeNull();
-        box.Style!.MaxHeight!.Value.Value.ShouldBe(300f, 1f);
+        box.Style!.MaxHeight!.Value.Value.Value.ShouldBe(300f, 1f);
     }
 }

--- a/tests/Miko.Tests/Styling/CustomPropertyTests.cs
+++ b/tests/Miko.Tests/Styling/CustomPropertyTests.cs
@@ -1,0 +1,326 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Shouldly;
+using static Miko.Styling.StyleVar;
+
+namespace Miko.Tests.Styling;
+
+public class CustomPropertyTests
+{
+    [Fact]
+    public void VarBinding_ShouldResolveFromParentCustomProperty()
+    {
+        var resolver = new StyleResolver();
+
+        var parent = new DivElement { Class = "accordion" };
+        var child = new DivElement { Class = "accordion-button" };
+        parent.AddChild(child);
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".accordion"] = new()
+            {
+                CustomProperties = new()
+                {
+                    ["--btn-color"] = Color.Red,
+                }
+            },
+            [".accordion-button"] = new()
+            {
+                Color = Var("--btn-color"),
+            }
+        });
+
+        var parentComputed = resolver.Resolve(parent, [sheet]);
+        parent.LayoutBox = new LayoutBox { Element = parent, ComputedStyle = parentComputed };
+
+        var childComputed = resolver.Resolve(child, [sheet], parentScope: parentComputed.CustomPropertyScope);
+        childComputed.Color.ShouldBe(Color.Red);
+    }
+
+    [Fact]
+    public void VarBinding_ShouldResolveFromOwnCustomProperty()
+    {
+        var resolver = new StyleResolver();
+        var element = new DivElement { Class = "self" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".self"] = new()
+            {
+                CustomProperties = new()
+                {
+                    ["--bg"] = Color.Blue,
+                },
+                BackgroundColor = Var("--bg"),
+            }
+        });
+
+        var computed = resolver.Resolve(element, [sheet]);
+        computed.BackgroundColor.ShouldBe(Color.Blue);
+    }
+
+    [Fact]
+    public void VarBinding_DescendantShouldOverrideAncestorVariable()
+    {
+        var resolver = new StyleResolver();
+
+        var grandparent = new DivElement { Class = "theme-light" };
+        var parent = new DivElement { Class = "theme-dark" };
+        var child = new DivElement { Class = "btn" };
+        grandparent.AddChild(parent);
+        parent.AddChild(child);
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".theme-light"] = new()
+            {
+                CustomProperties = new() { ["--text-color"] = Color.Black }
+            },
+            [".theme-dark"] = new()
+            {
+                CustomProperties = new() { ["--text-color"] = Color.White }
+            },
+            [".btn"] = new()
+            {
+                Color = Var("--text-color"),
+            }
+        });
+
+        var gpComputed = resolver.Resolve(grandparent, [sheet]);
+        grandparent.LayoutBox = new LayoutBox { Element = grandparent, ComputedStyle = gpComputed };
+
+        var parentComputed = resolver.Resolve(parent, [sheet], parentScope: gpComputed.CustomPropertyScope);
+        parent.LayoutBox = new LayoutBox { Element = parent, ComputedStyle = parentComputed };
+
+        var childComputed = resolver.Resolve(child, [sheet], parentScope: parentComputed.CustomPropertyScope);
+        childComputed.Color.ShouldBe(Color.White);
+    }
+
+    [Fact]
+    public void VarBinding_ShouldUseFallbackWhenVariableNotDefined()
+    {
+        var resolver = new StyleResolver();
+        var element = new DivElement { Class = "fallback" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".fallback"] = new()
+            {
+                BackgroundColor = new VarReference("--undefined-var", Color.Green),
+            }
+        });
+
+        var computed = resolver.Resolve(element, [sheet]);
+        computed.BackgroundColor.ShouldBe(Color.Green);
+    }
+
+    [Fact]
+    public void VarBinding_ShouldNotOverrideConcreteValueFromHigherSpecificity()
+    {
+        var resolver = new StyleResolver();
+        var element = new DivElement { Id = "specific", Class = "general" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".general"] = new()
+            {
+                CustomProperties = new() { ["--color"] = Color.Red },
+                Color = Var("--color"),
+            },
+            ["#specific"] = new()
+            {
+                Color = Color.Blue,
+            }
+        });
+
+        var computed = resolver.Resolve(element, [sheet]);
+        computed.Color.ShouldBe(Color.Blue);
+    }
+
+    [Fact]
+    public void VarBinding_ShouldWorkWithLengthType()
+    {
+        var resolver = new StyleResolver();
+        var element = new DivElement { Class = "sized" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".sized"] = new()
+            {
+                CustomProperties = new()
+                {
+                    ["--spacing"] = Length.Px(20),
+                },
+                PaddingTop = Var("--spacing"),
+                PaddingBottom = Var("--spacing"),
+            }
+        });
+
+        var computed = resolver.Resolve(element, [sheet]);
+        computed.PaddingTop.Value.ShouldBe(20);
+        computed.PaddingBottom.Value.ShouldBe(20);
+    }
+
+    [Fact]
+    public void VarBinding_TypeMismatchShouldBeIgnored()
+    {
+        var resolver = new StyleResolver();
+        var element = new DivElement { Class = "mismatch" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".mismatch"] = new()
+            {
+                CustomProperties = new()
+                {
+                    ["--a-color"] = Color.Red,
+                },
+                PaddingTop = Var("--a-color"),
+            }
+        });
+
+        var computed = resolver.Resolve(element, [sheet]);
+        computed.PaddingTop.Value.ShouldBe(0);
+    }
+
+    [Fact]
+    public void VarBinding_InlineStyleShouldOverrideVarBinding()
+    {
+        var resolver = new StyleResolver();
+        var element = new DivElement
+        {
+            Class = "var-test",
+            Style = new Style { Color = Color.Yellow }
+        };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".var-test"] = new()
+            {
+                CustomProperties = new() { ["--color"] = Color.Red },
+                Color = Var("--color"),
+            }
+        });
+
+        var computed = resolver.Resolve(element, [sheet]);
+        computed.Color.ShouldBe(Color.Yellow);
+    }
+
+    [Fact]
+    public void CustomPropertyScope_ShouldChainCorrectly()
+    {
+        var root = new CustomPropertyScope();
+        root.Set("--a", Color.Red);
+        root.Set("--b", Color.Blue);
+
+        var child = root.CreateChild();
+        child.Set("--a", Color.Green);
+
+        root.Get<Color>("--a").ShouldBe(Color.Red);
+        root.Get<Color>("--b").ShouldBe(Color.Blue);
+        child.Get<Color>("--a").ShouldBe(Color.Green);
+        child.Get<Color>("--b").ShouldBe(Color.Blue);
+        child.Get<Color>("--c").ShouldBeNull();
+    }
+
+    [Fact]
+    public void VarBinding_ShouldWorkThroughLayoutEngine()
+    {
+        var parent = new DivElement { Class = "container" };
+        var child = new DivElement { Class = "item" };
+        parent.AddChild(child);
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".container"] = new()
+            {
+                Display = Display.Block,
+                Width = Length.Px(500),
+                CustomProperties = new()
+                {
+                    ["--item-bg"] = Color.Red,
+                    ["--item-padding"] = Length.Px(10),
+                }
+            },
+            [".item"] = new()
+            {
+                BackgroundColor = Var("--item-bg"),
+                PaddingTop = Var("--item-padding"),
+            }
+        });
+
+        var engine = new LayoutEngine();
+        engine.Layout(parent, [sheet], 800, 600);
+
+        child.LayoutBox.ShouldNotBeNull();
+        child.LayoutBox!.ComputedStyle.BackgroundColor.ShouldBe(Color.Red);
+        child.LayoutBox.ComputedStyle.PaddingTop.Value.ShouldBe(10);
+    }
+
+    [Fact]
+    public void VarBinding_NoVariablesUsed_ShouldHaveZeroOverhead()
+    {
+        var resolver = new StyleResolver();
+        var element = new DivElement { Class = "plain" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".plain"] = new()
+            {
+                Color = Color.Red,
+                Width = Length.Px(100),
+            }
+        });
+
+        var computed = resolver.Resolve(element, [sheet]);
+        computed.Color.ShouldBe(Color.Red);
+        computed.Width.Value.ShouldBe(100);
+    }
+
+    [Fact]
+    public void StyleProperty_ImplicitConversion_ShouldWork()
+    {
+        var style = new Style();
+
+        style.Color = Color.Red;
+        style.Display = Display.Flex;
+        style.Width = Length.Px(100);
+        style.Opacity = 0.5f;
+
+        style.Color.ShouldNotBeNull();
+        style.Color!.Value.TryGetValue(out var color).ShouldBeTrue();
+        color.ShouldBe(Color.Red);
+
+        style.Display!.Value.TryGetValue(out var display).ShouldBeTrue();
+        display.ShouldBe(Display.Flex);
+    }
+
+    [Fact]
+    public void StyleProperty_VarReference_ShouldWork()
+    {
+        var style = new Style();
+
+        style.Color = Var("--my-color");
+        style.Width = Var("--my-width");
+
+        style.Color.ShouldNotBeNull();
+        style.Color!.Value.IsVar.ShouldBeTrue();
+        style.Color!.Value.Var.Name.ShouldBe("--my-color");
+
+        style.Width!.Value.IsVar.ShouldBeTrue();
+        style.Width!.Value.Var.Name.ShouldBe("--my-width");
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce `StyleProperty<T>` union struct enabling each style property to hold a concrete value or a `VarReference`, with implicit conversions for natural C# syntax (`Color = Color.Red` or `Color = Var("--my-color")`)
- Implement `StyleValue` zero-boxing union struct using `StructLayout(Explicit)` and `Unsafe.As` for CSS variable storage, eliminating heap allocations from boxing
- Add `CustomPropertyScope` chained scope structure for variable inheritance and override down the DOM tree
- Migrate all ~60 Style value-type properties from `T?` to `StyleProperty<T>?`, with `??=` cascade semantics preserved
- Replace reflection-based variable resolution with per-property compile-time dispatch in `StyleResolver`

## Test plan

- [x] `dotnet build miko.slnx` — 0 errors
- [x] `dotnet test` — all 681 tests pass
- [x] New tests cover: variable resolution from parent, self-resolution, descendant override, fallback values, type mismatch handling, inline style priority, LayoutEngine integration, StyleProperty implicit conversions, scope chaining