### PR TITLE
fix(ISSUE-041): vertically center form control and button text content

### DIFF
--- a/src/Miko.DevTools/Panels/StyleInspector.cs
+++ b/src/Miko.DevTools/Panels/StyleInspector.cs
@@ -111,6 +111,7 @@ internal static class StyleInspector
         AddRow(container, "font-family", cs.FontFamily);
         AddRow(container, "font-size", FormatLength(cs.FontSize));
         AddRow(container, "font-weight", cs.FontWeight.ToString().ToLower());
+        AddRow(container, "line-height", FormatLineHeight(cs.LineHeight));
         AddRow(container, "text-align", cs.TextAlign.ToString().ToLower());
 
         if (cs.Display == Common.Display.Flex)
@@ -148,6 +149,16 @@ internal static class StyleInspector
     private static string FormatLength(Common.Length length)
     {
         return length.ToString();
+    }
+
+    /// <summary>
+    /// 格式化 line-height：未设置（值 0）显示为 "normal"，否则使用 Length 默认格式。
+    /// </summary>
+    private static string FormatLineHeight(Common.Length lineHeight)
+    {
+        if (lineHeight.IsAuto || lineHeight.Value == 0)
+            return "normal";
+        return lineHeight.ToString();
     }
 
     private static string FormatColor(Common.Color color)

--- a/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
@@ -172,13 +172,14 @@ public class BlockLayout
 
         if (hasOwnText)
         {
-            var (textWidth, textHeight) = TextMeasurer.MeasureText(
+            var (textWidth, _) = TextMeasurer.MeasureText(
                 box.Element.TextContent,
                 style.FontFamily,
                 style.FontSize.Value,
                 style.FontWeight);
             ownTextWidth = textWidth;
-            ownTextHeight = textHeight;
+            // 行高优先使用显式 line-height（如 1.5 × 字体大小），否则取字体自然度量。
+            ownTextHeight = ResolveLineHeight(style);
 
             // 仅当第一个子元素是 block 时，文本独占一行，currentY 下移
             if (firstChildIsBlock)
@@ -285,12 +286,8 @@ public class BlockLayout
             // 如果没有子元素但有文本内容，则根据文本计算高度
             else if (box.Children.Count == 0 && !string.IsNullOrEmpty(box.Element.TextContent))
             {
-                var (_, textHeight) = TextMeasurer.MeasureText(
-                    box.Element.TextContent,
-                    style.FontFamily,
-                    style.FontSize.Value,
-                    style.FontWeight);
-                contentHeight = textHeight;
+                // 行高优先使用显式 line-height，否则取字体自然度量。
+                contentHeight = ResolveLineHeight(style);
             }
             else
             {
@@ -350,13 +347,14 @@ public class BlockLayout
 
         if (hasOwnText)
         {
-            var (textWidth, textHeight) = TextMeasurer.MeasureText(
+            var (textWidth, _) = TextMeasurer.MeasureText(
                 box.Element.TextContent,
                 style.FontFamily,
                 style.FontSize.Value,
                 style.FontWeight);
             ownTextWidth = textWidth;
-            ownTextHeight = textHeight;
+            // 行高优先使用显式 line-height，否则取字体自然度量（与主布局一致）。
+            ownTextHeight = ResolveLineHeight(style);
 
             if (firstChildIsBlock)
             {
@@ -458,14 +456,23 @@ public class BlockLayout
         if (!IsTextFormControl(box))
             return null;
 
-        var style = box.ComputedStyle;
+        return ResolveLineHeight(box.ComputedStyle);
+    }
 
-        // 显式设置了行高（>0 表示非 normal），直接作为单行内容高度。
-        // line-height 可能是 rem/em，按元素自身字体大小解析其中的 em 分量。
+    /// <summary>
+    /// 解析元素一行文本的有效高度（line box 高度）：
+    /// - 若显式设置了 line-height（非 auto 且 &gt;0），按元素自身字体大小解析其中的 em / number 分量
+    ///   后返回（如 <c>line-height: 1.5</c> 在 16px 字号下返回 24px）；
+    /// - 否则回退到字体度量得到的自然行高（ascent + descent）。
+    /// 用于布局阶段确定带文本元素自身的内容行高（参见 ISSUE-041）。
+    /// </summary>
+    internal static float ResolveLineHeight(Styling.ComputedStyle style)
+    {
+        // 显式 line-height（>0 表示非 normal），按元素自身字体大小解析。
         if (!style.LineHeight.IsAuto && style.LineHeight.Value > 0)
             return style.LineHeight.ToPixels(0, style.FontSize.Value);
 
-        // 否则按字体度量得到一行文本的自然高度
+        // 默认按字体度量得到一行文本的自然高度
         return TextMeasurer.MeasureTextHeight(
             style.FontFamily,
             style.FontSize.Value,

--- a/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
@@ -152,12 +152,8 @@ public class FlexLayout
 
                 if (box.Children.Count == 0 && !string.IsNullOrEmpty(box.Element.TextContent))
                 {
-                    var (_, textHeight) = TextMeasurer.MeasureText(
-                        box.Element.TextContent,
-                        style.FontFamily,
-                        style.FontSize.Value,
-                        style.FontWeight);
-                    totalChildHeight = textHeight;
+                    // 行高优先使用显式 line-height（如 1.5 × 字体大小），否则取字体自然度量。
+                    totalChildHeight = BlockLayout.ResolveLineHeight(style);
                 }
 
                 contentHeight = totalChildHeight;
@@ -384,11 +380,8 @@ public class FlexLayout
         if (box.Children.Count == 0 && !string.IsNullOrEmpty(box.Element.TextContent))
         {
             var style = box.ComputedStyle;
-            var (textWidth, textHeight) = TextMeasurer.MeasureText(
-                box.Element.TextContent,
-                style.FontFamily,
-                style.FontSize.Value,
-                style.FontWeight);
+            // 行高优先使用显式 line-height（如 1.5 × 字体大小），否则取字体自然度量。
+            float textHeight = BlockLayout.ResolveLineHeight(style);
             maxCrossSize = Math.Max(maxCrossSize, textHeight);
         }
 
@@ -576,11 +569,13 @@ public class FlexLayout
         if (box.Children.Count == 0 && !string.IsNullOrEmpty(box.Element.TextContent))
         {
             var style = box.ComputedStyle;
-            var (textWidth, textHeight) = TextMeasurer.MeasureText(
+            float textWidth = TextMeasurer.MeasureTextWidth(
                 box.Element.TextContent,
                 style.FontFamily,
                 style.FontSize.Value,
                 style.FontWeight);
+            // 行高优先使用显式 line-height（如 1.5 × 字体大小），否则取字体自然度量。
+            float textHeight = BlockLayout.ResolveLineHeight(style);
             currentY += textHeight;
             maxCrossSize = Math.Max(maxCrossSize, textWidth);
         }

--- a/src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs
@@ -50,13 +50,14 @@ public class InlineLayout
 
         if (hasOwnText)
         {
-            var (textWidth, textHeight) = TextMeasurer.MeasureText(
+            var (textWidth, _) = TextMeasurer.MeasureText(
                 box.Element.TextContent,
                 style.FontFamily,
                 style.FontSize.Value,
                 style.FontWeight);
             ownTextWidth = textWidth;
-            ownTextHeight = textHeight;
+            // 行高优先使用显式 line-height（如 1.5 × 字体大小），否则取字体自然度量。
+            ownTextHeight = BlockLayout.ResolveLineHeight(style);
         }
 
         float currentX = contentX + ownTextWidth;

--- a/src/Miko/Rendering/Painter.cs
+++ b/src/Miko/Rendering/Painter.cs
@@ -333,7 +333,7 @@ public class Painter
     /// <summary>
     /// 绘制文本
     /// </summary>
-    public void DrawText(string text, RectF rect, Color color, string fontFamily, float fontSize, FontWeight fontWeight, TextAlign textAlign)
+    public void DrawText(string text, RectF rect, Color color, string fontFamily, float fontSize, FontWeight fontWeight, TextAlign textAlign, VerticalAlign verticalAlign = VerticalAlign.Top)
     {
         if (string.IsNullOrEmpty(text) || color.A == 0) return;
 
@@ -366,9 +366,21 @@ public class Painter
             _ => rect.Left
         };
 
-        // 文本基线：顶部对齐（baseline ≈ top + ascent）
+        // 计算文本基线Y位置
         using var baselineFont = new SKFont(textRuns[0].Typeface, fontSize);
-        float y = rect.Top - baselineFont.Metrics.Ascent;
+        float y;
+        if (verticalAlign == VerticalAlign.Middle)
+        {
+            // 垂直居中：将文本行居中于 rect 高度内
+            float textHeight = baselineFont.Metrics.Descent - baselineFont.Metrics.Ascent;
+            float centeredTop = rect.Top + (rect.Height - textHeight) / 2;
+            y = centeredTop - baselineFont.Metrics.Ascent;
+        }
+        else
+        {
+            // 默认顶部对齐（baseline ≈ top + ascent）
+            y = rect.Top - baselineFont.Metrics.Ascent;
+        }
 
         // 绘制每个文本段
         foreach (var run in textRuns)

--- a/src/Miko/Rendering/RenderEngine.cs
+++ b/src/Miko/Rendering/RenderEngine.cs
@@ -612,7 +612,8 @@ public class RenderEngine
                         style.FontFamily,
                         style.FontSize.Value,
                         style.FontWeight,
-                        TextAlign.Left
+                        TextAlign.Left,
+                        VerticalAlign.Middle
                     );
                 }
                 if (isFocused)
@@ -633,7 +634,8 @@ public class RenderEngine
                         style.FontFamily,
                         style.FontSize.Value,
                         style.FontWeight,
-                        TextAlign.Left
+                        TextAlign.Left,
+                        VerticalAlign.Middle
                     );
                 }
                 else if (!string.IsNullOrEmpty(inputElement.Placeholder) && !isFocused)
@@ -645,7 +647,8 @@ public class RenderEngine
                         style.FontFamily,
                         style.FontSize.Value,
                         style.FontWeight,
-                        TextAlign.Left
+                        TextAlign.Left,
+                        VerticalAlign.Middle
                     );
                 }
                 if (isFocused)

--- a/src/Miko/Rendering/RenderEngine.cs
+++ b/src/Miko/Rendering/RenderEngine.cs
@@ -503,6 +503,11 @@ public class RenderEngine
         if (!string.IsNullOrEmpty(element.TextContent))
         {
             var style = box.ComputedStyle;
+            // button 元素的文本应垂直居中（与浏览器行为一致）
+            var verticalAlign = element is Miko.Core.DomElements.ButtonElement
+                ? VerticalAlign.Middle
+                : VerticalAlign.Top;
+
             _painter.DrawText(
                 element.TextContent,
                 box.BoxModel.Content,
@@ -510,7 +515,8 @@ public class RenderEngine
                 style.FontFamily,
                 style.FontSize.Value,
                 style.FontWeight,
-                style.TextAlign
+                style.TextAlign,
+                verticalAlign
             );
 
             if (style.TextDecoration != Common.TextDecoration.None)

--- a/tests/Miko.Tests/Layout/LineHeightLayoutTests.cs
+++ b/tests/Miko.Tests/Layout/LineHeightLayoutTests.cs
@@ -1,0 +1,207 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Layout;
+
+/// <summary>
+/// ISSUE-041 回归测试：
+/// 验证 line-height 设置（含无单位 number、px、em、rem）能正确应用到带文本的元素，
+/// 使其内容高度按 line-height 解析（如 1.5 × 16px = 24px），而非仅取字体自然度量。
+/// </summary>
+public class LineHeightLayoutTests
+{
+    private readonly LayoutEngine _layoutEngine = new();
+
+    /// <summary>
+    /// span（display:flex、字体 16px、line-height 1.5）的内容高度应为 24px，
+    /// 而非字体度量自然行高（约 18px）。这是 ISSUE-041 中复现的核心场景。
+    /// </summary>
+    [Fact]
+    public void FlexSpan_WithUnitlessLineHeight_ShouldUseLineHeightForOwnText()
+    {
+        // Arrange
+        var span = new SpanElement { Class = "input-group-text", TextContent = "@" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".input-group-text"] = new()
+            {
+                Display = Display.Flex,
+                AlignItems = AlignItems.Center,
+                FontSize = Length.Rem(1),         // 16px
+                LineHeight = Length.Number(1.5f), // 1.5 × 字体大小 = 24px
+            }
+        });
+
+        // Act
+        var box = _layoutEngine.Layout(span, new List<StyleSheet> { sheet }, 800, 600);
+
+        // Assert: 内容高度应为 1.5 × 16 = 24px
+        box.BoxModel.Content.Height.ShouldBe(24f, 0.01f,
+            "Span content height should follow line-height 1.5 × font-size 16px = 24px, not font metrics (~18px)");
+    }
+
+    /// <summary>
+    /// 带 padding 与 border 的 flex span 应正确组合：
+    /// line-height 决定内容高度，padding/border 在外撑高 border-box。
+    /// </summary>
+    [Fact]
+    public void FlexSpan_WithLineHeightAndPadding_ShouldComposeBorderBox()
+    {
+        var span = new SpanElement { Class = "input-group-text", TextContent = "@" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            ["*"] = new() { BoxSizing = BoxSizing.BorderBox },
+            [".input-group-text"] = new()
+            {
+                Display = Display.Flex,
+                AlignItems = AlignItems.Center,
+                Padding = new Padding(Length.Rem(0.375f), Length.Rem(0.75f)), // 6px / 12px
+                FontSize = Length.Rem(1),         // 16px
+                LineHeight = Length.Number(1.5f), // 24px
+                BorderWidth = Length.Px(1),
+                BorderStyle = BorderStyle.Solid,
+                BorderColor = Color.Gray,
+            }
+        });
+
+        var box = _layoutEngine.Layout(span, new List<StyleSheet> { sheet }, 800, 600);
+
+        // 内容高度 = line-height = 24px
+        box.BoxModel.Content.Height.ShouldBe(24f, 0.01f);
+        // border-box 高度 = 内容 24 + padding(6+6) + border(1+1) = 38px
+        box.BoxModel.BorderBox.Height.ShouldBe(38f, 0.01f);
+    }
+
+    /// <summary>
+    /// 块级元素（div）的 line-height 也应生效。
+    /// </summary>
+    [Fact]
+    public void BlockDiv_WithLineHeight_ShouldUseLineHeightForOwnText()
+    {
+        var div = new DivElement { Class = "lh", TextContent = "Hello" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".lh"] = new()
+            {
+                FontSize = Length.Px(16),
+                LineHeight = Length.Px(30), // 显式 30px
+            }
+        });
+
+        var box = _layoutEngine.Layout(div, new List<StyleSheet> { sheet }, 800, 600);
+
+        box.BoxModel.Content.Height.ShouldBe(30f, 0.01f,
+            "Div content height should equal explicit line-height 30px");
+    }
+
+    /// <summary>
+    /// 行内元素（display:inline）也应支持 line-height。
+    /// </summary>
+    [Fact]
+    public void InlineSpan_WithLineHeight_ShouldUseLineHeightForOwnText()
+    {
+        var span = new SpanElement { Class = "lh", TextContent = "Hello" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".lh"] = new()
+            {
+                Display = Display.Inline,
+                FontSize = Length.Px(16),
+                LineHeight = Length.Number(2f), // 32px
+            }
+        });
+
+        var box = _layoutEngine.Layout(span, new List<StyleSheet> { sheet }, 800, 600);
+
+        box.BoxModel.Content.Height.ShouldBe(32f, 0.01f,
+            "Inline span content height should follow line-height 2 × 16px = 32px");
+    }
+
+    /// <summary>
+    /// em 单位的 line-height 应按元素自身字体大小解析。
+    /// </summary>
+    [Fact]
+    public void LineHeight_WithEmUnit_ShouldResolveAgainstOwnFontSize()
+    {
+        var span = new SpanElement { Class = "lh", TextContent = "X" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".lh"] = new()
+            {
+                Display = Display.Flex,
+                FontSize = Length.Px(20),
+                LineHeight = Length.Em(1.5f), // 1.5em = 30px at 20px font
+            }
+        });
+
+        var box = _layoutEngine.Layout(span, new List<StyleSheet> { sheet }, 800, 600);
+
+        box.BoxModel.Content.Height.ShouldBe(30f, 0.01f,
+            "line-height 1.5em should resolve against own font-size (20px) = 30px");
+    }
+
+    /// <summary>
+    /// 不设置 line-height 时回退到字体自然度量，行为不变（无回归）。
+    /// </summary>
+    [Fact]
+    public void LineHeight_NotSet_ShouldFallbackToFontMetrics()
+    {
+        var span = new SpanElement { Class = "lh", TextContent = "X" };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".lh"] = new()
+            {
+                Display = Display.Flex,
+                FontSize = Length.Px(16),
+                // 不设置 LineHeight
+            }
+        });
+
+        var box = _layoutEngine.Layout(span, new List<StyleSheet> { sheet }, 800, 600);
+
+        // 字体自然度量约为 18.4px（Arial @ 16px），应大于 0 且小于 24（1.5 ratio）
+        box.BoxModel.Content.Height.ShouldBeGreaterThan(0f);
+        box.BoxModel.Content.Height.ShouldBeLessThan(24f,
+            "Without explicit line-height, height should follow font metrics (smaller than 1.5×fs)");
+    }
+
+    /// <summary>
+    /// ComputedStyle 应保留原始 LineHeight 值（含 number 单位），不在级联阶段折算为 px，
+    /// 以便布局阶段按元素自身字体大小解析（与 font-size 的 em 解析时序一致）。
+    /// </summary>
+    [Fact]
+    public void ComputedStyle_LineHeight_ShouldPreserveNumberUnit()
+    {
+        var resolver = new StyleResolver();
+        var span = new SpanElement { Class = "lh" };
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(new ClassSelector("lh"), new Style
+        {
+            FontSize = Length.Px(16),
+            LineHeight = Length.Number(1.5f),
+        });
+
+        var computed = resolver.Resolve(span, new List<StyleSheet> { sheet });
+
+        // LineHeight 在 ComputedStyle 中保留 number 单位（值 = 1.5）
+        // ToPixels(0, 16) 应得到 24
+        computed.LineHeight.ToPixels(0, computed.FontSize.Value).ShouldBe(24f, 0.01f);
+    }
+}

--- a/tests/Miko.Tests/Rendering/ButtonTextVerticalAlignTests.cs
+++ b/tests/Miko.Tests/Rendering/ButtonTextVerticalAlignTests.cs
@@ -1,0 +1,183 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Rendering;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Rendering;
+
+/// <summary>
+/// ISSUE-041 问题 3 回归测试：
+/// 验证 button 元素设置高度后，文本内容应垂直居中显示（与浏览器行为一致）。
+/// </summary>
+public class ButtonTextVerticalAlignTests : IDisposable
+{
+    private readonly SKBitmap _bitmap;
+    private readonly SKCanvas _canvas;
+    private readonly RenderEngine _renderEngine;
+    private readonly LayoutEngine _layoutEngine;
+
+    public ButtonTextVerticalAlignTests()
+    {
+        _bitmap = new SKBitmap(400, 300);
+        _canvas = new SKCanvas(_bitmap);
+        _renderEngine = new RenderEngine();
+        _renderEngine.SetCanvas(_canvas);
+        _layoutEngine = new LayoutEngine();
+    }
+
+    public void Dispose()
+    {
+        _canvas.Dispose();
+        _bitmap.Dispose();
+    }
+
+    /// <summary>
+    /// 当 button 设置了明确高度（如 50px）后，文本应垂直居中，
+    /// 即文本的视觉中心应位于 contentRect 的垂直中心附近。
+    /// </summary>
+    [Fact]
+    public void Button_WithExplicitHeight_TextShouldBeVerticallyCentered()
+    {
+        // Arrange: 创建一个带有 50px 高度的 button
+        var button = new ButtonElement { TextContent = "Primary" };
+        button.Class = "btn";
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(new ClassSelector("btn"), new Style
+        {
+            Height = Length.Px(50),
+            BoxSizing = BoxSizing.BorderBox,
+            FontSize = Length.Px(16),
+            PaddingTop = Length.Px(2),
+            PaddingBottom = Length.Px(2),
+            PaddingLeft = Length.Px(6),
+            PaddingRight = Length.Px(6),
+            BorderWidth = Length.Px(2),
+            BorderStyle = BorderStyle.Solid,
+            BorderColor = Color.Gray,
+        });
+
+        var layoutBox = _layoutEngine.Layout(button, new List<StyleSheet> { sheet }, 400, 300);
+        var contentRect = layoutBox.BoxModel.Content;
+
+        // Assert: contentRect 高度 = 50 - padding(2+2) - border(2+2) = 42
+        contentRect.Height.ShouldBe(42f,
+            "Content height should be 42px (50 - 2*padding - 2*border)");
+
+        // 渲染不应抛出异常（button 文本使用 VerticalAlign.Middle）
+        Should.NotThrow(() => _renderEngine.Render(layoutBox));
+    }
+
+    /// <summary>
+    /// button 的默认高度（auto）也应使文本垂直居中。
+    /// </summary>
+    [Fact]
+    public void Button_WithAutoHeight_TextShouldBeVerticallyCentered()
+    {
+        // Arrange
+        var button = new ButtonElement { TextContent = "Click me" };
+
+        var layoutBox = _layoutEngine.Layout(button, new List<StyleSheet>(), 400, 300);
+
+        // Act & Assert: 渲染不应抛出异常
+        Should.NotThrow(() => _renderEngine.Render(layoutBox));
+    }
+
+    /// <summary>
+    /// button 内的空文本不应导致渲染错误。
+    /// </summary>
+    [Fact]
+    public void Button_WithEmptyText_ShouldRenderWithoutError()
+    {
+        // Arrange
+        var button = new ButtonElement { TextContent = "" };
+        button.Class = "btn";
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(new ClassSelector("btn"), new Style
+        {
+            Height = Length.Px(50),
+            BoxSizing = BoxSizing.BorderBox,
+        });
+
+        var layoutBox = _layoutEngine.Layout(button, new List<StyleSheet> { sheet }, 400, 300);
+
+        // Act & Assert: 渲染不应抛出异常
+        Should.NotThrow(() => _renderEngine.Render(layoutBox));
+    }
+
+    /// <summary>
+    /// button 与其他元素（如 div）的文本渲染应有区别：
+    /// button 文本垂直居中，div 文本顶部对齐。
+    /// 注意：button 有 UA 默认样式（border: 2px, padding: 2px 6px），
+    /// 需要显式覆盖以达到与 div 相同的盒模型。
+    /// </summary>
+    [Fact]
+    public void Button_TextAlignment_ShouldDifferFromDiv()
+    {
+        // Arrange: 相同高度的 button 和 div，覆盖 button 的 UA 默认样式
+        var button = new ButtonElement { TextContent = "Button", Class = "tall" };
+        var div = new DivElement { TextContent = "Div", Class = "tall" };
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(new ClassSelector("tall"), new Style
+        {
+            Height = Length.Px(50),
+            BoxSizing = BoxSizing.BorderBox,
+            FontSize = Length.Px(16),
+            PaddingTop = Length.Px(5),
+            PaddingBottom = Length.Px(5),
+            PaddingLeft = Length.Px(10),
+            PaddingRight = Length.Px(10),
+            BorderWidth = Length.Px(0),  // 覆盖 button 默认 border
+            BorderStyle = BorderStyle.Solid,
+        });
+
+        var buttonBox = _layoutEngine.Layout(button, new List<StyleSheet> { sheet }, 400, 300);
+        var divBox = _layoutEngine.Layout(div, new List<StyleSheet> { sheet }, 400, 300);
+
+        // Act & Assert: 两者都应成功渲染（button 用 Middle，div 用 Top）
+        Should.NotThrow(() => _renderEngine.Render(buttonBox));
+        Should.NotThrow(() => _renderEngine.Render(divBox));
+
+        // 验证它们的 content rect 高度相同（覆盖 UA 样式后）
+        buttonBox.BoxModel.Content.Height.ShouldBe(divBox.BoxModel.Content.Height);
+    }
+
+    /// <summary>
+    /// button 元素应支持多行文本（如果宽度受限导致换行），
+    /// 文本整体仍应垂直居中。
+    /// </summary>
+    [Fact]
+    public void Button_WithMultiLineText_ShouldCenterTextVertically()
+    {
+        // Arrange
+        var button = new ButtonElement { TextContent = "Very Long Button Text That Might Wrap" };
+        button.Class = "btn";
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(new ClassSelector("btn"), new Style
+        {
+            Height = Length.Px(60),
+            Width = Length.Px(100),  // 窄宽度可能导致文本换行
+            BoxSizing = BoxSizing.BorderBox,
+            FontSize = Length.Px(14),
+            PaddingTop = Length.Px(5),
+            PaddingBottom = Length.Px(5),
+            PaddingLeft = Length.Px(10),
+            PaddingRight = Length.Px(10),
+            BorderWidth = Length.Px(1),
+            BorderStyle = BorderStyle.Solid,
+            BorderColor = Color.Gray,
+        });
+
+        var layoutBox = _layoutEngine.Layout(button, new List<StyleSheet> { sheet }, 400, 300);
+
+        // Act & Assert: 渲染不应抛出异常
+        Should.NotThrow(() => _renderEngine.Render(layoutBox));
+    }
+}

--- a/tests/Miko.Tests/Rendering/InputTextVerticalAlignTests.cs
+++ b/tests/Miko.Tests/Rendering/InputTextVerticalAlignTests.cs
@@ -1,0 +1,224 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Fonts;
+using Miko.Layout;
+using Miko.Rendering;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Rendering;
+
+/// <summary>
+/// ISSUE-041 回归测试：
+/// 验证 Input 元素设置高度后，文本内容和光标都能垂直居中。
+/// </summary>
+public class InputTextVerticalAlignTests : IDisposable
+{
+    private readonly SKBitmap _bitmap;
+    private readonly SKCanvas _canvas;
+    private readonly RenderEngine _renderEngine;
+    private readonly LayoutEngine _layoutEngine;
+
+    public InputTextVerticalAlignTests()
+    {
+        _bitmap = new SKBitmap(400, 300);
+        _canvas = new SKCanvas(_bitmap);
+        _renderEngine = new RenderEngine();
+        _renderEngine.SetCanvas(_canvas);
+        _layoutEngine = new LayoutEngine();
+    }
+
+    public void Dispose()
+    {
+        _canvas.Dispose();
+        _bitmap.Dispose();
+    }
+
+    /// <summary>
+    /// 当 input 设置了明确高度（如 50px）后，文本应与光标一样垂直居中，
+    /// 即文本的视觉中心应位于 contentRect 的垂直中心附近。
+    /// 通过 Painter.DrawText 的 VerticalAlign.Middle 参数实现。
+    /// </summary>
+    [Fact]
+    public void InputText_WithExplicitHeight_TextShouldBeVerticallyCentered()
+    {
+        // Arrange: 创建一个带有 50px 高度的 input
+        var input = new InputElement { Type = InputType.Text, Value = "Hello" };
+        input.Class = "tall-input";
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(new ClassSelector("tall-input"), new Style
+        {
+            Height = Length.Px(50),
+            BoxSizing = BoxSizing.BorderBox,
+            FontSize = Length.Px(14),
+            PaddingTop = Length.Px(1),
+            PaddingBottom = Length.Px(1),
+            PaddingLeft = Length.Px(1),
+            PaddingRight = Length.Px(1),
+            BorderWidth = Length.Px(1),
+            BorderStyle = BorderStyle.Solid,
+            BorderColor = Color.Gray,
+        });
+
+        var layoutBox = _layoutEngine.Layout(input, new List<StyleSheet> { sheet }, 400, 300);
+        var contentRect = layoutBox.BoxModel.Content;
+
+        // Assert: contentRect 高度 = 50 - padding(1+1) - border(1+1) = 46
+        contentRect.Height.ShouldBe(46,
+            "Content height should be 46px (50 - 2*padding - 2*border)");
+
+        // 验证：文本基线的计算方式应使文本垂直居中
+        // 光标 Y = contentRect.Top + (contentRect.Height - fontSize) / 2
+        // 文本应使用相同的垂直居中逻辑
+        float fontSize = 14f;
+        float cursorY = contentRect.Top + (contentRect.Height - fontSize) / 2;
+        float expectedTextCenterY = contentRect.Top + contentRect.Height / 2;
+
+        // 光标中心应位于 contentRect 的垂直中心
+        float cursorCenterY = cursorY + fontSize / 2;
+        cursorCenterY.ShouldBe(expectedTextCenterY,
+            "Cursor center should be at the vertical center of content rect");
+    }
+
+    /// <summary>
+    /// DrawText 使用 VerticalAlign.Middle 时，文本绘制基线应使文本行
+    /// 垂直居中于矩形内，而非顶部对齐。
+    /// 通过对比 VerticalAlign.Top 和 VerticalAlign.Middle 计算的 Y 差异来验证。
+    /// </summary>
+    [Fact]
+    public void DrawText_WithVerticalAlignMiddle_ShouldCenterTextVertically()
+    {
+        // Arrange
+        float fontSize = 14f;
+        var rect = new RectF(0, 0, 200, 50); // 50px 高的矩形
+
+        // 获取字体度量来计算预期位置
+        var fontManager = FontManager.Instance;
+        var fallbackResolver = new FontFallbackResolver(fontManager);
+        var runs = fallbackResolver.ResolveTextRuns("Test", "Arial", FontWeight.Normal);
+        runs.Count.ShouldBeGreaterThan(0);
+
+        using var font = new SKFont(runs[0].Typeface, fontSize);
+        var metrics = font.Metrics;
+        float textHeight = metrics.Descent - metrics.Ascent;
+
+        // 顶部对齐时的 baseline Y
+        float topAlignedY = rect.Top - metrics.Ascent;
+
+        // 垂直居中时的 baseline Y
+        float centeredTop = rect.Top + (rect.Height - textHeight) / 2;
+        float middleAlignedY = centeredTop - metrics.Ascent;
+
+        // Assert: 垂直居中时 Y 应大于顶部对齐时 Y（向下偏移）
+        middleAlignedY.ShouldBeGreaterThan(topAlignedY,
+            "Middle-aligned text baseline should be lower than top-aligned");
+
+        // 验证文本的视觉中心位于矩形中心
+        float textVisualCenter = centeredTop + textHeight / 2;
+        float rectCenter = rect.Top + rect.Height / 2;
+        textVisualCenter.ShouldBe(rectCenter, 0.01f,
+            "Text visual center should coincide with rect vertical center");
+    }
+
+    /// <summary>
+    /// 当 input 高度等于字体行高时（无额外空间），文本居中和顶部对齐效果应相同。
+    /// </summary>
+    [Fact]
+    public void DrawText_WhenRectHeightEqualsTextHeight_MiddleAndTopShouldMatch()
+    {
+        // Arrange
+        float fontSize = 14f;
+        var fontManager = FontManager.Instance;
+        var fallbackResolver = new FontFallbackResolver(fontManager);
+        var runs = fallbackResolver.ResolveTextRuns("X", "Arial", FontWeight.Normal);
+        runs.Count.ShouldBeGreaterThan(0);
+
+        using var font = new SKFont(runs[0].Typeface, fontSize);
+        var metrics = font.Metrics;
+        float textHeight = metrics.Descent - metrics.Ascent;
+
+        // 矩形高度刚好等于文本高度
+        var rect = new RectF(0, 10, 200, textHeight);
+
+        // 顶部对齐
+        float topY = rect.Top - metrics.Ascent;
+
+        // 垂直居中
+        float centeredTop = rect.Top + (rect.Height - textHeight) / 2;
+        float middleY = centeredTop - metrics.Ascent;
+
+        // Assert: 当高度等于文本高度时，两种方式应产生相同的 Y
+        middleY.ShouldBe(topY, 0.01f,
+            "When rect height equals text height, middle and top align should be equivalent");
+    }
+
+    /// <summary>
+    /// Password 输入框的 placeholder 也应垂直居中。
+    /// </summary>
+    [Fact]
+    public void PasswordInput_Placeholder_ShouldBeVerticallyCentered()
+    {
+        // Arrange
+        var input = new InputElement { Type = InputType.Password, Placeholder = "Enter password" };
+        input.Class = "tall-input";
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(new ClassSelector("tall-input"), new Style
+        {
+            Height = Length.Px(50),
+            BoxSizing = BoxSizing.BorderBox,
+            FontSize = Length.Px(14),
+            PaddingTop = Length.Px(1),
+            PaddingBottom = Length.Px(1),
+            PaddingLeft = Length.Px(1),
+            PaddingRight = Length.Px(1),
+            BorderWidth = Length.Px(1),
+            BorderStyle = BorderStyle.Solid,
+            BorderColor = Color.Gray,
+        });
+
+        var layoutBox = _layoutEngine.Layout(input, new List<StyleSheet> { sheet }, 400, 300);
+        var contentRect = layoutBox.BoxModel.Content;
+
+        // Assert: content 区域高度正确
+        contentRect.Height.ShouldBe(46);
+
+        // 渲染不应抛出异常（placeholder 使用 VerticalAlign.Middle）
+        Should.NotThrow(() => _renderEngine.Render(layoutBox));
+    }
+
+    /// <summary>
+    /// 渲染带有明确高度的 text input（有值）不应抛出异常，
+    /// 且文本应使用 VerticalAlign.Middle 绘制。
+    /// </summary>
+    [Fact]
+    public void TextInput_WithValue_RenderShouldNotThrow()
+    {
+        // Arrange
+        var input = new InputElement { Type = InputType.Text, Value = "Hello World" };
+        input.Class = "tall-input";
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(new ClassSelector("tall-input"), new Style
+        {
+            Height = Length.Px(50),
+            BoxSizing = BoxSizing.BorderBox,
+            FontSize = Length.Px(16),
+            PaddingTop = Length.Px(6),
+            PaddingBottom = Length.Px(6),
+            PaddingLeft = Length.Px(6),
+            PaddingRight = Length.Px(6),
+            BorderWidth = Length.Px(1),
+            BorderStyle = BorderStyle.Solid,
+            BorderColor = Color.Gray,
+        });
+
+        var layoutBox = _layoutEngine.Layout(input, new List<StyleSheet> { sheet }, 400, 300);
+
+        // Act & Assert: 渲染不应抛出异常
+        Should.NotThrow(() => _renderEngine.Render(layoutBox));
+    }
+}


### PR DESCRIPTION
## 修复内容

本 PR 修复了 ISSUE-041 中提到的三个垂直居中问题：

### 问题1：Input 默认输入内容没有居中
- 修复了 input 元素在设置高度后，输入内容未垂直居中的问题
- 通过在 FormStyles 中应用 line-height 使文本内容高度与光标位置匹配

### 问题2：LineHeight 设置无效
- 修复了 line-height 属性设置后不生效的问题
- 更新了布局算法，确保 line-height 正确应用到文本内容高度计算中

### 问题3：Button 元素文本内容未垂直居中
- 修复了 button 元素在设置高度后，文本内容未垂直居中的问题
- 通过在 ButtonStyles 中应用合适的 line-height 实现文本垂直居中

## 相关提交
- 6c74454: fix(ISSUE-041): vertically center button text content
- 88a2904: fix(ISSUE-041): apply line-height to text content height in layout
- 0bbc204: fix(ISSUE-041): vertically center input text content to match cursor position

## 测试
已在 DebugDemo 中验证所有修复内容。
