### PR TITLE
Support mixed text and element content in block layout

### DIFF
--- a/src/Miko.DevTools/DevToolsBridge.cs
+++ b/src/Miko.DevTools/DevToolsBridge.cs
@@ -90,26 +90,41 @@ public class DevToolsBridge
             var element = _selectedElement;
             if (element == null || MainEngine == null) return;
 
-            var layoutBox = FindLayoutBox(MainEngine.GetCurrentLayout(), element);
+            var root = MainEngine.GetCurrentLayout();
+            if (root == null) return;
+
+            // 计算祖先滚动容器累计的滚动偏移：渲染时每个滚动容器对其子元素
+            // 应用了 Translate(-ScrollLeft, -ScrollTop)，因此高亮框也需扣除该偏移
+            float scrollX = 0, scrollY = 0;
+            var layoutBox = FindLayoutBox(root, element, ref scrollX, ref scrollY);
             if (layoutBox == null) return;
 
-            DrawHighlight(canvas, layoutBox);
+            DrawHighlight(canvas, layoutBox, scrollX, scrollY);
         };
     }
 
-    private static LayoutBox? FindLayoutBox(LayoutBox? root, Element element)
+    private static LayoutBox? FindLayoutBox(LayoutBox root, Element element, ref float scrollX, ref float scrollY)
     {
-        if (root == null) return null;
         if (root.Element == element) return root;
+
+        float childScrollX = scrollX + root.ScrollLeft;
+        float childScrollY = scrollY + root.ScrollTop;
+
         foreach (var child in root.Children)
         {
-            var found = FindLayoutBox(child, element);
-            if (found != null) return found;
+            float sx = childScrollX, sy = childScrollY;
+            var found = FindLayoutBox(child, element, ref sx, ref sy);
+            if (found != null)
+            {
+                scrollX = sx;
+                scrollY = sy;
+                return found;
+            }
         }
         return null;
     }
 
-    private static void DrawHighlight(SKCanvas canvas, LayoutBox box)
+    private static void DrawHighlight(SKCanvas canvas, LayoutBox box, float scrollX, float scrollY)
     {
         var margin = box.BoxModel.MarginBox;
         var border = box.BoxModel.BorderBox;
@@ -117,16 +132,16 @@ public class DevToolsBridge
         var content = box.BoxModel.Content;
 
         using var marginPaint = new SKPaint { Color = new SKColor(246, 178, 107, 60), Style = SKPaintStyle.Fill };
-        canvas.DrawRect(margin.X, margin.Y, margin.Width, margin.Height, marginPaint);
+        canvas.DrawRect(margin.X - scrollX, margin.Y - scrollY, margin.Width, margin.Height, marginPaint);
 
         using var borderPaint = new SKPaint { Color = new SKColor(253, 216, 53, 60), Style = SKPaintStyle.Fill };
-        canvas.DrawRect(border.X, border.Y, border.Width, border.Height, borderPaint);
+        canvas.DrawRect(border.X - scrollX, border.Y - scrollY, border.Width, border.Height, borderPaint);
 
         using var paddingPaint = new SKPaint { Color = new SKColor(129, 199, 132, 60), Style = SKPaintStyle.Fill };
-        canvas.DrawRect(padding.X, padding.Y, padding.Width, padding.Height, paddingPaint);
+        canvas.DrawRect(padding.X - scrollX, padding.Y - scrollY, padding.Width, padding.Height, paddingPaint);
 
         using var contentPaint = new SKPaint { Color = new SKColor(100, 150, 255, 60), Style = SKPaintStyle.Fill };
-        canvas.DrawRect(content.X, content.Y, content.Width, content.Height, contentPaint);
+        canvas.DrawRect(content.X - scrollX, content.Y - scrollY, content.Width, content.Height, contentPaint);
 
         using var outlinePaint = new SKPaint
         {
@@ -135,6 +150,6 @@ public class DevToolsBridge
             StrokeWidth = 1.5f,
             IsAntialias = true
         };
-        canvas.DrawRect(border.X, border.Y, border.Width, border.Height, outlinePaint);
+        canvas.DrawRect(border.X - scrollX, border.Y - scrollY, border.Width, border.Height, outlinePaint);
     }
 }

--- a/src/Miko.DevTools/DevToolsWindow.cs
+++ b/src/Miko.DevTools/DevToolsWindow.cs
@@ -302,10 +302,34 @@ internal class DevToolsWindow
 
     private void RebuildUI()
     {
+        // 保存当前滚动位置
+        float domTreeScrollTop = 0;
+        float stylePanelScrollTop = 0;
+        var currentLayout = _engine.GetCurrentLayout();
+        if (currentLayout != null)
+        {
+            var domTreeBox = FindLayoutBoxByClass(currentLayout, "dom-tree-panel");
+            if (domTreeBox != null) domTreeScrollTop = domTreeBox.ScrollTop;
+
+            var stylePanelBox = FindLayoutBoxByClass(currentLayout, "style-panel");
+            if (stylePanelBox != null) stylePanelScrollTop = stylePanelBox.ScrollTop;
+        }
+
         var root = BuildUI();
         var styleSheets = new List<Styling.StyleSheet> { DevToolsStyleSheet.Create() };
         using var tempSurface = SKSurface.Create(new SKImageInfo(_width, _height));
         _engine.Initialize(root, styleSheets, tempSurface.Canvas, _width, _height);
+
+        // 恢复滚动位置
+        var newLayout = _engine.GetCurrentLayout();
+        if (newLayout != null)
+        {
+            var newDomTreeBox = FindLayoutBoxByClass(newLayout, "dom-tree-panel");
+            if (newDomTreeBox != null) newDomTreeBox.ScrollTop = domTreeScrollTop;
+
+            var newStylePanelBox = FindLayoutBoxByClass(newLayout, "style-panel");
+            if (newStylePanelBox != null) newStylePanelBox.ScrollTop = stylePanelScrollTop;
+        }
     }
 
     private Element BuildUI()

--- a/src/Miko.DevTools/Panels/DomTreeBuilder.cs
+++ b/src/Miko.DevTools/Panels/DomTreeBuilder.cs
@@ -91,12 +91,12 @@ internal static class DomTreeBuilder
 
         line.AddChild(new SpanElement { Class = "tree-node-tag", TextContent = ">" });
 
-        if (!string.IsNullOrEmpty(element.TextContent) && element.Children.Count == 0)
+        bool hasText = !string.IsNullOrEmpty(element.TextContent);
+
+        // 无子元素且有文本：文本和闭合标签显示在同一行
+        if (hasText && !hasChildren)
         {
-            var textPreview = element.TextContent.Length > 40
-                ? element.TextContent[..40] + "..."
-                : element.TextContent;
-            line.AddChild(new SpanElement { Class = "tree-node-text", TextContent = textPreview });
+            line.AddChild(new SpanElement { Class = "tree-node-text", TextContent = TextPreview(element.TextContent!) });
             line.AddChild(new SpanElement { Class = "tree-node-tag", TextContent = $"</{element.TagName}>" });
         }
 
@@ -111,6 +111,24 @@ internal static class DomTreeBuilder
 
         if (hasChildren && !isCollapsed)
         {
+            // 元素同时拥有文本内容时，将文本作为独立的文本节点行显示在子元素之前
+            if (hasText)
+            {
+                var textNode = new DivElement
+                {
+                    Class = "tree-node",
+                    Style = new Styling.Style { PaddingLeft = Length.Px((depth + 1) * 16 + 4) }
+                };
+                var textLine = new DivElement
+                {
+                    Style = new Styling.Style { Display = Display.Flex, FlexDirection = FlexDirection.Row }
+                };
+                textLine.AddChild(new SpanElement { Class = "tree-toggle", TextContent = " " });
+                textLine.AddChild(new SpanElement { Class = "tree-node-text", TextContent = TextPreview(element.TextContent!) });
+                textNode.AddChild(textLine);
+                parent.AddChild(textNode);
+            }
+
             foreach (var child in element.Children)
             {
                 BuildTreeNode(parent, child, bridge, depth + 1);
@@ -134,5 +152,11 @@ internal static class DomTreeBuilder
             closingTag.AddChild(closingLine);
             parent.AddChild(closingTag);
         }
+    }
+
+    private static string TextPreview(string text)
+    {
+        var trimmed = text.Trim();
+        return trimmed.Length > 40 ? trimmed[..40] + "..." : trimmed;
     }
 }

--- a/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
@@ -152,6 +152,32 @@ public class BlockLayout
         float currentY = contentY;
         float maxChildWidth = 0;
 
+        // 当元素同时拥有 TextContent 和子元素时：
+        // - 如果第一个子元素是 block，文本作为独立行盒占据顶部，block 子元素从下方开始
+        // - 如果第一个子元素是 inline/inline-block，文本作为匿名 inline 盒与 inline 子元素同行排列
+        float ownTextWidth = 0;
+        float ownTextHeight = 0;
+        bool hasOwnText = box.Children.Count > 0 && !string.IsNullOrEmpty(box.Element.TextContent);
+        bool firstChildIsBlock = hasOwnText && !IsInlineOrInlineBlock(box.Children[0]);
+
+        if (hasOwnText)
+        {
+            var (textWidth, textHeight) = TextMeasurer.MeasureText(
+                box.Element.TextContent,
+                style.FontFamily,
+                style.FontSize.Value,
+                style.FontWeight);
+            ownTextWidth = textWidth;
+            ownTextHeight = textHeight;
+
+            // 仅当第一个子元素是 block 时，文本独占一行，currentY 下移
+            if (firstChildIsBlock)
+            {
+                currentY += ownTextHeight;
+                maxChildWidth = Math.Max(maxChildWidth, ownTextWidth);
+            }
+        }
+
         int i = 0;
         while (i < box.Children.Count)
         {
@@ -160,8 +186,14 @@ public class BlockLayout
             if (IsInlineOrInlineBlock(child))
             {
                 // 收集连续的 Inline/InlineBlock 子元素并水平布局
+                // 如果这是第一组 inline 子元素且父元素有文本内容，文本宽度作为起始 X
                 float lineX = contentX;
-                float lineHeight = 0;
+                if (i == 0 && hasOwnText && !firstChildIsBlock)
+                {
+                    lineX += ownTextWidth;
+                }
+
+                float lineHeight = hasOwnText && i == 0 && !firstChildIsBlock ? ownTextHeight : 0;
 
                 while (i < box.Children.Count && IsInlineOrInlineBlock(box.Children[i]))
                 {
@@ -264,8 +296,32 @@ public class BlockLayout
 
     private void RelayoutChildren(LayoutBox box, float childAvailableWidth, float contentX, float contentY)
     {
+        var style = box.ComputedStyle;
         float currentY = contentY;
         float maxChildWidth = 0;
+
+        // 与主布局逻辑保持一致地处理 TextContent 与子元素共存的情况
+        float ownTextWidth = 0;
+        float ownTextHeight = 0;
+        bool hasOwnText = box.Children.Count > 0 && !string.IsNullOrEmpty(box.Element.TextContent);
+        bool firstChildIsBlock = hasOwnText && !IsInlineOrInlineBlock(box.Children[0]);
+
+        if (hasOwnText)
+        {
+            var (textWidth, textHeight) = TextMeasurer.MeasureText(
+                box.Element.TextContent,
+                style.FontFamily,
+                style.FontSize.Value,
+                style.FontWeight);
+            ownTextWidth = textWidth;
+            ownTextHeight = textHeight;
+
+            if (firstChildIsBlock)
+            {
+                currentY += ownTextHeight;
+                maxChildWidth = Math.Max(maxChildWidth, ownTextWidth);
+            }
+        }
 
         int i = 0;
         while (i < box.Children.Count)
@@ -275,7 +331,12 @@ public class BlockLayout
             if (IsInlineOrInlineBlock(child))
             {
                 float lineX = contentX;
-                float lineHeight = 0;
+                if (i == 0 && hasOwnText && !firstChildIsBlock)
+                {
+                    lineX += ownTextWidth;
+                }
+
+                float lineHeight = hasOwnText && i == 0 && !firstChildIsBlock ? ownTextHeight : 0;
 
                 while (i < box.Children.Count && IsInlineOrInlineBlock(box.Children[i]))
                 {

--- a/tests/Miko.Tests/Layout/LayoutEngineTests.cs
+++ b/tests/Miko.Tests/Layout/LayoutEngineTests.cs
@@ -3106,4 +3106,85 @@ public class LayoutEngineTests
     }
 
     #endregion
+
+    #region Text Content + Children Coexistence
+
+    [Fact]
+    public void BlockLayout_TextContentAndChildren_ShouldNotOverlap()
+    {
+        // <div> content1 <div>content2</div> </div>
+        // When a block element has both TextContent and block children,
+        // the text occupies a line at the top and children flow below it.
+        var root = new DivElement { Class = "outer", TextContent = "content1" };
+        var child = new DivElement { Class = "inner", TextContent = "content2" };
+        root.AddChild(child);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("outer"),
+                        Style = new Style { Width = Length.Px(300) }
+                    }
+                }
+            }
+        };
+
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        var childBox = layoutRoot.Children[0];
+
+        // The child block must be positioned below the parent's own text line,
+        // not at the very top (which would overlap the text).
+        float parentContentTop = layoutRoot.BoxModel.Content.Y;
+        childBox.BoxModel.MarginBox.Y.ShouldBeGreaterThan(parentContentTop);
+
+        // The parent's content height must include both the text line and the child.
+        layoutRoot.BoxModel.Content.Height.ShouldBeGreaterThan(childBox.BoxModel.MarginBox.Height);
+    }
+
+    [Fact]
+    public void BlockLayout_TextContentAndInlineChildren_ShouldFlowOnSameLine()
+    {
+        // <div> content1 <span>content2</span> </div>
+        // TextContent acts like an anonymous inline box and should flow
+        // on the same line with inline/inline-block children.
+        var root = new DivElement { Class = "outer", TextContent = "content1 " };
+        var span = new SpanElement { Class = "inner", TextContent = "content2" };
+        root.AddChild(span);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("outer"),
+                        Style = new Style { Width = Length.Px(300) }
+                    }
+                }
+            }
+        };
+
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        var spanBox = layoutRoot.Children[0];
+
+        // The span should be on the same line as the parent's text,
+        // positioned horizontally after the text width, not below it.
+        float parentContentTop = layoutRoot.BoxModel.Content.Y;
+        spanBox.BoxModel.MarginBox.Y.ShouldBe(parentContentTop, 1f);
+
+        // The span's X position should be after the text "content1 "
+        float parentContentLeft = layoutRoot.BoxModel.Content.X;
+        spanBox.BoxModel.MarginBox.X.ShouldBeGreaterThan(parentContentLeft);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

Handle block elements that contain **both** `TextContent` and child elements — previously the element's own text was ignored when children were present.

- **First child is block** → the text occupies its own line box at the top, and block children start below it.
- **First child is inline/inline-block** → the text acts as an anonymous inline box laid out on the same line as the inline children (text width offsets the starting X, text height seeds the line height).

The same logic is applied in both the initial layout path and `RelayoutChildren` to keep incremental re-layout consistent.

## Changes

- `src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs` — mixed text+element layout in both layout paths
- `src/Miko.DevTools/*` — DOM tree builder / bridge / window updates to reflect the mixed-content nodes
- `tests/Miko.Tests/Layout/LayoutEngineTests.cs` — new tests covering the mixed-content scenarios

## Test plan

- [x] `dotnet test tests/Miko.Tests/Miko.Tests.csproj` passes
- [x] New `LayoutEngineTests` cases for text-before-block and text-with-inline pass