### PR TITLE
fix(ISSUE-043): prevent stale transitions across page navigation

### DIFF
--- a/src/Miko/Core/MikoEngine.cs
+++ b/src/Miko/Core/MikoEngine.cs
@@ -89,6 +89,12 @@ public class MikoEngine
 
     private static void MapElementIdentityRecursive(Element oldElement, Element newElement)
     {
+        // 仅在新旧元素表示"同一个"元素时才迁移 LayoutBox。
+        // 否则旧元素的 LayoutBox（携带其 transition 定义与计算样式）会被错误地挂到
+        // 结构位置相同但语义不同的新元素上，导致旧页面的 transition 在新页面上被触发
+        // （见 ISSUE-043：切换页面时 .btn 的背景色动画在 /form 页面上播放）。
+        if (!IsSameElementIdentity(oldElement, newElement)) return;
+
         if (oldElement.LayoutBox != null)
         {
             newElement.LayoutBox = oldElement.LayoutBox;
@@ -99,6 +105,19 @@ public class MikoEngine
         {
             MapElementIdentityRecursive(oldElement.Children[i], newElement.Children[i]);
         }
+    }
+
+    /// <summary>
+    /// 判断两个元素是否表示"同一个"元素，用于跨重建（导航/重新渲染）的身份保持。
+    /// 以标签名为身份依据：
+    /// - 切换页面时结构位置相同但标签不同的元素（如 button.btn ↔ input.form-control）不会被误配，
+    ///   避免旧页面的 transition 状态被错误迁移（见 ISSUE-043）。
+    /// - 同一元素仅 class 变化（如 div "panel" ↔ "panel open"）仍视为同一元素，
+    ///   从而保留 Razor 重新渲染时基于状态变化触发 transition 的能力。
+    /// </summary>
+    private static bool IsSameElementIdentity(Element a, Element b)
+    {
+        return a.TagName == b.TagName;
     }
 
     public void Update(SKCanvas canvas)

--- a/tests/Miko.Tests/Core/NavigationTransitionTests.cs
+++ b/tests/Miko.Tests/Core/NavigationTransitionTests.cs
@@ -1,0 +1,112 @@
+using Miko.Animation;
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Styling;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Core;
+
+/// <summary>
+/// 回归测试：切换页面（重新 Initialize）时，旧页面元素的 transition 不应在新页面元素上触发。
+/// 见 ISSUE-043。
+/// </summary>
+public class NavigationTransitionTests : IDisposable
+{
+    private readonly SKBitmap _bitmap;
+    private readonly SKCanvas _canvas;
+
+    public NavigationTransitionTests()
+    {
+        _bitmap = new SKBitmap(600, 600);
+        _canvas = new SKCanvas(_bitmap);
+        _canvas.Clear(SKColors.White);
+    }
+
+    public void Dispose()
+    {
+        _canvas.Dispose();
+        _bitmap.Dispose();
+    }
+
+    private static StyleSheet BuildStyleSheet()
+    {
+        var styleSheet = new StyleSheet();
+        styleSheet.Add(new CssObject
+        {
+            // 模拟 .btn：带 background-color transition 和实色背景
+            [".btn"] = new CssObject
+            {
+                Width = Length.Px(120),
+                Height = Length.Px(40),
+                BackgroundColor = Color.FromRgb(13, 110, 253),
+                Color = Color.White,
+                Transitions = [Transition.For(x => x.BackgroundColor).Duration(0.15f).Linear()]
+            },
+            // 模拟 .form-control：无 transition、无实色背景
+            [".form-control"] = new CssObject
+            {
+                Width = Length.Px(200),
+                Height = Length.Px(30),
+                BackgroundColor = Color.Transparent
+            }
+        });
+        return styleSheet;
+    }
+
+    private static Element BuildButtonPage()
+    {
+        var root = new DivElement { Class = "container" };
+        root.Style = new Style { Width = Length.Px(500), Height = Length.Px(500) };
+        root.AddChild(new ButtonElement { Class = "btn", TextContent = "Primary" });
+        return root;
+    }
+
+    private static Element BuildFormPage()
+    {
+        var root = new DivElement { Class = "container" };
+        root.Style = new Style { Width = Length.Px(500), Height = Length.Px(500) };
+        root.AddChild(new InputElement { Class = "form-control" });
+        return root;
+    }
+
+    [Fact]
+    public void PageSwitch_ShouldNotTriggerOldPageTransition_OnNewPageElement()
+    {
+        var styleSheet = BuildStyleSheet();
+        var engine = new MikoEngine();
+
+        // 渲染 /button 页面
+        engine.Initialize(BuildButtonPage(), [styleSheet], _canvas, 600, 600);
+        engine.AnimationManager.HasActiveAnimations.ShouldBeFalse();
+
+        // 切换到 /form 页面（结构位置相同：container > 单个子元素，但子元素类型/class 不同）
+        var formPage = BuildFormPage();
+        engine.Initialize(formPage, [styleSheet], _canvas, 600, 600);
+
+        // 旧页面 .btn 的 background-color transition 不应在 .form-control 上被触发
+        engine.AnimationManager.HasActiveAnimations.ShouldBeFalse();
+
+        // 新页面 input 的内联样式不应被写入 .btn 的起始背景色
+        var input = formPage.Children[0];
+        if (input.Style?.BackgroundColor is { } bg)
+        {
+            bg.ShouldBe(Color.Transparent);
+        }
+    }
+
+    [Fact]
+    public void PageSwitch_ToSameStructure_ShouldStillPreserveIdentity_ForMatchingElements()
+    {
+        var styleSheet = BuildStyleSheet();
+        var engine = new MikoEngine();
+
+        // 两次渲染相同结构的 /button 页面：LayoutBox 身份应保持，元素无 transition 被错误触发
+        engine.Initialize(BuildButtonPage(), [styleSheet], _canvas, 600, 600);
+        engine.Initialize(BuildButtonPage(), [styleSheet], _canvas, 600, 600);
+
+        // 背景色未变化，不应有 transition
+        engine.AnimationManager.HasActiveAnimations.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Issue

切换页面时存在 2 帧渲染异常：从 `/button` 切到 `/form` 时，新页面元素出现本不该有的背景色，随后淡出。详见 [issues/ISSUE-043.md](issues/ISSUE-043.md)。

## Root cause

`MikoEngine.MapElementIdentityRecursive` 在导航重建时把旧元素树的 `LayoutBox` **按子节点位置**搬到新元素树，但没有校验两侧元素是否真的是同一类元素。

切换 `/button` → `/form` 时，旧 `.btn` 元素的 `LayoutBox`（其上挂着 `background-color` transition 定义和已计算的实色背景）被错误地搬到新页面相同索引位置的元素上。随后 `CaptureTransitionableStyles` 以 button 的旧背景作为快照、布局后 `DetectAndTriggerTransitions` 检测到背景色差异，于是在 form 页面元素上触发了 button 的过渡动画——这正是 issue 中描述的 2 帧背景异常。

## Fix

为 `LayoutBox` 迁移加 `IsSameElementIdentity` 守卫，依据 `TagName` 判断身份：

- 跨页面 `button.btn` ↔ `input`/`label`（标签不同）不会被误配，旧页面的 transition 状态不会带过来。
- 同一元素仅 class 变化（如 `div "panel"` ↔ `"panel open"`）仍视为同一元素，Razor 状态变化触发的 transition 继续可用。

之所以选 `TagName` 而不是同时校验 `Class`，是因为现有测试 `PseudoElement_Transition_ShouldTriggerOnReinitialize` 显示 class 变化恰恰是 Razor 触发状态过渡的方式——把 class 纳入身份键会破坏这条链路。

## Tests

- 新增 [tests/Miko.Tests/Core/NavigationTransitionTests.cs](tests/Miko.Tests/Core/NavigationTransitionTests.cs)
  - `PageSwitch_ShouldNotTriggerOldPageTransition_OnNewPageElement` — 复现 ISSUE-043，断言切页后无动画启动、新元素 inline style 上不会被写入 button 的起始背景色
  - `PageSwitch_ToSameStructure_ShouldStillPreserveIdentity_ForMatchingElements` — 同结构重渲染不应触发伪过渡
- 全量测试通过：`Failed: 0, Passed: 817`