### PR TITLE
Add DevTools package, fix flex layout and text rendering

### DIFF
--- a/examples/MikoApp1.Razor/MikoApp1.Razor.csproj
+++ b/examples/MikoApp1.Razor/MikoApp1.Razor.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Miko.Bootstrap\Miko.Bootstrap.csproj" />
+    <ProjectReference Include="..\..\src\Miko.DevTools\Miko.DevTools.csproj" />
     <ProjectReference Include="..\..\src\Miko\Miko.csproj" />
   </ItemGroup>
 

--- a/examples/MikoApp1.Razor/RazorApp.cs
+++ b/examples/MikoApp1.Razor/RazorApp.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Miko.Bootstrap;
+using Miko.DevTools;
 using Miko.Hosting;
 
 namespace MikoApp1.Razor;
@@ -11,6 +12,7 @@ public static class RazorApp
         var builder = MikoAppBuilder.CreateDefault();
         builder.UseTitle("Miko Razor Demo");
         builder.AddBootstrap();
+        builder.AddDevTools();
         builder.AddStyleSheet(GlobalStyles.Create());
         builder.UseSize(1024, 768);
         builder.UseGeneratedRoutes();

--- a/miko.slnx
+++ b/miko.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="src/Miko.Bootstrap/Miko.Bootstrap.csproj" />
+    <Project Path="src/Miko.DevTools/Miko.DevTools.csproj" />
     <Project Path="src/Miko/Miko.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/src/Miko.DevTools/DevToolsBridge.cs
+++ b/src/Miko.DevTools/DevToolsBridge.cs
@@ -1,0 +1,140 @@
+using System.Collections.Concurrent;
+using Miko.Common;
+using Miko.Core;
+using Miko.DevTools.Logging;
+using Miko.Layout;
+using Miko.Rendering;
+using SkiaSharp;
+
+namespace Miko.DevTools;
+
+public class DevToolsBridge
+{
+    private readonly DevToolsOptions _options;
+    private DevToolsWindow? _devToolsWindow;
+
+    public MikoEngine? MainEngine { get; private set; }
+    public RenderEngine? MainRenderEngine { get; private set; }
+    public ConcurrentQueue<LogEntry> LogBuffer { get; } = new();
+    public bool IsOpen { get; internal set; }
+
+    private volatile Element? _selectedElement;
+    public Element? SelectedElement
+    {
+        get => _selectedElement;
+        set
+        {
+            if (_selectedElement != value)
+            {
+                _selectedElement = value;
+                UpdateOverlay();
+                MarkDevToolsDirty();
+            }
+        }
+    }
+
+    public DevToolsBridge(DevToolsOptions options)
+    {
+        _options = options;
+    }
+
+    public void Initialize(MikoEngine mainEngine, RenderEngine mainRenderEngine)
+    {
+        MainEngine = mainEngine;
+        MainRenderEngine = mainRenderEngine;
+    }
+
+    public void ToggleDevTools()
+    {
+        if (IsOpen)
+            CloseDevTools();
+        else
+            OpenDevTools();
+    }
+
+    public void OpenDevTools()
+    {
+        if (IsOpen || MainEngine == null) return;
+        IsOpen = true;
+        _devToolsWindow = new DevToolsWindow(this, _options);
+        _devToolsWindow.Open();
+    }
+
+    public void CloseDevTools()
+    {
+        if (!IsOpen) return;
+        IsOpen = false;
+        SelectedElement = null;
+        _devToolsWindow?.Close();
+        _devToolsWindow = null;
+    }
+
+    internal void MarkDevToolsDirty()
+    {
+        _devToolsWindow?.MarkDirty();
+    }
+
+    private void UpdateOverlay()
+    {
+        if (MainRenderEngine == null) return;
+
+        var selected = _selectedElement;
+        if (selected == null)
+        {
+            MainRenderEngine.OverlayCallback = null;
+            return;
+        }
+
+        MainRenderEngine.OverlayCallback = canvas =>
+        {
+            var element = _selectedElement;
+            if (element == null || MainEngine == null) return;
+
+            var layoutBox = FindLayoutBox(MainEngine.GetCurrentLayout(), element);
+            if (layoutBox == null) return;
+
+            DrawHighlight(canvas, layoutBox);
+        };
+    }
+
+    private static LayoutBox? FindLayoutBox(LayoutBox? root, Element element)
+    {
+        if (root == null) return null;
+        if (root.Element == element) return root;
+        foreach (var child in root.Children)
+        {
+            var found = FindLayoutBox(child, element);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    private static void DrawHighlight(SKCanvas canvas, LayoutBox box)
+    {
+        var margin = box.BoxModel.MarginBox;
+        var border = box.BoxModel.BorderBox;
+        var padding = box.BoxModel.PaddingBox;
+        var content = box.BoxModel.Content;
+
+        using var marginPaint = new SKPaint { Color = new SKColor(246, 178, 107, 60), Style = SKPaintStyle.Fill };
+        canvas.DrawRect(margin.X, margin.Y, margin.Width, margin.Height, marginPaint);
+
+        using var borderPaint = new SKPaint { Color = new SKColor(253, 216, 53, 60), Style = SKPaintStyle.Fill };
+        canvas.DrawRect(border.X, border.Y, border.Width, border.Height, borderPaint);
+
+        using var paddingPaint = new SKPaint { Color = new SKColor(129, 199, 132, 60), Style = SKPaintStyle.Fill };
+        canvas.DrawRect(padding.X, padding.Y, padding.Width, padding.Height, paddingPaint);
+
+        using var contentPaint = new SKPaint { Color = new SKColor(100, 150, 255, 60), Style = SKPaintStyle.Fill };
+        canvas.DrawRect(content.X, content.Y, content.Width, content.Height, contentPaint);
+
+        using var outlinePaint = new SKPaint
+        {
+            Color = new SKColor(66, 133, 244, 200),
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = 1.5f,
+            IsAntialias = true
+        };
+        canvas.DrawRect(border.X, border.Y, border.Width, border.Height, outlinePaint);
+    }
+}

--- a/src/Miko.DevTools/DevToolsExtensions.cs
+++ b/src/Miko.DevTools/DevToolsExtensions.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Miko.DevTools.Logging;
+using Miko.Hosting;
+using Miko.Rendering;
+using Silk.NET.Input;
+
+namespace Miko.DevTools;
+
+public static class DevToolsExtensions
+{
+    public static MikoAppBuilder AddDevTools(this MikoAppBuilder builder, Action<DevToolsOptions>? configure = null)
+    {
+        var options = new DevToolsOptions();
+        configure?.Invoke(options);
+
+        var bridge = new DevToolsBridge(options);
+        var loggerProvider = new DevToolsLoggerProvider(bridge.LogBuffer);
+
+        builder.Services.AddSingleton(bridge);
+        builder.Services.AddSingleton<ILoggerProvider>(loggerProvider);
+
+        builder.AddGlobalKeyHandler(key =>
+        {
+            if (key == Key.F12)
+            {
+                bridge.ToggleDevTools();
+                return true;
+            }
+            return false;
+        });
+
+        builder.Services.Configure<MikoAppOptions>(o =>
+        {
+            o.PostInitHooks.Add(sp =>
+            {
+                var engine = sp.GetRequiredService<Core.MikoEngine>();
+                var renderEngine = sp.GetRequiredService<RenderEngine>();
+                bridge.Initialize(engine, renderEngine);
+            });
+        });
+
+        return builder;
+    }
+}

--- a/src/Miko.DevTools/DevToolsOptions.cs
+++ b/src/Miko.DevTools/DevToolsOptions.cs
@@ -1,0 +1,7 @@
+namespace Miko.DevTools;
+
+public class DevToolsOptions
+{
+    public int Width { get; set; } = 900;
+    public int Height { get; set; } = 600;
+}

--- a/src/Miko.DevTools/DevToolsWindow.cs
+++ b/src/Miko.DevTools/DevToolsWindow.cs
@@ -1,0 +1,370 @@
+using Microsoft.Extensions.Logging;
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.DevTools.Panels;
+using Miko.DevTools.Styles;
+using Miko.Events;
+using Miko.Layout;
+using Miko.Rendering;
+using Silk.NET.Input;
+using Silk.NET.Maths;
+using Silk.NET.OpenGL;
+using Silk.NET.Windowing;
+using SkiaSharp;
+using SilkMouseButton = Silk.NET.Input.MouseButton;
+
+namespace Miko.DevTools;
+
+internal class DevToolsWindow
+{
+    private readonly DevToolsBridge _bridge;
+    private readonly DevToolsOptions _options;
+    private readonly MikoEngine _engine;
+    private readonly EventDispatcher _eventDispatcher = new();
+
+    private Thread? _thread;
+    private IWindow? _window;
+    private IInputContext? _inputContext;
+    private GL? _gl;
+    private GRContext? _grContext;
+    private int _width;
+    private int _height;
+    private volatile bool _shouldClose;
+
+    private Element? _lastRoot;
+    private volatile bool _needsRebuild;
+    private bool _scrollToConsoleBottom;
+
+    private bool _isDragging;
+    private MikoEngine.ScrollbarHitResult? _draggingScrollbar;
+
+    private string _activeTab = "elements";
+    private Element? _lastSelectedElement;
+    private int _lastLogBufferCount;
+    private LogLevel _consoleFilterLevel = LogLevel.Trace;
+
+    public DevToolsWindow(DevToolsBridge bridge, DevToolsOptions options)
+    {
+        _bridge = bridge;
+        _options = options;
+        _engine = new MikoEngine();
+        _width = options.Width;
+        _height = options.Height;
+    }
+
+    public void Open()
+    {
+        _shouldClose = false;
+        _thread = new Thread(RunWindow) { IsBackground = true, Name = "DevToolsWindow" };
+        _thread.Start();
+    }
+
+    public void Close()
+    {
+        _shouldClose = true;
+    }
+
+    private void RunWindow()
+    {
+        var options = WindowOptions.Default with
+        {
+            Title = "Miko DevTools",
+            Size = new Vector2D<int>(_width, _height),
+            API = GraphicsAPI.Default
+        };
+
+        _window = Window.Create(options);
+        _window.Load += OnLoad;
+        _window.Update += OnUpdate;
+        _window.Render += OnRender;
+        _window.Resize += OnResize;
+        _window.Closing += OnClose;
+        _window.Run();
+        _window.Dispose();
+    }
+
+    private void OnLoad()
+    {
+        _gl = _window!.CreateOpenGL();
+
+        var grInterface = GRGlInterface.Create(name =>
+        {
+            if (_window!.GLContext!.TryGetProcAddress(name, out var addr))
+                return addr;
+            return IntPtr.Zero;
+        });
+
+        _grContext = GRContext.CreateGl(grInterface);
+
+        _inputContext = _window!.CreateInput();
+        foreach (var mouse in _inputContext.Mice)
+        {
+            mouse.MouseDown += OnMouseDown;
+            mouse.MouseUp += OnMouseUp;
+            mouse.MouseMove += OnMouseMove;
+            mouse.Scroll += OnMouseScroll;
+        }
+
+        foreach (var keyboard in _inputContext.Keyboards)
+        {
+            keyboard.KeyDown += OnKeyDown;
+        }
+
+        var root = BuildUI();
+        var styleSheets = new List<Styling.StyleSheet> { DevToolsStyleSheet.Create() };
+        using var tempSurface = SKSurface.Create(new SKImageInfo(_width, _height));
+        _engine.Initialize(root, styleSheets, tempSurface.Canvas, _width, _height);
+    }
+
+    private void OnUpdate(double _)
+    {
+        if (_shouldClose)
+        {
+            _window?.Close();
+        }
+    }
+
+    private void OnRender(double _)
+    {
+        if (_grContext == null || _gl == null) return;
+
+        bool shouldRebuild = _needsRebuild;
+        _needsRebuild = false;
+
+        var currentRoot = _bridge.MainEngine?.GetRoot();
+        if (currentRoot != _lastRoot)
+        {
+            _lastRoot = currentRoot;
+            shouldRebuild = true;
+        }
+
+        if (_bridge.SelectedElement != _lastSelectedElement)
+        {
+            _lastSelectedElement = _bridge.SelectedElement;
+            shouldRebuild = true;
+        }
+
+        var currentLogCount = _bridge.LogBuffer.Count;
+        if (_activeTab == "console" && currentLogCount != _lastLogBufferCount)
+        {
+            _lastLogBufferCount = currentLogCount;
+            shouldRebuild = true;
+            _scrollToConsoleBottom = true;
+        }
+
+        if (shouldRebuild)
+        {
+            RebuildUI();
+        }
+
+        if (_scrollToConsoleBottom)
+        {
+            _scrollToConsoleBottom = false;
+            ScrollConsoleToBottom();
+        }
+
+        int fboId = _gl.GetInteger(GLEnum.FramebufferBinding);
+        var fbInfo = new GRGlFramebufferInfo((uint)fboId, 0x8058);
+        var target = new GRBackendRenderTarget(_width, _height, 0, 8, fbInfo);
+
+        using var surface = SKSurface.Create(_grContext, target, GRSurfaceOrigin.BottomLeft, SKColorType.Rgba8888);
+        var canvas = surface.Canvas;
+        canvas.Clear(new SKColor(36, 36, 36));
+        _engine.Render(canvas);
+        canvas.Flush();
+        _grContext.Flush();
+    }
+
+    private void OnResize(Vector2D<int> size)
+    {
+        _width = size.X;
+        _height = size.Y;
+        _gl?.Viewport(size);
+        _engine.SetViewportSize(size.X, size.Y);
+    }
+
+    private void OnMouseDown(IMouse mouse, SilkMouseButton button)
+    {
+        if (button != SilkMouseButton.Left) return;
+
+        var scrollbarHit = _engine.HitTestScrollbar(mouse.Position.X, mouse.Position.Y);
+        if (scrollbarHit != null)
+        {
+            _draggingScrollbar = scrollbarHit;
+            _isDragging = true;
+            if (scrollbarHit.HitType == MikoEngine.ScrollbarHitType.VerticalThumb ||
+                scrollbarHit.HitType == MikoEngine.ScrollbarHitType.HorizontalThumb)
+            {
+                return;
+            }
+        }
+
+        var target = _engine.HitTest(mouse.Position.X, mouse.Position.Y);
+        if (target == null) return;
+
+        var args = new MouseEventArgs
+        {
+            Target = target,
+            X = mouse.Position.X,
+            Y = mouse.Position.Y,
+            Button = Events.MouseButton.Left,
+            Bubbles = true
+        };
+        _eventDispatcher.Dispatch(target, EventTypes.Click, args);
+    }
+
+    private void OnMouseUp(IMouse mouse, SilkMouseButton button)
+    {
+        if (button != SilkMouseButton.Left) return;
+
+        if (_isDragging && _draggingScrollbar != null)
+        {
+            var hit = _draggingScrollbar;
+            _draggingScrollbar = null;
+            _isDragging = false;
+            if (hit.HitType == MikoEngine.ScrollbarHitType.VerticalTrack ||
+                hit.HitType == MikoEngine.ScrollbarHitType.HorizontalTrack)
+            {
+                _engine.ScrollTrackClick(hit.Box, hit.HitType, mouse.Position.X, mouse.Position.Y);
+            }
+            return;
+        }
+
+        _isDragging = false;
+    }
+
+    private void OnMouseMove(IMouse mouse, System.Numerics.Vector2 position)
+    {
+        if (!_isDragging || _draggingScrollbar == null) return;
+
+        var hit = _draggingScrollbar;
+        if (hit.HitType == MikoEngine.ScrollbarHitType.VerticalThumb)
+            _engine.DragVerticalThumb(hit.Box, position.Y, hit.ThumbOffset);
+        else if (hit.HitType == MikoEngine.ScrollbarHitType.HorizontalThumb)
+            _engine.DragHorizontalThumb(hit.Box, position.X, hit.ThumbOffset);
+    }
+
+    private void OnMouseScroll(IMouse mouse, ScrollWheel scrollWheel)
+    {
+        float deltaY = scrollWheel.Y * -40f;
+        float deltaX = scrollWheel.X * -40f;
+        _engine.ScrollBy(mouse.Position.X, mouse.Position.Y, deltaX, deltaY);
+    }
+
+    private void OnKeyDown(IKeyboard keyboard, Key key, int scancode)
+    {
+        if (key == Key.Escape || key == Key.F12)
+        {
+            _bridge.CloseDevTools();
+        }
+    }
+
+    private void OnClose()
+    {
+        _bridge.IsOpen = false;
+        _bridge.SelectedElement = null;
+        _inputContext?.Dispose();
+        _grContext?.Dispose();
+        _gl?.Dispose();
+    }
+
+    internal void MarkDirty()
+    {
+        _needsRebuild = true;
+    }
+
+    private void ScrollConsoleToBottom()
+    {
+        var layout = _engine.GetCurrentLayout();
+        if (layout == null) return;
+
+        var outputBox = FindLayoutBoxByClass(layout, "console-output");
+        if (outputBox == null || !outputBox.HasVerticalScrollbar) return;
+
+        float maxScroll = outputBox.ScrollableContentHeight - outputBox.BoxModel.PaddingBox.Height;
+        if (maxScroll > 0)
+        {
+            outputBox.ScrollTop = maxScroll;
+        }
+    }
+
+    private static LayoutBox? FindLayoutBoxByClass(LayoutBox box, string className)
+    {
+        if (box.Element.HasClass(className)) return box;
+        foreach (var child in box.Children)
+        {
+            var found = FindLayoutBoxByClass(child, className);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    private void RebuildUI()
+    {
+        var root = BuildUI();
+        var styleSheets = new List<Styling.StyleSheet> { DevToolsStyleSheet.Create() };
+        using var tempSurface = SKSurface.Create(new SKImageInfo(_width, _height));
+        _engine.Initialize(root, styleSheets, tempSurface.Canvas, _width, _height);
+    }
+
+    private Element BuildUI()
+    {
+        var root = new DivElement { Id = "devtools-root", Class = "devtools-root" };
+
+        var toolbar = BuildToolbar();
+        root.AddChild(toolbar);
+
+        var content = new DivElement { Id = "devtools-content", Class = "devtools-content" };
+
+        var elementsPanel = ElementsPanel.Build(_bridge, _activeTab == "elements");
+        var consolePanel = ConsolePanel.Build(_bridge, _consoleFilterLevel, _activeTab == "console", level =>
+        {
+            _consoleFilterLevel = level;
+            _needsRebuild = true;
+        });
+
+        content.AddChild(elementsPanel);
+        content.AddChild(consolePanel);
+
+        root.AddChild(content);
+        return root;
+    }
+
+    private DivElement BuildToolbar()
+    {
+        var toolbar = new DivElement { Class = "devtools-toolbar" };
+
+        var elementsTabBtn = new DivElement
+        {
+            Class = _activeTab == "elements" ? "devtools-tab devtools-tab-active" : "devtools-tab",
+            TextContent = "Elements"
+        };
+        elementsTabBtn.OnClick = _ =>
+        {
+            if (_activeTab != "elements")
+            {
+                _activeTab = "elements";
+                _needsRebuild = true;
+            }
+        };
+
+        var consoleTabBtn = new DivElement
+        {
+            Class = _activeTab == "console" ? "devtools-tab devtools-tab-active" : "devtools-tab",
+            TextContent = "Console"
+        };
+        consoleTabBtn.OnClick = _ =>
+        {
+            if (_activeTab != "console")
+            {
+                _activeTab = "console";
+                _needsRebuild = true;
+            }
+        };
+
+        toolbar.AddChild(elementsTabBtn);
+        toolbar.AddChild(consoleTabBtn);
+        return toolbar;
+    }
+}

--- a/src/Miko.DevTools/Logging/DevToolsLogger.cs
+++ b/src/Miko.DevTools/Logging/DevToolsLogger.cs
@@ -1,0 +1,28 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Miko.DevTools.Logging;
+
+internal class DevToolsLogger : ILogger
+{
+    private readonly string _category;
+    private readonly ConcurrentQueue<LogEntry> _buffer;
+
+    public DevToolsLogger(string category, ConcurrentQueue<LogEntry> buffer)
+    {
+        _category = category;
+        _buffer = buffer;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel)) return;
+
+        var message = formatter(state, exception);
+        _buffer.Enqueue(new LogEntry(DateTimeOffset.Now, logLevel, _category, message, exception));
+    }
+}

--- a/src/Miko.DevTools/Logging/DevToolsLoggerProvider.cs
+++ b/src/Miko.DevTools/Logging/DevToolsLoggerProvider.cs
@@ -1,0 +1,25 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Miko.DevTools.Logging;
+
+internal class DevToolsLoggerProvider : ILoggerProvider
+{
+    private readonly ConcurrentQueue<LogEntry> _buffer;
+    private readonly ConcurrentDictionary<string, DevToolsLogger> _loggers = new();
+
+    public DevToolsLoggerProvider(ConcurrentQueue<LogEntry> buffer)
+    {
+        _buffer = buffer;
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return _loggers.GetOrAdd(categoryName, name => new DevToolsLogger(name, _buffer));
+    }
+
+    public void Dispose()
+    {
+        _loggers.Clear();
+    }
+}

--- a/src/Miko.DevTools/Logging/LogEntry.cs
+++ b/src/Miko.DevTools/Logging/LogEntry.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.Logging;
+
+namespace Miko.DevTools.Logging;
+
+public record LogEntry(
+    DateTimeOffset Timestamp,
+    LogLevel Level,
+    string Category,
+    string Message,
+    Exception? Exception);

--- a/src/Miko.DevTools/Miko.DevTools.csproj
+++ b/src/Miko.DevTools/Miko.DevTools.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Miko.DevTools</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Miko\Miko.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Miko.DevTools/Panels/ConsolePanel.cs
+++ b/src/Miko.DevTools/Panels/ConsolePanel.cs
@@ -1,0 +1,145 @@
+using Microsoft.Extensions.Logging;
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.DevTools.Logging;
+using Miko.Styling;
+
+namespace Miko.DevTools.Panels;
+
+internal static class ConsolePanel
+{
+    private static readonly List<LogEntry> _entries = new();
+
+    public static DivElement Build(DevToolsBridge bridge, LogLevel filterLevel, bool visible, Action<LogLevel>? onFilterChange = null)
+    {
+        var panel = new DivElement { Class = "console-panel" };
+        if (!visible)
+        {
+            panel.Style = new Style { Display = Display.None };
+        }
+
+        DrainBuffer(bridge);
+
+        var filterBar = BuildFilterBar(bridge, filterLevel, onFilterChange ?? (_ => { }));
+        panel.AddChild(filterBar);
+
+        var output = new DivElement { Class = "console-output" };
+
+        var filtered = _entries.Where(e => e.Level >= filterLevel).ToList();
+
+        if (filtered.Count == 0)
+        {
+            output.AddChild(new DivElement
+            {
+                Class = "console-empty",
+                TextContent = "No log entries"
+            });
+        }
+        else
+        {
+            foreach (var entry in filtered.TakeLast(500))
+            {
+                output.AddChild(BuildLogEntry(entry));
+            }
+        }
+
+        panel.AddChild(output);
+        return panel;
+    }
+
+    private static void DrainBuffer(DevToolsBridge bridge)
+    {
+        while (bridge.LogBuffer.TryDequeue(out var entry))
+        {
+            _entries.Add(entry);
+            if (_entries.Count > 10000)
+                _entries.RemoveAt(0);
+        }
+    }
+
+    private static DivElement BuildFilterBar(DevToolsBridge bridge, LogLevel currentLevel, Action<LogLevel> onFilterChange)
+    {
+        var bar = new DivElement { Class = "console-filter-bar" };
+        bar.AddChild(new SpanElement { Class = "console-filter-label", TextContent = "Level:" });
+
+        var levels = new[] { LogLevel.Trace, LogLevel.Debug, LogLevel.Information, LogLevel.Warning, LogLevel.Error };
+        foreach (var level in levels)
+        {
+            var capturedLevel = level;
+            var btn = new DivElement
+            {
+                Class = level == currentLevel
+                    ? "console-filter-btn console-filter-btn-active"
+                    : "console-filter-btn",
+                TextContent = FormatLevel(level)
+            };
+            btn.OnClick = _ =>
+            {
+                onFilterChange(capturedLevel);
+            };
+            bar.AddChild(btn);
+        }
+
+        return bar;
+    }
+
+    private static DivElement BuildLogEntry(LogEntry entry)
+    {
+        var levelClass = entry.Level switch
+        {
+            LogLevel.Trace => "console-entry-trace",
+            LogLevel.Debug => "console-entry-debug",
+            LogLevel.Information => "console-entry-info",
+            LogLevel.Warning => "console-entry-warning",
+            LogLevel.Error => "console-entry-error",
+            LogLevel.Critical => "console-entry-critical",
+            _ => "console-entry-info"
+        };
+
+        var row = new DivElement { Class = $"console-entry {levelClass}" };
+
+        var timestamp = new SpanElement
+        {
+            Class = "console-timestamp",
+            TextContent = entry.Timestamp.ToString("HH:mm:ss.fff")
+        };
+        row.AddChild(timestamp);
+
+        var shortCategory = ShortenCategory(entry.Category);
+        var category = new SpanElement
+        {
+            Class = "console-category",
+            TextContent = $"[{shortCategory}]"
+        };
+        row.AddChild(category);
+
+        row.AddChild(new SpanElement { TextContent = entry.Message });
+
+        if (entry.Exception != null)
+        {
+            row.AddChild(new DivElement
+            {
+                Class = "console-entry-error",
+                TextContent = entry.Exception.Message
+            });
+        }
+
+        return row;
+    }
+
+    private static string ShortenCategory(string category)
+    {
+        var lastDot = category.LastIndexOf('.');
+        return lastDot >= 0 ? category[(lastDot + 1)..] : category;
+    }
+
+    private static string FormatLevel(LogLevel level) => level switch
+    {
+        LogLevel.Trace => "Trace",
+        LogLevel.Debug => "Debug",
+        LogLevel.Information => "Info",
+        LogLevel.Warning => "Warn",
+        LogLevel.Error => "Error",
+        _ => level.ToString()
+    };
+}

--- a/src/Miko.DevTools/Panels/DomTreeBuilder.cs
+++ b/src/Miko.DevTools/Panels/DomTreeBuilder.cs
@@ -1,0 +1,138 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+
+namespace Miko.DevTools.Panels;
+
+internal static class DomTreeBuilder
+{
+    private static readonly HashSet<Element> _collapsedElements = new();
+
+    public static DivElement Build(DevToolsBridge bridge)
+    {
+        var container = new DivElement { Class = "dom-tree-panel" };
+
+        var root = bridge.MainEngine?.GetRoot();
+        if (root == null)
+        {
+            container.AddChild(new DivElement
+            {
+                Class = "console-empty",
+                TextContent = "No DOM tree available"
+            });
+            return container;
+        }
+
+        BuildTreeNode(container, root, bridge, 0);
+        return container;
+    }
+
+    private static void BuildTreeNode(DivElement parent, Element element, DevToolsBridge bridge, int depth)
+    {
+        var node = new DivElement();
+
+        bool isSelected = bridge.SelectedElement == element;
+        node.Class = isSelected ? "tree-node tree-node-selected" : "tree-node";
+        node.Style = new Styling.Style
+        {
+            PaddingLeft = Length.Px(depth * 16 + 4)
+        };
+
+        bool hasChildren = element.Children.Count > 0;
+        bool isCollapsed = _collapsedElements.Contains(element);
+
+        var line = new DivElement { Style = new Styling.Style { Display = Display.Flex, FlexDirection = FlexDirection.Row } };
+
+        if (hasChildren)
+        {
+            var toggle = new SpanElement
+            {
+                Class = "tree-toggle",
+                TextContent = isCollapsed ? "▶" : "▼"
+            };
+            toggle.OnClick = args =>
+            {
+                args.StopPropagation();
+                if (_collapsedElements.Contains(element))
+                    _collapsedElements.Remove(element);
+                else
+                    _collapsedElements.Add(element);
+                bridge.MarkDevToolsDirty();
+            };
+            line.AddChild(toggle);
+        }
+        else
+        {
+            line.AddChild(new SpanElement
+            {
+                Class = "tree-toggle",
+                TextContent = " "
+            });
+        }
+
+        var tag = new SpanElement
+        {
+            Class = "tree-node-tag",
+            TextContent = $"<{element.TagName}"
+        };
+        line.AddChild(tag);
+
+        if (!string.IsNullOrEmpty(element.Id))
+        {
+            line.AddChild(new SpanElement { Class = "tree-node-attr", TextContent = $" id=" });
+            line.AddChild(new SpanElement { Class = "tree-node-string", TextContent = $"\"{element.Id}\"" });
+        }
+
+        if (!string.IsNullOrEmpty(element.Class))
+        {
+            line.AddChild(new SpanElement { Class = "tree-node-attr", TextContent = $" class=" });
+            line.AddChild(new SpanElement { Class = "tree-node-string", TextContent = $"\"{element.Class}\"" });
+        }
+
+        line.AddChild(new SpanElement { Class = "tree-node-tag", TextContent = ">" });
+
+        if (!string.IsNullOrEmpty(element.TextContent) && element.Children.Count == 0)
+        {
+            var textPreview = element.TextContent.Length > 40
+                ? element.TextContent[..40] + "..."
+                : element.TextContent;
+            line.AddChild(new SpanElement { Class = "tree-node-text", TextContent = textPreview });
+            line.AddChild(new SpanElement { Class = "tree-node-tag", TextContent = $"</{element.TagName}>" });
+        }
+
+        node.AddChild(line);
+
+        node.OnClick = _ =>
+        {
+            bridge.SelectedElement = element;
+        };
+
+        parent.AddChild(node);
+
+        if (hasChildren && !isCollapsed)
+        {
+            foreach (var child in element.Children)
+            {
+                BuildTreeNode(parent, child, bridge, depth + 1);
+            }
+
+            var closingTag = new DivElement
+            {
+                Class = "tree-node",
+                Style = new Styling.Style { PaddingLeft = Length.Px(depth * 16 + 4) }
+            };
+            var closingLine = new DivElement
+            {
+                Style = new Styling.Style { Display = Display.Flex, FlexDirection = FlexDirection.Row }
+            };
+            closingLine.AddChild(new SpanElement { Class = "tree-toggle", TextContent = " " });
+            closingLine.AddChild(new SpanElement
+            {
+                Class = "tree-node-tag",
+                TextContent = $"</{element.TagName}>"
+            });
+            closingTag.AddChild(closingLine);
+            parent.AddChild(closingTag);
+        }
+    }
+}

--- a/src/Miko.DevTools/Panels/ElementsPanel.cs
+++ b/src/Miko.DevTools/Panels/ElementsPanel.cs
@@ -1,0 +1,25 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Styling;
+
+namespace Miko.DevTools.Panels;
+
+internal static class ElementsPanel
+{
+    public static DivElement Build(DevToolsBridge bridge, bool visible)
+    {
+        var panel = new DivElement { Class = "elements-panel" };
+        if (!visible)
+        {
+            panel.Style = new Style { Display = Display.None };
+        }
+
+        var treePanel = DomTreeBuilder.Build(bridge);
+        var stylePanel = StyleInspector.Build(bridge.SelectedElement, bridge.MainEngine);
+
+        panel.AddChild(treePanel);
+        panel.AddChild(stylePanel);
+
+        return panel;
+    }
+}

--- a/src/Miko.DevTools/Panels/StyleInspector.cs
+++ b/src/Miko.DevTools/Panels/StyleInspector.cs
@@ -1,0 +1,171 @@
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+
+namespace Miko.DevTools.Panels;
+
+internal static class StyleInspector
+{
+    public static DivElement Build(Element? selectedElement, MikoEngine? engine)
+    {
+        var panel = new DivElement { Class = "style-panel" };
+
+        if (selectedElement == null || engine == null)
+        {
+            panel.AddChild(new DivElement
+            {
+                Class = "console-empty",
+                TextContent = "Select an element to inspect"
+            });
+            return panel;
+        }
+
+        var layoutBox = FindLayoutBox(engine.GetCurrentLayout(), selectedElement);
+        if (layoutBox == null)
+        {
+            panel.AddChild(new DivElement
+            {
+                Class = "console-empty",
+                TextContent = "No layout data available"
+            });
+            return panel;
+        }
+
+        panel.AddChild(BuildBoxModel(layoutBox));
+        panel.AddChild(BuildComputedStyles(layoutBox.ComputedStyle));
+
+        return panel;
+    }
+
+    private static DivElement BuildBoxModel(LayoutBox box)
+    {
+        var container = new DivElement { Class = "box-model" };
+        var title = new DivElement { Class = "style-section-title", TextContent = "Box Model" };
+        container.AddChild(title);
+
+        var margin = box.BoxModel.Margin;
+        var padding = box.BoxModel.Padding;
+        var content = box.BoxModel.Content;
+        var border = box.BoxModel.Border;
+
+        var marginBox = new DivElement { Class = "box-margin" };
+        marginBox.AddChild(new DivElement { Class = "box-label", TextContent = "margin" });
+        marginBox.AddChild(new DivElement
+        {
+            Class = "box-value",
+            TextContent = $"{margin.Top:0.#}  {margin.Right:0.#}  {margin.Bottom:0.#}  {margin.Left:0.#}"
+        });
+
+        var borderBox = new DivElement { Class = "box-border" };
+        borderBox.AddChild(new DivElement { Class = "box-label", TextContent = "border" });
+        borderBox.AddChild(new DivElement
+        {
+            Class = "box-value",
+            TextContent = $"{border.Top:0.#}  {border.Right:0.#}  {border.Bottom:0.#}  {border.Left:0.#}"
+        });
+
+        var paddingBox = new DivElement { Class = "box-padding" };
+        paddingBox.AddChild(new DivElement { Class = "box-label", TextContent = "padding" });
+        paddingBox.AddChild(new DivElement
+        {
+            Class = "box-value",
+            TextContent = $"{padding.Top:0.#}  {padding.Right:0.#}  {padding.Bottom:0.#}  {padding.Left:0.#}"
+        });
+
+        var contentBox = new DivElement { Class = "box-content" };
+        contentBox.AddChild(new DivElement
+        {
+            Class = "box-value",
+            TextContent = $"{content.Width:0.#} x {content.Height:0.#}"
+        });
+
+        paddingBox.AddChild(contentBox);
+        borderBox.AddChild(paddingBox);
+        marginBox.AddChild(borderBox);
+        container.AddChild(marginBox);
+
+        return container;
+    }
+
+    private static DivElement BuildComputedStyles(ComputedStyle cs)
+    {
+        var container = new DivElement();
+        var title = new DivElement { Class = "style-section-title", TextContent = "Computed Styles" };
+        container.AddChild(title);
+
+        AddRow(container, "display", cs.Display.ToString().ToLower());
+        AddRow(container, "position", cs.Position.ToString().ToLower());
+        AddRow(container, "width", FormatLength(cs.Width));
+        AddRow(container, "height", FormatLength(cs.Height));
+        AddRow(container, "min-width", FormatLength(cs.MinWidth));
+        AddRow(container, "min-height", FormatLength(cs.MinHeight));
+        AddRow(container, "max-width", FormatLength(cs.MaxWidth));
+        AddRow(container, "max-height", FormatLength(cs.MaxHeight));
+
+        AddRow(container, "padding", $"{FormatLength(cs.PaddingTop)} {FormatLength(cs.PaddingRight)} {FormatLength(cs.PaddingBottom)} {FormatLength(cs.PaddingLeft)}");
+        AddRow(container, "margin", $"{FormatLength(cs.MarginTop)} {FormatLength(cs.MarginRight)} {FormatLength(cs.MarginBottom)} {FormatLength(cs.MarginLeft)}");
+
+        AddRow(container, "background-color", FormatColor(cs.BackgroundColor));
+        AddRow(container, "color", FormatColor(cs.Color));
+        AddRow(container, "font-family", cs.FontFamily);
+        AddRow(container, "font-size", FormatLength(cs.FontSize));
+        AddRow(container, "font-weight", cs.FontWeight.ToString().ToLower());
+        AddRow(container, "text-align", cs.TextAlign.ToString().ToLower());
+
+        if (cs.Display == Common.Display.Flex)
+        {
+            AddRow(container, "flex-direction", cs.FlexDirection.ToString().ToLower());
+            AddRow(container, "justify-content", cs.JustifyContent.ToString().ToLower());
+            AddRow(container, "align-items", cs.AlignItems.ToString().ToLower());
+            AddRow(container, "flex-wrap", cs.FlexWrap.ToString().ToLower());
+            AddRow(container, "flex-grow", cs.FlexGrow.ToString("0.##"));
+            AddRow(container, "flex-shrink", cs.FlexShrink.ToString("0.##"));
+        }
+
+        if (cs.Opacity < 1f)
+            AddRow(container, "opacity", cs.Opacity.ToString("0.##"));
+
+        if (cs.OverflowX != Common.Overflow.Visible)
+            AddRow(container, "overflow-x", cs.OverflowX.ToString().ToLower());
+        if (cs.OverflowY != Common.Overflow.Visible)
+            AddRow(container, "overflow-y", cs.OverflowY.ToString().ToLower());
+
+        if (cs.BorderTopWidth.Value > 0)
+            AddRow(container, "border", $"{FormatLength(cs.BorderTopWidth)} {cs.BorderTopStyle.ToString().ToLower()} {FormatColor(cs.BorderTopColor)}");
+
+        return container;
+    }
+
+    private static void AddRow(DivElement container, string property, string value)
+    {
+        var row = new DivElement { Class = "style-row" };
+        row.AddChild(new SpanElement { Class = "style-prop", TextContent = property });
+        row.AddChild(new SpanElement { Class = "style-value", TextContent = value });
+        container.AddChild(row);
+    }
+
+    private static string FormatLength(Common.Length length)
+    {
+        return length.ToString();
+    }
+
+    private static string FormatColor(Common.Color color)
+    {
+        if (color.A == 0) return "transparent";
+        if (color.A == 255) return $"rgb({color.R}, {color.G}, {color.B})";
+        return $"rgba({color.R}, {color.G}, {color.B}, {color.A / 255f:0.##})";
+    }
+
+    private static LayoutBox? FindLayoutBox(LayoutBox? root, Element element)
+    {
+        if (root == null) return null;
+        if (root.Element == element) return root;
+        foreach (var child in root.Children)
+        {
+            var found = FindLayoutBox(child, element);
+            if (found != null) return found;
+        }
+        return null;
+    }
+}

--- a/src/Miko.DevTools/Styles/DevToolsStyleSheet.cs
+++ b/src/Miko.DevTools/Styles/DevToolsStyleSheet.cs
@@ -1,0 +1,335 @@
+﻿using Miko.Common;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+
+namespace Miko.DevTools.Styles;
+
+internal static class DevToolsStyleSheet
+{
+    private static readonly Color BgDark = new(36, 36, 36);
+    private static readonly Color BgMedium = new(45, 45, 45);
+    private static readonly Color BgLight = new(60, 60, 60);
+    private static readonly Color BgSelected = new(38, 79, 120);
+    private static readonly Color TextPrimary = new(212, 212, 212);
+    private static readonly Color TextSecondary = new(150, 150, 150);
+    private static readonly Color TextTag = new(86, 156, 214);
+    private static readonly Color TextAttr = new(156, 220, 254);
+    private static readonly Color TextString = new(206, 145, 120);
+    private static readonly Color TextValue = new(181, 206, 168);
+    private static readonly Color BorderColor = new(70, 70, 70);
+    private static readonly Color TabActiveBorder = new(0, 122, 204);
+
+    public static StyleSheet Create()
+    {
+        var sheet = new StyleSheet();
+
+        sheet.AddRule(new ClassSelector("devtools-root"), new Style
+        {
+            Display = Display.Flex,
+            FlexDirection = FlexDirection.Column,
+            Width = Length.Percent(100),
+            Height = Length.Percent(100),
+            BackgroundColor = BgDark,
+            Color = TextPrimary,
+            FontSize = Length.Px(12)
+        });
+
+        sheet.AddRule(new ClassSelector("devtools-toolbar"), new Style
+        {
+            Display = Display.Flex,
+            FlexDirection = FlexDirection.Row,
+            Height = Length.Px(34),
+            BackgroundColor = BgMedium,
+            BorderBottom = new BorderSide(Length.Px(1), BorderStyle.Solid, BorderColor),
+            AlignItems = AlignItems.Center,
+            PaddingLeft = Length.Px(8)
+        });
+
+        sheet.AddRule(new ClassSelector("devtools-tab"), new Style
+        {
+            PaddingLeft = Length.Px(12),
+            PaddingRight = Length.Px(12),
+            PaddingTop = Length.Px(8),
+            PaddingBottom = Length.Px(8),
+            Color = TextSecondary,
+            Cursor = Cursor.Pointer
+        });
+
+        sheet.AddRule(new ClassSelector("devtools-tab-active"), new Style
+        {
+            Color = TextPrimary,
+            BorderBottom = new BorderSide(Length.Px(2), BorderStyle.Solid, TabActiveBorder)
+        });
+
+        sheet.AddRule(new ClassSelector("devtools-content"), new Style
+        {
+            Flex = 1,
+            Display = Display.Flex,
+            OverflowY = Overflow.Hidden
+        });
+
+        // Elements panel
+        sheet.AddRule(new ClassSelector("elements-panel"), new Style
+        {
+            Display = Display.Flex,
+            FlexDirection = FlexDirection.Row,
+            Width = Length.Percent(100),
+            Height = Length.Percent(100)
+        });
+
+        sheet.AddRule(new ClassSelector("dom-tree-panel"), new Style
+        {
+            FlexGrow = 1,
+            OverflowY = Overflow.Scroll,
+            PaddingTop = Length.Px(4),
+            PaddingBottom = Length.Px(4),
+            PaddingLeft = Length.Px(4),
+            PaddingRight = Length.Px(4),
+            BorderRight = new BorderSide(Length.Px(1), BorderStyle.Solid, BorderColor)
+        });
+
+        sheet.AddRule(new ClassSelector("style-panel"), new Style
+        {
+            Width = Length.Px(280),
+            OverflowY = Overflow.Scroll,
+            PaddingTop = Length.Px(8),
+            PaddingBottom = Length.Px(8),
+            PaddingLeft = Length.Px(8),
+            PaddingRight = Length.Px(8)
+        });
+
+        // DOM tree nodes
+        sheet.AddRule(new ClassSelector("tree-node"), new Style
+        {
+            PaddingTop = Length.Px(1),
+            PaddingBottom = Length.Px(1),
+            PaddingLeft = Length.Px(4),
+            PaddingRight = Length.Px(4),
+            Cursor = Cursor.Pointer
+        });
+
+        sheet.AddRule(new ClassSelector("tree-node-selected"), new Style
+        {
+            BackgroundColor = BgSelected
+        });
+
+        sheet.AddRule(new ClassSelector("tree-node-tag"), new Style
+        {
+            Color = TextTag
+        });
+
+        sheet.AddRule(new ClassSelector("tree-node-attr"), new Style
+        {
+            Color = TextAttr
+        });
+
+        sheet.AddRule(new ClassSelector("tree-node-string"), new Style
+        {
+            Color = TextString
+        });
+
+        sheet.AddRule(new ClassSelector("tree-node-text"), new Style
+        {
+            Color = TextSecondary,
+            FontStyle = FontStyle.Italic
+        });
+
+        sheet.AddRule(new ClassSelector("tree-toggle"), new Style
+        {
+            Color = TextSecondary,
+            PaddingRight = Length.Px(4),
+            Display = Display.InlineBlock,
+            Width = Length.Px(12)
+        });
+
+        // Style inspector
+        sheet.AddRule(new ClassSelector("style-section-title"), new Style
+        {
+            Color = TextPrimary,
+            FontWeight = FontWeight.Bold,
+            PaddingTop = Length.Px(4),
+            PaddingBottom = Length.Px(4),
+            BorderBottom = new BorderSide(Length.Px(1), BorderStyle.Solid, BorderColor),
+            MarginBottom = Length.Px(4)
+        });
+
+        sheet.AddRule(new ClassSelector("style-row"), new Style
+        {
+            Display = Display.Flex,
+            FlexDirection = FlexDirection.Row,
+            PaddingTop = Length.Px(1),
+            PaddingBottom = Length.Px(1)
+        });
+
+        sheet.AddRule(new ClassSelector("style-prop"), new Style
+        {
+            Color = TextAttr,
+            Width = Length.Px(120),
+            FlexShrink = 0
+        });
+
+        sheet.AddRule(new ClassSelector("style-value"), new Style
+        {
+            Color = TextValue,
+            FlexGrow = 1
+        });
+
+        // Box model visualizer
+        sheet.AddRule(new ClassSelector("box-model"), new Style
+        {
+            Display = Display.Flex,
+            FlexDirection = FlexDirection.Column,
+            AlignItems = AlignItems.Center,
+            PaddingTop = Length.Px(8),
+            PaddingBottom = Length.Px(8)
+        });
+
+        sheet.AddRule(new ClassSelector("box-margin"), new Style
+        {
+            BackgroundColor = new Color(246, 178, 107, 80),
+            PaddingTop = Length.Px(12),
+            PaddingBottom = Length.Px(12),
+            PaddingLeft = Length.Px(16),
+            PaddingRight = Length.Px(16),
+            Width = Length.Percent(100)
+        });
+
+        sheet.AddRule(new ClassSelector("box-border"), new Style
+        {
+            BackgroundColor = new Color(253, 216, 53, 80),
+            PaddingTop = Length.Px(12),
+            PaddingBottom = Length.Px(12),
+            PaddingLeft = Length.Px(16),
+            PaddingRight = Length.Px(16)
+        });
+
+        sheet.AddRule(new ClassSelector("box-padding"), new Style
+        {
+            BackgroundColor = new Color(129, 199, 132, 80),
+            PaddingTop = Length.Px(12),
+            PaddingBottom = Length.Px(12),
+            PaddingLeft = Length.Px(16),
+            PaddingRight = Length.Px(16)
+        });
+
+        sheet.AddRule(new ClassSelector("box-content"), new Style
+        {
+            BackgroundColor = new Color(100, 150, 255, 80),
+            PaddingTop = Length.Px(8),
+            PaddingBottom = Length.Px(8),
+            PaddingLeft = Length.Px(12),
+            PaddingRight = Length.Px(12),
+            Color = TextPrimary
+        });
+
+        sheet.AddRule(new ClassSelector("box-label"), new Style
+        {
+            Color = TextSecondary,
+            FontSize = Length.Px(10)
+        });
+
+        sheet.AddRule(new ClassSelector("box-value"), new Style
+        {
+            Color = TextPrimary,
+            FontSize = Length.Px(11)
+        });
+
+        // Console panel
+        sheet.AddRule(new ClassSelector("console-panel"), new Style
+        {
+            Display = Display.Flex,
+            FlexDirection = FlexDirection.Column,
+            Width = Length.Percent(100),
+            Height = Length.Percent(100)
+        });
+
+        sheet.AddRule(new ClassSelector("console-filter-bar"), new Style
+        {
+            Display = Display.Flex,
+            FlexDirection = FlexDirection.Row,
+            AlignItems = AlignItems.Center,
+            Height = Length.Px(30),
+            PaddingLeft = Length.Px(8),
+            PaddingRight = Length.Px(8),
+            BackgroundColor = BgMedium,
+            BorderBottom = new BorderSide(Length.Px(1), BorderStyle.Solid, BorderColor),
+            Gap = Length.Px(8)
+        });
+
+        sheet.AddRule(new ClassSelector("console-filter-label"), new Style
+        {
+            Color = TextSecondary,
+            FontSize = Length.Px(11)
+        });
+
+        sheet.AddRule(new ClassSelector("console-filter-btn"), new Style
+        {
+            PaddingLeft = Length.Px(6),
+            PaddingRight = Length.Px(6),
+            PaddingTop = Length.Px(2),
+            PaddingBottom = Length.Px(2),
+            Color = TextSecondary,
+            Cursor = Cursor.Pointer,
+            BorderRadius = Length.Px(3)
+        });
+
+        sheet.AddRule(new ClassSelector("console-filter-btn-active"), new Style
+        {
+            BackgroundColor = BgSelected,
+            Color = TextPrimary
+        });
+
+        sheet.AddRule(new ClassSelector("console-output"), new Style
+        {
+            FlexGrow = 1,
+            OverflowY = Overflow.Scroll,
+            PaddingTop = Length.Px(4),
+            PaddingBottom = Length.Px(4),
+            PaddingLeft = Length.Px(8),
+            PaddingRight = Length.Px(8)
+        });
+
+        sheet.AddRule(new ClassSelector("console-entry"), new Style
+        {
+            PaddingTop = Length.Px(2),
+            PaddingBottom = Length.Px(2),
+            BorderBottom = new BorderSide(Length.Px(1), BorderStyle.Solid, new Color(50, 50, 50)),
+            FontSize = Length.Px(11)
+        });
+
+        sheet.AddRule(new ClassSelector("console-entry-trace"), new Style { Color = new Color(120, 120, 120) });
+        sheet.AddRule(new ClassSelector("console-entry-debug"), new Style { Color = new Color(150, 150, 150) });
+        sheet.AddRule(new ClassSelector("console-entry-info"), new Style { Color = TextPrimary });
+        sheet.AddRule(new ClassSelector("console-entry-warning"), new Style { Color = new Color(255, 204, 0) });
+        sheet.AddRule(new ClassSelector("console-entry-error"), new Style { Color = new Color(255, 85, 85) });
+        sheet.AddRule(new ClassSelector("console-entry-critical"), new Style
+        {
+            Color = new Color(255, 255, 255),
+            BackgroundColor = new Color(200, 0, 0)
+        });
+
+        sheet.AddRule(new ClassSelector("console-timestamp"), new Style
+        {
+            Color = TextSecondary,
+            PaddingRight = Length.Px(8),
+            FontSize = Length.Px(10)
+        });
+
+        sheet.AddRule(new ClassSelector("console-category"), new Style
+        {
+            Color = TextAttr,
+            PaddingRight = Length.Px(8),
+            FontSize = Length.Px(10)
+        });
+
+        sheet.AddRule(new ClassSelector("console-empty"), new Style
+        {
+            Color = TextSecondary,
+            FontStyle = FontStyle.Italic,
+            PaddingTop = Length.Px(16),
+            PaddingLeft = Length.Px(8)
+        });
+
+        return sheet;
+    }
+}

--- a/src/Miko/AssemblyInfo.cs
+++ b/src/Miko/AssemblyInfo.cs
@@ -2,3 +2,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Miko.Tests")]
 [assembly: InternalsVisibleTo("Miko.Benchmarks")]
+[assembly: InternalsVisibleTo("Miko.DevTools")]

--- a/src/Miko/Hosting/MikoApp.cs
+++ b/src/Miko/Hosting/MikoApp.cs
@@ -141,6 +141,10 @@ public class MikoApp
         using var tempSurface = SKSurface.Create(new SKImageInfo(_width, _height));
         var root = BuildRoot();
         _engine.Initialize(root, _options.StyleSheets, tempSurface.Canvas, _width, _height);
+
+        foreach (var hook in _options.PostInitHooks)
+            hook(_serviceProvider);
+
         _frameTimer.Start();
     }
 
@@ -500,6 +504,11 @@ public class MikoApp
 
     private void OnKeyDown(IKeyboard keyboard, Key key, int scancode)
     {
+        foreach (var handler in _options.GlobalKeyDownHandlers)
+        {
+            if (handler(key)) return;
+        }
+
         if (_focusedElement is not InputElement input) return;
         if (input.Type != InputType.Text && input.Type != InputType.Password) return;
 

--- a/src/Miko/Hosting/MikoAppBuilder.cs
+++ b/src/Miko/Hosting/MikoAppBuilder.cs
@@ -9,6 +9,7 @@ using Miko.Layout;
 using Miko.Rendering;
 using Miko.Routing;
 using Miko.Styling;
+using Silk.NET.Input;
 
 namespace Miko.Hosting;
 
@@ -89,6 +90,12 @@ public class MikoAppBuilder
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)] Type layoutType)
     {
         Services.Configure<MikoAppOptions>(o => o.DefaultLayout = layoutType);
+        return this;
+    }
+
+    public MikoAppBuilder AddGlobalKeyHandler(Func<Key, bool> handler)
+    {
+        Services.Configure<MikoAppOptions>(o => o.GlobalKeyDownHandlers.Add(handler));
         return this;
     }
 

--- a/src/Miko/Hosting/MikoAppOptions.cs
+++ b/src/Miko/Hosting/MikoAppOptions.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Miko.Core;
 using Miko.Routing;
 using Miko.Styling;
+using Silk.NET.Input;
 
 namespace Miko.Hosting;
 
@@ -20,6 +21,8 @@ public class MikoAppOptions
     public Type? DefaultLayout { get; set; }
 
     public List<FontRegistration> Fonts { get; set; } = new();
+    public List<Func<Key, bool>> GlobalKeyDownHandlers { get; set; } = new();
+    public List<Action<IServiceProvider>> PostInitHooks { get; set; } = new();
 }
 
 public class FontRegistration

--- a/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
@@ -128,6 +128,25 @@ public class BlockLayout
         float contentX = x + box.BoxModel.Margin.Left + box.BoxModel.Border.Left + box.BoxModel.Padding.Left;
         float contentY = y + box.BoxModel.Margin.Top + box.BoxModel.Border.Top + box.BoxModel.Padding.Top;
 
+        // 计算确定性高度，用于子元素百分比高度解析
+        float? childAvailableHeight = null;
+        if (!style.Height.IsAuto)
+        {
+            float h = style.Height.ToPixels(constraints.AvailableHeight ?? 0);
+            if (style.BoxSizing == BoxSizing.BorderBox)
+                h -= box.BoxModel.Border.Vertical + box.BoxModel.Padding.Vertical;
+            childAvailableHeight = Math.Max(0, h);
+        }
+        else if (constraints.AvailableHeight.HasValue &&
+                 (style.OverflowY == Overflow.Auto || style.OverflowY == Overflow.Scroll || style.OverflowY == Overflow.Hidden))
+        {
+            float h = constraints.AvailableHeight.Value
+                - box.BoxModel.Margin.Vertical
+                - box.BoxModel.Border.Vertical
+                - box.BoxModel.Padding.Vertical;
+            childAvailableHeight = Math.Max(0, h);
+        }
+
         // 4. 布局子元素
         // Block 子元素垂直堆叠，Inline/InlineBlock 子元素水平排列
         float currentY = contentY;
@@ -162,7 +181,7 @@ public class BlockLayout
             else
             {
                 // Block 子元素垂直堆叠
-                var childConstraints = new LayoutConstraints(childAvailableWidth, null);
+                var childConstraints = new LayoutConstraints(childAvailableWidth, childAvailableHeight);
                 LayoutChild(child, childConstraints, contentX, currentY);
 
                 currentY = child.BoxModel.MarginBox.Bottom;

--- a/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
@@ -84,6 +84,15 @@ public class FlexLayout
                 contentHeight = Math.Max(0, contentHeight);
             }
         }
+        else if (constraints.AvailableHeight.HasValue &&
+                 (style.OverflowY == Overflow.Auto || style.OverflowY == Overflow.Scroll || style.OverflowY == Overflow.Hidden))
+        {
+            contentHeight = constraints.AvailableHeight.Value
+                - box.BoxModel.Margin.Vertical
+                - box.BoxModel.Border.Vertical
+                - box.BoxModel.Padding.Vertical;
+            contentHeight = Math.Max(0, contentHeight);
+        }
         else
         {
             contentHeight = 0; // 稍后根据子元素计算

--- a/src/Miko/Rendering/Painter.cs
+++ b/src/Miko/Rendering/Painter.cs
@@ -365,8 +365,9 @@ public class Painter
             _ => rect.Left
         };
 
-        // 垂直居中
-        float y = rect.Top + (rect.Height + fontSize) / 2;
+        // 文本基线：顶部对齐（baseline ≈ top + ascent）
+        using var baselineFont = new SKFont(textRuns[0].Typeface, fontSize);
+        float y = rect.Top - baselineFont.Metrics.Ascent;
 
         // 绘制每个文本段
         foreach (var run in textRuns)
@@ -839,7 +840,8 @@ public class Painter
             _ => rect.Left
         };
 
-        float baselineY = rect.Top + (rect.Height + fontSize) / 2;
+        using var baselineFont = new SKFont(textRuns[0].Typeface, fontSize);
+        float baselineY = rect.Top - baselineFont.Metrics.Ascent;
         float lineY = decoration switch
         {
             TextDecoration.Underline => baselineY + fontSize * 0.15f,

--- a/src/Miko/Rendering/RenderEngine.cs
+++ b/src/Miko/Rendering/RenderEngine.cs
@@ -19,6 +19,8 @@ public class RenderEngine
     private float _currentScrollOffsetX;
     private float _currentScrollOffsetY;
 
+    public Action<SKCanvas>? OverlayCallback { get; set; }
+
     /// <summary>
     /// 设置画布
     /// </summary>
@@ -42,6 +44,7 @@ public class RenderEngine
         _currentScrollOffsetY = 0;
         RenderBox(layoutRoot);
         FlushDropdowns();
+        OverlayCallback?.Invoke(_canvas!);
     }
 
     public void RenderDirty(LayoutBox layoutRoot, List<RectF> dirtyRegions)

--- a/src/Miko/Styling/ComputedStyle.cs
+++ b/src/Miko/Styling/ComputedStyle.cs
@@ -13,7 +13,7 @@ public class ComputedStyle : Style
     public new BoxSizing BoxSizing { get; set; } = Common.BoxSizing.ContentBox;
     public new FlexDirection FlexDirection { get; set; } = Common.FlexDirection.Row;
     public new JustifyContent JustifyContent { get; set; } = Common.JustifyContent.FlexStart;
-    public new AlignItems AlignItems { get; set; } = Common.AlignItems.FlexStart;
+    public new AlignItems AlignItems { get; set; } = Common.AlignItems.Stretch;
 
     // Flex 子元素属性（CSS 默认值）
     public new float FlexGrow { get; set; } = 0f;

--- a/src/Miko/Styling/Style.cs
+++ b/src/Miko/Styling/Style.cs
@@ -22,6 +22,19 @@ public class Style
     public StyleProperty<float>? FlexShrink { get; set; }
     public StyleProperty<Length>? FlexBasis { get; set; }
 
+    /// <summary>
+    /// flex 简写属性 (flex: N → flex-grow: N; flex-shrink: 1; flex-basis: 0%)
+    /// </summary>
+    public float Flex
+    {
+        set
+        {
+            FlexGrow = value;
+            FlexShrink = 1;
+            FlexBasis = Length.Percent(0);
+        }
+    }
+
     // 盒子模型
     public StyleProperty<BoxSizing>? BoxSizing { get; set; }
     public StyleProperty<Length>? Width { get; set; }

--- a/tests/Miko.Tests/Layout/LayoutEngineTests.cs
+++ b/tests/Miko.Tests/Layout/LayoutEngineTests.cs
@@ -745,8 +745,8 @@ public class LayoutEngineTests
                         Style = new Style
                         {
                             Display = Display.Flex,
-                            FlexDirection = FlexDirection.Row
-                            // 注意：没有显式设置 AlignItems，默认为 FlexStart
+                            FlexDirection = FlexDirection.Row,
+                            AlignItems = AlignItems.FlexStart
                         }
                     },
                     new StyleRule
@@ -2744,6 +2744,365 @@ public class LayoutEngineTests
         // button 默认 border-box，width:100% = 父内容宽度 = border-box 宽度
         buttonBox.BoxModel.MarginBox.Width.ShouldBeLessThanOrEqualTo(
             layoutRoot.BoxModel.Content.Width);
+    }
+
+    #endregion
+
+    #region Flex Column Nested Percentage Height
+
+    [Fact]
+    public void FlexColumn_FlexGrowChild_NestedPercentageHeight_ShouldResolveCorrectly()
+    {
+        var root = new DivElement { Class = "root" };
+        var toolbar = new DivElement { Class = "toolbar", TextContent = "sss" };
+        var content = new DivElement { Class = "content" };
+        var panel = new DivElement { Class = "panel" };
+        var test = new DivElement { Class = "test", TextContent = "test" };
+
+        panel.AddChild(test);
+        content.AddChild(panel);
+        root.AddChild(toolbar);
+        root.AddChild(content);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("root"),
+                        Style = new Style
+                        {
+                            Width = Length.Px(500),
+                            Height = Length.Px(500),
+                            Display = Display.Flex,
+                            FlexDirection = FlexDirection.Column
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("toolbar"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            FlexDirection = FlexDirection.Row,
+                            Height = Length.Px(34),
+                            AlignItems = AlignItems.Center,
+                            PaddingLeft = Length.Px(8)
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("content"),
+                        Style = new Style
+                        {
+                            FlexGrow = 1,
+                            FlexShrink = 1,
+                            FlexBasis = Length.Percent(0),
+                            OverflowY = Overflow.Hidden
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("panel"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            Width = Length.Percent(100),
+                            Height = Length.Percent(100),
+                            OverflowY = Overflow.Scroll
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("test"),
+                        Style = new Style
+                        {
+                            Width = Length.Px(100),
+                            Height = Length.Px(800)
+                        }
+                    }
+                }
+            }
+        };
+
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        var contentBox = layoutRoot.Children[1];
+        contentBox.BoxModel.Content.Height.ShouldBeGreaterThan(0);
+        contentBox.BoxModel.Content.Height.ShouldBe(466, 1f);
+
+        var panelBox = contentBox.Children[0];
+        panelBox.BoxModel.Content.Height.ShouldBeGreaterThan(0);
+        panelBox.BoxModel.Content.Height.ShouldBe(contentBox.BoxModel.Content.Height, 1f);
+
+        var testBox = panelBox.Children[0];
+        testBox.BoxModel.Content.Height.ShouldBe(800, 1f);
+    }
+
+    [Fact]
+    public void FlexShorthand_ShouldSetGrowShrinkBasis()
+    {
+        var style = new Style { Flex = 1 };
+
+        style.FlexGrow.ShouldNotBeNull();
+        style.FlexGrow!.Value.Value.ShouldBe(1f);
+        style.FlexShrink.ShouldNotBeNull();
+        style.FlexShrink!.Value.Value.ShouldBe(1f);
+        style.FlexBasis.ShouldNotBeNull();
+        style.FlexBasis!.Value.Value.ShouldBe(Length.Percent(0));
+    }
+
+    #endregion
+
+    #region Flex Row Cross-Axis Height
+
+    [Fact]
+    public void FlexRow_ChildWithOverflowScroll_ShouldHaveContainerHeight()
+    {
+        // devtools-root (flex column, 500x500)
+        //   toolbar (height: 34px)
+        //   content (flex:1, display:flex, overflow-y:hidden)
+        //     elements-panel (flex row, width:100%, height:100%)
+        //       dom-tree-panel (flex-grow:1, overflow-y:scroll, padding:4px)
+        //         test "DOM"
+        //       style-panel (width:280px)
+
+        var root = new DivElement { Class = "root" };
+        var toolbar = new DivElement { Class = "toolbar", TextContent = "sss" };
+        var content = new DivElement { Class = "content" };
+        var panel = new DivElement { Class = "elements-panel" };
+        var treePanel = new DivElement { Class = "dom-tree-panel" };
+        var test = new DivElement { Class = "test", TextContent = "DOM" };
+        var stylePanel = new DivElement { Class = "style-panel", TextContent = "style" };
+
+        treePanel.AddChild(test);
+        panel.AddChild(treePanel);
+        panel.AddChild(stylePanel);
+        content.AddChild(panel);
+        root.AddChild(toolbar);
+        root.AddChild(content);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("root"),
+                        Style = new Style
+                        {
+                            Width = Length.Px(500),
+                            Height = Length.Px(500),
+                            Display = Display.Flex,
+                            FlexDirection = FlexDirection.Column
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("toolbar"),
+                        Style = new Style
+                        {
+                            Height = Length.Px(34)
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("content"),
+                        Style = new Style
+                        {
+                            Flex = 1,
+                            Display = Display.Flex,
+                            OverflowY = Overflow.Hidden
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("elements-panel"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            FlexDirection = FlexDirection.Row,
+                            Width = Length.Percent(100),
+                            Height = Length.Percent(100)
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("dom-tree-panel"),
+                        Style = new Style
+                        {
+                            FlexGrow = 1,
+                            OverflowY = Overflow.Scroll,
+                            Padding = new Padding(Length.Px(4))
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("style-panel"),
+                        Style = new Style
+                        {
+                            Width = Length.Px(280),
+                            OverflowY = Overflow.Scroll,
+                            Padding = new Padding(Length.Px(8))
+                        }
+                    }
+                }
+            }
+        };
+
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        // content should fill remaining height (500 - 34 = 466)
+        var contentBox = layoutRoot.Children[1];
+        contentBox.BoxModel.Content.Height.ShouldBe(466, 1f);
+
+        // elements-panel (height:100%) should match content height
+        var elementsPanelBox = contentBox.Children[0];
+        elementsPanelBox.BoxModel.Content.Height.ShouldBe(466, 1f);
+
+        // dom-tree-panel should stretch to fill the cross-axis (full container height)
+        var treePanelBox = elementsPanelBox.Children[0];
+        treePanelBox.BoxModel.Content.Height.ShouldBeGreaterThan(100);
+
+        // text content should be at the top, not vertically centered
+        var testBox = treePanelBox.Children[0];
+        testBox.BoxModel.Content.Y.ShouldBe(treePanelBox.BoxModel.Content.Y, 1f);
+    }
+
+    [Fact]
+    public void FlexRow_BlockChild_TextShouldBeAtTop()
+    {
+        // Exact repro from DebugDemo.Razor: nested flex column → flex row → block panels
+        // Text in .dom-tree-panel and .style-panel should start at the top, not centered.
+        //
+        // devtools-root (flex column, 500x500)
+        //   devtools-toolbar (height: 34px) "sss"
+        //   devtools-content (flex:1, display:flex, overflow-y:hidden)
+        //     elements-panel (flex row, width:100%, height:100%)
+        //       dom-tree-panel (block, flex-grow:1, overflow-y:scroll, padding:4px)
+        //         test "DOM"
+        //       style-panel (block, width:280, overflow-y:scroll, padding:8px)
+        //         "style"
+
+        var root = new DivElement { Class = "devtools-root" };
+        var toolbar = new DivElement { Class = "devtools-toolbar", TextContent = "sss" };
+        var content = new DivElement { Class = "devtools-content" };
+        var elementsPanel = new DivElement { Class = "elements-panel" };
+        var treePanel = new DivElement { Class = "dom-tree-panel" };
+        var test = new DivElement { Class = "test", TextContent = "DOM" };
+        var stylePanel = new DivElement { Class = "style-panel", TextContent = "style" };
+
+        treePanel.AddChild(test);
+        elementsPanel.AddChild(treePanel);
+        elementsPanel.AddChild(stylePanel);
+        content.AddChild(elementsPanel);
+        root.AddChild(toolbar);
+        root.AddChild(content);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("devtools-root"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            FlexDirection = FlexDirection.Column,
+                            Width = Length.Px(500),
+                            Height = Length.Px(500)
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("devtools-toolbar"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            FlexDirection = FlexDirection.Row,
+                            Height = Length.Px(34),
+                            AlignItems = AlignItems.Center,
+                            PaddingLeft = Length.Px(8)
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("devtools-content"),
+                        Style = new Style
+                        {
+                            Flex = 1,
+                            Display = Display.Flex,
+                            OverflowY = Overflow.Hidden
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("elements-panel"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            FlexDirection = FlexDirection.Row,
+                            Width = Length.Percent(100),
+                            Height = Length.Percent(100)
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("dom-tree-panel"),
+                        Style = new Style
+                        {
+                            FlexGrow = 1,
+                            OverflowY = Overflow.Scroll,
+                            Padding = new Padding(Length.Px(4)),
+                            BorderRight = new BorderSide(Length.Px(1), BorderStyle.Solid, new Color(70, 70, 70))
+                        }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("style-panel"),
+                        Style = new Style
+                        {
+                            Width = Length.Px(280),
+                            OverflowY = Overflow.Scroll,
+                            Padding = new Padding(Length.Px(8))
+                        }
+                    }
+                }
+            }
+        };
+
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        // content (flex:1) should fill remaining: 500 - 34 = 466
+        var contentBox = layoutRoot.Children[1];
+        contentBox.BoxModel.Content.Height.ShouldBe(466, 1f);
+
+        // elements-panel (height:100%) should match content
+        var elementsPanelBox = contentBox.Children[0];
+        elementsPanelBox.BoxModel.Content.Height.ShouldBe(466, 1f);
+
+        // dom-tree-panel should be stretched to fill container height
+        var treePanelBox = elementsPanelBox.Children[0];
+        treePanelBox.BoxModel.Content.Height.ShouldBeGreaterThan(400);
+
+        // test div inside dom-tree-panel: its Y should be at the top of the panel content area
+        var testBox = treePanelBox.Children[0];
+        float treePanelContentY = treePanelBox.BoxModel.Content.Y;
+        testBox.BoxModel.MarginBox.Y.ShouldBe(treePanelContentY, 1f);
+
+        // style-panel text should also start at the top (style-panel has no children, just TextContent)
+        // For elements with TextContent and no children, the text is rendered at content.Y
+        // so we just verify the content.Y is at the top of the elements-panel content area
+        var stylePanelBox = elementsPanelBox.Children[1];
+        stylePanelBox.BoxModel.Content.Height.ShouldBeGreaterThan(400);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- Add `Miko.DevTools` library: browser-like developer tools with Elements tab (DOM tree + style inspector + box model) and Console tab (log capture with level filtering)
- Fix flex column layout bug where nested percentage-height children resolve to 0
- Fix `Painter.DrawText` always vertically centering text regardless of element layout
- Add `Style.Flex` shorthand property matching CSS `flex: N` behavior

## Changes

### New: Miko.DevTools
- `builder.AddDevTools()` extension method — press F12 to open DevTools in a second window
- Elements tab: interactive DOM tree with expand/collapse, click-to-select, computed style inspector, box model visualizer
- Console tab: captures all ILogger output with level filtering (Trace/Debug/Info/Warn/Error)
- DOM linkage: selecting a node highlights the element in the main window with colored overlay (margin/border/padding/content)

### Fix: Flex layout height propagation
- BlockLayout now passes definite height to block children so `Height: 100%` resolves correctly
- FlexLayout uses `AvailableHeight` constraint when overflow is set (same pattern as BlockLayout)
- Default `AlignItems` changed from `FlexStart` to `Stretch` (CSS spec compliance)

### Fix: Text rendering vertical position
- `Painter.DrawText` was hardcoded to vertically center text within the content rect
- Changed to top-aligned baseline positioning using font metrics
- Input elements (which need centering) use separate rendering code, unaffected

### New: Style.Flex shorthand
- `Flex = 1` expands to `FlexGrow = 1; FlexShrink = 1; FlexBasis = 0%`

## Test plan
- [x] All 685 existing + new tests pass (`dotnet test`)
- [x] Full solution builds with 0 errors (`dotnet build miko.slnx`)
- [x] Run MikoApp1.Razor, press F12, verify DevTools window opens
- [x] Click DOM nodes in Elements tab, verify highlight in main window
- [x] Switch to Console tab, verify log entries appear