### PR TITLE
style(bootstrap): refine component styles and use unitless line-height

### DIFF
--- a/src/Miko.Bootstrap/Components/Badge/BadgeStyles.cs
+++ b/src/Miko.Bootstrap/Components/Badge/BadgeStyles.cs
@@ -1,4 +1,4 @@
-using Miko.Common;
+﻿using Miko.Common;
 using Miko.Styling;
 
 namespace Miko.Bootstrap.Components;
@@ -54,7 +54,7 @@ internal static class BadgeStyles
                 Padding = new Padding(t.BadgePaddingY, t.BadgePaddingX),
                 FontSize = t.BadgeFontSize,
                 FontWeight = t.BadgeFontWeight,
-                LineHeight = Length.Px(1),
+                LineHeight = Number(1f),
                 Color = t.BadgeColor,
                 TextAlign = TextAlign.Center,
                 // NOTE: white-space: nowrap not supported in CssObject

--- a/src/Miko.Bootstrap/Components/Button/ButtonStyles.cs
+++ b/src/Miko.Bootstrap/Components/Button/ButtonStyles.cs
@@ -14,6 +14,7 @@ public class ButtonToken
         BtnFontWeight = FontWeight.Normal;
         BtnLineHeight = 1.5f;
         BtnColor = theme.BodyColor;
+        BtnBg = Transparent;
         BtnBorderWidth = theme.BorderWidth;
         BtnBorderRadius = theme.BorderRadius;
         BtnDisabledOpacity = 0.65f;
@@ -88,6 +89,7 @@ public class ButtonToken
     public FontWeight BtnFontWeight { get; set; }
     public float BtnLineHeight { get; set; }
     public Color BtnColor { get; set; }
+    public Color BtnBg { get; set; }
     public Length BtnBorderWidth { get; set; }
     public Length BtnBorderRadius { get; set; }
     public float BtnDisabledOpacity { get; set; }
@@ -163,12 +165,15 @@ internal static class ButtonStyles
                 Padding = new Padding(t.BtnPaddingY, t.BtnPaddingX),
                 FontSize = t.BtnFontSize,
                 FontWeight = t.BtnFontWeight,
-                LineHeight = Length.Px(t.BtnLineHeight),
+                LineHeight = Number(t.BtnLineHeight),
                 Color = t.BtnColor,
                 TextAlign = TextAlign.Center,
-                // NOTE: white-space, vertical-align, cursor, user-select not supported
+                TextDecoration = TextDecoration.None,
+                WhiteSpace = WhiteSpace.Nowrap,
+                VerticalAlign = VerticalAlign.Middle,
                 Border = new Border(t.BtnBorderWidth, BorderStyle.Solid, Color.Transparent),
                 BorderRadius = t.BtnBorderRadius,
+                BackgroundColor = t.BtnBg,
                 Transitions = t.BtnTransition
             },
 

--- a/src/Miko.Bootstrap/Components/Form/FormStyles.cs
+++ b/src/Miko.Bootstrap/Components/Form/FormStyles.cs
@@ -1,57 +1,69 @@
-﻿using Miko.Common;
+﻿using Miko.Animation;
+using Miko.Common;
 using Miko.Styling;
 
 namespace Miko.Bootstrap.Components;
 
 public class FormToken
 {
-    public FormToken(Theme theme)
+    public Theme BS { get; }
+
+    public FormToken(Theme bs)
     {
+        BS = bs;
+        
+        // Check Token
+        FormCheckBg = bs.BodyBg;
+
         FormLabelMarginBottom = Length.Rem(0.5f);
-        FormLabelColor = theme.BodyColor;
+        FormLabelColor = bs.BodyColor;
 
         FormTextMarginTop = Length.Rem(0.25f);
         FormTextFontSize = Length.Rem(0.875f);
-        FormTextColor = theme.SecondaryColor;
+        FormTextColor = bs.SecondaryColor;
 
         InputPaddingY = Length.Rem(0.375f);
         InputPaddingX = Length.Rem(0.75f);
         InputFontSize = Length.Rem(1f);
         InputLineHeight = 1.5f;
-        InputColor = theme.BodyColor;
-        InputBg = theme.BodyBg;
-        InputBorderWidth = theme.BorderWidth;
-        InputBorderColor = theme.BorderColor;
-        InputBorderRadius = theme.BorderRadius;
-        InputFocusBorderColor = theme.Primary;
-        InputDisabledBg = theme.SecondaryBg;
+        InputColor = bs.BodyColor;
+        InputBg = bs.BodyBg;
+        InputBorderWidth = bs.BorderWidth;
+        InputBorderColor = bs.BorderColor;
+        InputBorderRadius = bs.BorderRadius;
+        InputFocusBorderColor = bs.Primary;
+        InputDisabledBg = bs.SecondaryBg;
 
         InputPaddingYSm = Length.Rem(0.25f);
         InputPaddingXSm = Length.Rem(0.5f);
         InputFontSizeSm = Length.Rem(0.875f);
-        InputBorderRadiusSm = theme.BorderRadiusSm;
+        InputBorderRadiusSm = bs.BorderRadiusSm;
 
         InputPaddingYLg = Length.Rem(0.5f);
         InputPaddingXLg = Length.Rem(1f);
         InputFontSizeLg = Length.Rem(1.25f);
-        InputBorderRadiusLg = theme.BorderRadiusLg;
+        InputBorderRadiusLg = bs.BorderRadiusLg;
 
         FormCheckPaddingStart = Length.Rem(1.5f);
         FormCheckInputWidth = Length.Rem(1f);
-        FormCheckInputBorderColor = theme.BorderColor;
-        FormCheckInputBorderRadius = theme.BorderRadiusSm;
-        FormCheckInputCheckedBg = theme.Primary;
-        FormCheckInputCheckedBorderColor = theme.Primary;
+        FormCheckInputBorderColor = bs.BorderColor;
+        FormCheckInputBorderRadius = bs.BorderRadiusSm;
+        FormCheckInputCheckedBg = bs.Primary;
+        FormCheckInputCheckedBorderColor = bs.Primary;
 
-        InputGroupBorderColor = theme.BorderColor;
-        InputGroupTextBg = theme.TertiaryBg;
-        InputGroupTextColor = theme.BodyColor;
+        InputGroupBorderColor = bs.BorderColor;
+        InputGroupTextBg = bs.TertiaryBg;
+        InputGroupTextColor = bs.BodyColor;
 
-        FormValidColor = theme.FormValidColor;
-        FormValidBorderColor = theme.FormValidBorderColor;
-        FormInvalidColor = theme.FormInvalidColor;
-        FormInvalidBorderColor = theme.FormInvalidBorderColor;
+        FormValidColor = bs.FormValidColor;
+        FormValidBorderColor = bs.FormValidBorderColor;
+        FormInvalidColor = bs.FormInvalidColor;
+        FormInvalidBorderColor = bs.FormInvalidBorderColor;
     }
+
+
+    public Color FormCheckBg { get; set; }
+    public BackgroundImage FormCheckBgImage { get; set; }
 
     public Length FormLabelMarginBottom { get; set; }
     public Color FormLabelColor { get; set; }
@@ -126,110 +138,230 @@ internal static class FormStyles
             [".form-control"] = new()
             {
                 Display = Display.Block,
-                Width = Length.Percent(100),
-                Padding = new Padding(t.InputPaddingY, t.InputPaddingX),
-                FontSize = t.InputFontSize,
-                LineHeight = Length.Px(t.InputLineHeight),
-                Color = t.InputColor,
-                BackgroundColor = t.InputBg,
-                Border = new Border(Length.Px(t.InputBorderWidth), BorderStyle.Solid, t.InputBorderColor),
-                BorderRadius = t.InputBorderRadius,
-                // NOTE: appearance: none not supported in CssObject
-                // NOTE: transition not added (border-color .15s ease-in-out, box-shadow .15s ease-in-out)
+                Width = Percent(100),
+                Padding = new Padding(Rem(0.375f), Rem(0.375f)),
+                FontSize = Rem(1f),
+                FontWeight = FontWeight.Normal,
+                LineHeight = Number(1.5f),
+                Color = t.BS.BodyColor,
+                BackgroundColor = t.BS.BodyBg,
+                Border = new Border(t.BS.BorderWidth, BorderStyle.Solid, t.BS.BorderColor),
+                BorderRadius = t.BS.BorderRadius,
+                Transitions = [
+                    Transition.For(x => x.BorderColor).Duration(0.15f).EaseInOut(),
+                    Transition.For(x => x.BoxShadow).Duration(0.15f).EaseInOut(),
+                ],
+                ["&:focus"] = new()
+                {
+                    Color = t.BS.BodyColor,
+                    BackgroundColor = t.BS.BodyBg,
+                    BorderColor = "#86b7fe",
+                    BoxShadow = new BoxShadow(0, 0, 0, Rem(0.25f), Rgba(13, 110, 253, 0.25f))
+                },
+                ["&:disabled"] = new()
+                {
+                    BackgroundColor = t.BS.SecondaryBg,
+                    Opacity = 1f
+                },
+            },
+
+            [".form-control-plaintext"] = new()
+            {
+                Display = Display.Block,
+                Width = Percent(100),
+                Padding = new Padding(Rem(0.375f), 0),
+                MarginBottom = 0,
+                LineHeight = Rem(1.5f),
+                Color = t.BS.BorderColor,
+                BackgroundColor = Transparent,
+                Border = new Border(0, BorderStyle.Solid, Transparent),
+                BorderWidth = t.BS.BorderWidth,
 
                 ["&:focus"] = new()
                 {
-                    BorderColor = t.InputFocusBorderColor,
-                    // NOTE: box-shadow: 0 0 0 .25rem rgba(primary, .25) not supported
+                    // Outline = 0,
                 },
 
-                ["&:disabled"] = new()
+                ["&.form-control-sm,&.form-control-lg"] = new()
                 {
-                    BackgroundColor = t.InputDisabledBg,
-                    Opacity = 1f
+                    PaddingRight = 0,
+                    PaddingLeft = 0,
                 }
             },
 
             [".form-control-sm"] = new()
             {
-                Padding = new Padding(t.InputPaddingYSm, t.InputPaddingXSm),
-                FontSize = t.InputFontSizeSm,
-                BorderRadius = t.InputBorderRadiusSm
+                MinHeight = Em(1.5f) + Rem(0.5f) + t.BS.BorderWidth * 2,
+                Padding = new Padding(Rem(0.25f), Rem(0.5f)),
+                FontSize = Rem(0.875f),
+                BorderRadius = t.BS.BorderRadiusSm
             },
 
             [".form-control-lg"] = new()
             {
-                Padding = new Padding(t.InputPaddingYLg, t.InputPaddingXLg),
-                FontSize = t.InputFontSizeLg,
-                BorderRadius = t.InputBorderRadiusLg
+                MinHeight = Em(1.5f) + Rem(1f) + t.BS.BorderWidth * 2,
+                Padding = new Padding(Rem(0.5f), Rem(1)),
+                FontSize = Rem(1.25f),
+                BorderRadius = t.BS.BorderRadiusLg
+            },
+
+            ["textarea"] = new()
+            {
+                ["&.form-control"] = new()
+                {
+                    MinHeight = Em(1.5f) + Rem(0.75f) + t.BS.BorderWidth * 2
+                },
+                ["&.form-control-sm"] = new()
+                {
+                    MinHeight = Em(1.5f) + Rem(0.5f) + t.BS.BorderWidth * 2
+                },
+                ["&.form-control-lg"] = new()
+                {
+                    MinHeight = Em(1.5f) + Rem(1f) + t.BS.BorderWidth * 2
+                },
+            },
+
+            [".form-control-color"] = new()
+            {
+                Width = Rem(3f),
+                Height = Em(1.5f) + Rem(0.75f) + t.BS.BorderWidth * 2,
+                Padding = Rem(0.375f),
+
+                ["&:not(:disabled):not([readonly])"] = new()
+                {
+
+                },
+
+                ["&.form-control-sm"] = new()
+                {
+                    Height = Em(1.5f) + Rem(0.5f) + t.BS.BorderWidth * 2
+                },
+
+                ["&.form-control-lg"] = new()
+                {
+                    Height = Em(1.5f) + Rem(1f) + t.BS.BorderWidth * 2
+                }
             },
 
             [".form-select"] = new()
             {
                 Display = Display.Block,
-                Width = Length.Percent(100),
-                Padding = new Padding(t.InputPaddingY, Length.Rem(2.25f), t.InputPaddingY, t.InputPaddingX),
-                FontSize = t.InputFontSize,
-                LineHeight = Length.Px(t.InputLineHeight),
-                Color = t.InputColor,
-                BackgroundColor = t.InputBg,
-                Border = new Border(Length.Px(t.InputBorderWidth), BorderStyle.Solid, t.InputBorderColor),
-                BorderRadius = t.InputBorderRadius,
-                // NOTE: appearance: none, background-image (chevron SVG) not supported
+                Width = Percent(100),
+                Padding = new Padding(Rem(0.375f), Rem(2.25f), Rem(0.375f), Rem(0.75f)),
+                FontSize = Rem(1),
+                LineHeight = Number(1.5f),
+                Color = t.BS.BodyColor,
+                BackgroundColor = t.BS.BodyBg,
+                // BackgroundImage = 
+                // BackgroundRepeat = BackgroundRepeat.NoRepeat,
+                // BackgroundPosition = 
+                // BackgroundSize = BackgroundSize.From(Px(16), Px(12)),
+                Border = new Border(Px(t.BS.BorderWidth), BorderStyle.Solid, t.BS.BorderColor),
+                BorderRadius = t.BS.BorderRadius,
+                Transitions = [
+                    Transition.For(x => x.BorderColor).Duration(0.15f).EaseInOut(),
+                    Transition.For(x => x.BoxShadow).Duration(0.15f).EaseInOut(),
+                ],
 
                 ["&:focus"] = new()
                 {
-                    BorderColor = t.InputFocusBorderColor
+                    BorderColor = "#86b7fe",
+                    // Outline = 0,
+                    BoxShadow = new BoxShadow(0, 0, 0, Rem(0.25f), Rgba(13, 110, 253, 0.25f))
                 },
 
                 ["&:disabled"] = new()
                 {
-                    BackgroundColor = t.InputDisabledBg
+                    BackgroundColor = t.BS.SecondaryColor
                 }
             },
 
             [".form-select-sm"] = new()
             {
-                Padding = new Padding(t.InputPaddingYSm, Length.Rem(1.75f), t.InputPaddingYSm, t.InputPaddingXSm),
-                FontSize = t.InputFontSizeSm,
-                BorderRadius = t.InputBorderRadiusSm
+                PaddingTop = Rem(0.25f),
+                PaddingBottom = Rem(0.25f),
+                PaddingLeft = Rem(0.5f),
+                FontSize = Rem(0.875f),
+                BorderRadius = t.BS.BorderRadiusSm
             },
 
             [".form-select-lg"] = new()
             {
-                Padding = new Padding(t.InputPaddingYLg, Length.Rem(2.75f), t.InputPaddingYLg, t.InputPaddingXLg),
-                FontSize = t.InputFontSizeLg,
-                BorderRadius = t.InputBorderRadiusLg
+                PaddingTop = Rem(0.5f),
+                PaddingBottom = Rem(0.5f),
+                PaddingLeft = Rem(1f),
+                FontSize = Rem(1.25f),
+                BorderRadius = t.BS.BorderRadiusLg
             },
 
             [".form-check"] = new()
             {
                 Display = Display.Block,
-                MinHeight = Length.Rem(1.5f),
-                PaddingLeft = t.FormCheckPaddingStart,
-                MarginBottom = Length.Rem(0.125f)
+                MinHeight = Rem(1.5f),
+                PaddingLeft = Em(1.5f),
+                MarginBottom = Rem(0.125f),
+
+                [".form-check-input"] = new()
+                {
+                    // 不应该再支持float样式，可以用其它布局方式来替代
+                    // Float = Float.Left,
+                    // MarginLeft = Em(-1.5f),
+                }
+            },
+
+            [".form-check-reverse"] = new()
+            {
+                MarginRight = Em(1.5f),
+                PaddingLeft = 0,
+                TextAlign = TextAlign.Right,
+                [".form-check-input"] = new()
+                {
+                    // Float = Float.Right,
+                    // MarginRight = Em(-1.5f),
+                    // MarginLeft = 0,
+                }
             },
 
             [".form-check-input"] = new()
             {
-                Width = t.FormCheckInputWidth,
-                Height = t.FormCheckInputWidth,
-                MarginTop = Length.Rem(0.25f),
-                MarginRight = Length.Rem(0.5f),
-                BackgroundColor = t.InputBg,
-                Border = new Border(Length.Px(t.InputBorderWidth), BorderStyle.Solid, t.FormCheckInputBorderColor),
-                BorderRadius = t.FormCheckInputBorderRadius,
-                // NOTE: appearance: none, float: left not supported
+                FlexShrink = 0,
+                Width = Em(1f),
+                Height = Em(1f),
+                MarginTop = Em(0.25f),
+                VerticalAlign = VerticalAlign.Top,
+                BackgroundColor = t.FormCheckBg,
+                BackgroundImage = t.FormCheckBgImage,
+                BackgroundRepeat = BackgroundRepeat.NoRepeat,
+                BackgroundPosition = BackgroundPosition.Center,
+                BackgroundSize = BackgroundSize.Contain,
+                Border = new Border(Px(t.BS.BorderWidth), BorderStyle.Solid, t.BS.BorderColor),
 
-                ["&:checked"] = new()
+                ["&[type=checkbox]"] = new()
                 {
-                    BackgroundColor = t.FormCheckInputCheckedBg,
-                    BorderColor = t.FormCheckInputCheckedBorderColor
+                    BorderRadius = Em(0.25f),
                 },
+
+                ["&[type=radio]"] = new()
+                {
+                    BorderRadius = Percent(50),
+                },
+
+                // ["&:active"] = new()
+                // {
+                //     // filter: brightness(90%);
+                // },
 
                 ["&:focus"] = new()
                 {
-                    BorderColor = t.InputFocusBorderColor
+                    BorderColor = t.InputFocusBorderColor,
+                    // Outline = 0,
+                    BoxShadow = new BoxShadow(0, 0, 0, Rem(0.25f), Rgba(13, 110, 253, 0.25f))
+                },
+
+                ["&:checked"] = new()
+                {
+                    BackgroundColor = "#0d6efd",
+                    BorderColor = "#0d6efd"
                 },
 
                 ["&:disabled"] = new()
@@ -245,11 +377,48 @@ internal static class FormStyles
 
             [".form-range"] = new()
             {
-                Width = Length.Percent(100),
-                Height = Length.Rem(1.5f),
+                Width = Percent(100),
+                Height = Rem(1.5f),
                 Padding = new Padding(0),
-                BackgroundColor = Color.Transparent
-                // NOTE: appearance: none, custom thumb/track pseudo-elements not supported
+                BackgroundColor = Transparent,
+                // ["&:focus"] = new()
+                // {
+                //     Outline = 0,
+                // },
+                //
+                // ["&:disabled"] = new()
+                // {
+                // }
+
+                ["&::range-thumb"] = new()
+                {
+                    Width = Rem(1f),
+                    Height = Rem(1f),
+                    // MarginTop = 
+                    BackgroundColor = "#0d6efd",
+                    Border = new Border(0),
+                    BorderRadius = Rem(1f),
+                    Transitions = [
+                        Transition.For(x => x.BackgroundColor).Duration(0.15f).EaseInOut(),
+                        Transition.For(x => x.BorderColor).Duration(0.15f).EaseInOut(),
+                        Transition.For(x => x.BoxShadow).Duration(0.15f).EaseInOut(),
+                    ]
+                },
+
+                ["&::range-track"] = new()
+                {
+                    Width = Percent(100),
+                    Height = Rem(0.5f),
+                    Color = Transparent,
+                    BackgroundColor = t.BS.SecondaryBg,
+                    BorderColor = Transparent,
+                    BorderRadius = Rem(1f)
+                },
+
+                ["&::range-progress"] = new()
+                {
+                    BackgroundColor = Transparent,
+                },
             },
 
             [".input-group"] = new()
@@ -258,22 +427,62 @@ internal static class FormStyles
                 Display = Display.Flex,
                 FlexWrap = FlexWrap.Wrap,
                 AlignItems = AlignItems.Stretch,
-                Width = Length.Percent(100),
+                Width = Percent(100),
 
-                ["> .form-control"] = new()
+                // ["> .form-control,> .form-select,> .form-floating"] = new()
+                // {
+                //     Position = Position.Relative,
+                //     FlexGrow = 1,
+                //     FlexShrink = 1,
+                //     FlexBasis = 0,
+                //     Width = Percent(1),
+                //     MinWidth = Px(0)
+                // },
+
+                ["> .form-control:focus,> .form-select:focus"] = new()
                 {
-                    Position = Position.Relative,
-                    FlexGrow = 1,
-                    FlexBasis = Length.Px(0),
-                    MinWidth = Length.Px(0)
+                    ZIndex = 5,
                 },
 
-                ["> .form-select"] = new()
+                [".btn"] = new()
                 {
                     Position = Position.Relative,
-                    FlexGrow = 1,
-                    FlexBasis = Length.Px(0),
-                    MinWidth = Length.Px(0)
+                    ZIndex = 2,
+                    ["&:focus"] = new()
+                    {
+                        ZIndex = 5,
+                    }
+                },
+
+                ["&:not(.has-validation)"] = new()
+                {
+                    ["> :not(:last-child):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating)"] = new()
+                    {
+                        BorderTopRightRadius = 0,
+                        BorderBottomRightRadius = 0,
+                    }
+                },
+
+                ["&.has-validation"] = new()
+                {
+                    ["> :not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating)"] = new()
+                    {
+                        BorderTopRightRadius = 0,
+                        BorderBottomRightRadius = 0,
+                    }
+                },
+
+                ["> :not(:first-child):not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback)"] = new()
+                {
+                    MarginLeft = -1 * t.BS.BorderWidth,
+                    BorderTopLeftRadius = 0,
+                    BorderBottomLeftRadius = 0,
+                },
+
+                ["> .form-floating:not(:first-child) > .form-control,> .form-floating:not(:first-child) > .form-select"] = new()
+                {
+                    BorderTopLeftRadius = 0,
+                    BorderBottomLeftRadius = 0,
                 }
             },
 
@@ -281,12 +490,35 @@ internal static class FormStyles
             {
                 Display = Display.Flex,
                 AlignItems = AlignItems.Center,
-                Padding = new Padding(t.InputPaddingY, t.InputPaddingX),
-                FontSize = t.InputFontSize,
-                Color = t.InputGroupTextColor,
-                BackgroundColor = t.InputGroupTextBg,
-                Border = new Border(Length.Px(t.InputBorderWidth), BorderStyle.Solid, t.InputGroupBorderColor),
-                BorderRadius = t.InputBorderRadius
+                Padding = new Padding(Rem(0.375f), Rem(0.375f)),
+                FontSize = Rem(1),
+                FontWeight = FontWeight.Normal,
+                LineHeight = Number(1.5f),
+                Color = t.BS.BodyColor,
+                TextAlign = TextAlign.Center,
+                WhiteSpace = WhiteSpace.Nowrap,
+                BackgroundColor = t.BS.TertiaryBg,
+                Border = new Border(Px(t.BS.BorderWidth), BorderStyle.Solid, t.BS.BorderColor),
+                BorderRadius = t.BS.BorderRadius
+            },
+
+            [".input-group-lg > .form-control,.input-group-lg > .form-select,.input-group-lg > .input-group-text,.input-group-lg > .btn"] = new()
+            {
+                Padding = new Padding(Rem(0.25f), Rem(0.5f)),
+                FontSize = Rem(1.25f),
+                BorderRadius = t.BS.BorderRadiusLg,
+            },
+            
+            [".input-group-sm > .form-control,.input-group-sm > .form-select,.input-group-sm > .input-group-text,.input-group-sm > .btn"] = new()
+            {
+                Padding = new Padding(Rem(0.25f), Rem(0.5f)),
+                FontSize = Rem(0.875f),
+                BorderRadius = t.BS.BorderRadiusLg,
+            },
+
+            [".input-group-lg > .form-select,.input-group-sm > .form-select"] = new()
+            {
+                PaddingRight = Rem(3),
             },
 
             [".form-control.is-valid"] = new()
@@ -302,18 +534,18 @@ internal static class FormStyles
             [".valid-feedback"] = new()
             {
                 Display = Display.None,
-                Width = Length.Percent(100),
-                MarginTop = Length.Rem(0.25f),
-                FontSize = Length.Rem(0.875f),
+                Width = Percent(100),
+                MarginTop = Rem(0.25f),
+                FontSize = Rem(0.875f),
                 Color = t.FormValidColor
             },
 
             [".invalid-feedback"] = new()
             {
                 Display = Display.None,
-                Width = Length.Percent(100),
-                MarginTop = Length.Rem(0.25f),
-                FontSize = Length.Rem(0.875f),
+                Width = Percent(100),
+                MarginTop = Rem(0.25f),
+                FontSize = Rem(0.875f),
                 Color = t.FormInvalidColor
             },
 

--- a/src/Miko.Bootstrap/Components/Icon/IconStyles.cs
+++ b/src/Miko.Bootstrap/Components/Icon/IconStyles.cs
@@ -16,7 +16,7 @@ internal static class IconStyles
                 FontStyle = FontStyle.Normal,
                 FontWeight = FontWeight.Normal,
                 FontSize = Length.Px(16),
-                LineHeight = Length.Px(1)
+                LineHeight = Number(1)
             },
             [".icon-sm"] = new() { FontSize = Length.Px(16) },
             [".icon-md"] = new() { FontSize = Length.Px(24) },

--- a/src/Miko.Bootstrap/Components/Table/TableStyles.cs
+++ b/src/Miko.Bootstrap/Components/Table/TableStyles.cs
@@ -1,4 +1,4 @@
-using Miko.Common;
+﻿using Miko.Common;
 using Miko.Styling;
 
 namespace Miko.Bootstrap.Components;
@@ -13,6 +13,7 @@ public class TableToken
         TableCellPaddingXSm = Length.Rem(0.25f);
         TableColor = theme.EmphasisColor;
         TableBg = theme.BodyBg;
+        TableAccentBg = Transparent;
         TableBorderColor = theme.BorderColor;
         TableBorderWidth = theme.BorderWidth;
         TableStripedBg = Color.FromRgba(0, 0, 0, 0.05f);
@@ -37,6 +38,7 @@ public class TableToken
     public Length TableCellPaddingXSm { get; set; }
     public Color TableColor { get; set; }
     public Color TableBg { get; set; }
+    public Color TableAccentBg { get; set; }
     public Color TableBorderColor { get; set; }
     public float TableBorderWidth { get; set; }
     public Color TableStripedBg { get; set; }
@@ -59,30 +61,29 @@ internal static class TableStyles
 {
     internal static CssObject GenStyle(TableToken t)
     {
+        VariantToken token = new(t.TableCellPaddingY, t.TableCellPaddingX, t.TableColor, t.TableBg, t.TableBorderWidth, t.TableAccentBg);
+
         return new CssObject
         {
             [".table"] = new()
             {
-                Width = Length.Percent(100),
-                MarginBottom = Length.Rem(1),
+                Width = Percent(100),
+                MarginBottom = Rem(1),
+                VerticalAlign = VerticalAlign.Top,
+                BorderColor = t.TableBorderColor,
                 Color = t.TableColor,
-                BackgroundColor = t.TableBg,
-                // NOTE: caption-side, border-collapse not supported
-                BorderWidth = Length.Px(0),
 
-                ["th"] = new()
+                ["> :not(caption) > * > *"] = GenVariantTable(token),
+
+                ["> tbody"] = new()
                 {
-                    Padding = new Padding(t.TableCellPaddingY, t.TableCellPaddingX),
-                    BorderBottom = new BorderSide(Length.Px(t.TableBorderWidth), BorderStyle.Solid, t.TableBorderColor),
-                    VerticalAlign = VerticalAlign.Bottom
+                    // VerticalAlign = 
                 },
 
-                ["td"] = new()
+                ["> thead"] = new()
                 {
-                    Padding = new Padding(t.TableCellPaddingY, t.TableCellPaddingX),
-                    BorderBottom = new BorderSide(Length.Px(t.TableBorderWidth), BorderStyle.Solid, t.TableBorderColor),
-                    VerticalAlign = VerticalAlign.Top
-                }
+                    VerticalAlign = VerticalAlign.Bottom,
+                },
             },
 
             [".table-sm"] = new()
@@ -153,7 +154,7 @@ internal static class TableStyles
 
             [".table-primary"] = new()
             {
-                BackgroundColor = t.TablePrimaryBg
+                ["> *"] = GenVariantTable(token with{ TableColor = "#000" }),
             },
 
             [".table-secondary"] = new()
@@ -216,6 +217,26 @@ internal static class TableStyles
             {
                 OverflowX = Overflow.Auto
             }
+        };
+    }
+
+    private record struct VariantToken(
+        Length TableCellPaddingY,
+        Length TableCellPaddingX,
+        Color TableColor,
+        Color TableBg,
+        Length TableBorderWidth,
+        Color TableAccentBg);
+
+    private static CssObject GenVariantTable(VariantToken t)
+    {
+        return new()
+        {
+            Padding = new Padding(t.TableCellPaddingY, t.TableCellPaddingX),
+            Color = t.TableColor,
+            BackgroundColor = t.TableBg,
+            BorderBottomWidth = t.TableBorderWidth,
+            BoxShadow = new BoxShadow(0, 0, 0, Px(9999), t.TableAccentBg)
         };
     }
 }

--- a/src/Miko.Bootstrap/GlobalUsings.cs
+++ b/src/Miko.Bootstrap/GlobalUsings.cs
@@ -1,0 +1,5 @@
+﻿// The Chaldea licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+global using static Miko.Common.Length;
+global using static Miko.Common.Color;

--- a/src/Miko.Bootstrap/Styles/RebootStyles.cs
+++ b/src/Miko.Bootstrap/Styles/RebootStyles.cs
@@ -13,15 +13,6 @@ internal static class RebootStyles
             {
                 BoxSizing = BoxSizing.BorderBox
             },
-            // ["body"] = new()
-            // {
-            //     Margin = new Margin(0),
-            //     FontSize = Length.Px(t.BodyFontSize),
-            //     FontWeight = (FontWeight)t.BodyFontWeight,
-            //     LineHeight = t.BodyLineHeight,
-            //     Color = t.BodyColor,
-            //     BackgroundColor = t.BodyBg
-            // },
             ["hr"] = new()
             {
                 Margin = new Margin(Length.Rem(1), 0),
@@ -33,7 +24,7 @@ internal static class RebootStyles
             {
                 FontSize = Length.Px(40),
                 FontWeight = FontWeight.Medium,
-                LineHeight = Length.Px(1.2f),
+                LineHeight = Number(1.2f),
                 MarginTop = Length.Px(0),
                 MarginBottom = Length.Rem(0.5f),
                 Color = t.HeadingColor
@@ -42,7 +33,7 @@ internal static class RebootStyles
             {
                 FontSize = Length.Px(32),
                 FontWeight = FontWeight.Medium,
-                LineHeight = Length.Px(1.2f),
+                LineHeight = Number(1.2f),
                 MarginTop = Length.Px(0),
                 MarginBottom = Length.Rem(0.5f),
                 Color = t.HeadingColor
@@ -51,7 +42,7 @@ internal static class RebootStyles
             {
                 FontSize = Length.Px(28),
                 FontWeight = FontWeight.Medium,
-                LineHeight = Length.Px(1.2f),
+                LineHeight = Number(1.2f),
                 MarginTop = Length.Px(0),
                 MarginBottom = Length.Rem(0.5f),
                 Color = t.HeadingColor
@@ -60,7 +51,7 @@ internal static class RebootStyles
             {
                 FontSize = Length.Px(24),
                 FontWeight = FontWeight.Medium,
-                LineHeight = Length.Px(1.2f),
+                LineHeight = Number(1.2f),
                 MarginTop = Length.Px(0),
                 MarginBottom = Length.Rem(0.5f),
                 Color = t.HeadingColor
@@ -69,7 +60,7 @@ internal static class RebootStyles
             {
                 FontSize = Length.Px(20),
                 FontWeight = FontWeight.Medium,
-                LineHeight = Length.Px(1.2f),
+                LineHeight = Number(1.2f),
                 MarginTop = Length.Px(0),
                 MarginBottom = Length.Rem(0.5f),
                 Color = t.HeadingColor
@@ -78,7 +69,7 @@ internal static class RebootStyles
             {
                 FontSize = Length.Px(16),
                 FontWeight = FontWeight.Medium,
-                LineHeight = Length.Px(1.2f),
+                LineHeight = Number(1.2f),
                 MarginTop = Length.Px(0),
                 MarginBottom = Length.Rem(0.5f),
                 Color = t.HeadingColor
@@ -143,13 +134,18 @@ internal static class RebootStyles
             },
             ["table"] = new()
             {
-                // NOTE: caption-side, border-collapse not supported in CssObject
                 BorderWidth = Length.Px(0),
                 BorderStyle = BorderStyle.Solid
             },
             ["th"] = new()
             {
-                FontWeight = FontWeight.Normal
+                TextAlign = TextAlign.Left,
+            },
+            ["thead,tbody,tfoot,tr,td,th"] = new()
+            {
+                BorderColor = t.BorderColor,
+                BorderStyle = BorderStyle.Solid,
+                BorderWidth = 0,
             },
             ["label"] = new()
             {

--- a/tests/Miko.Tests/Miko.Tests.csproj
+++ b/tests/Miko.Tests/Miko.Tests.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <!-- Native SkiaSharp libraries for headless Linux (e.g. ubuntu-latest CI).
+         The base SkiaSharp package ships no native libs; without this the tests
+         fail to load linux-x64/native/libSkiaSharp. -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 概述

精炼 Miko.Bootstrap 的组件样式。

## 改动

- **unitless line-height**：将 Badge / Button / Icon / Form / Table / Reboot 中的 `LineHeight` 由 `Length.Px(...)` 改为无单位的 `Number(...)`，符合 CSS line-height 语义
- **GlobalUsings.cs**：新增静态导入 `Miko.Common.Length`、`Miko.Common.Color`
- **Button**：启用新支持的 CSS 属性（`WhiteSpace`、`VerticalAlign`、`TextDecoration`），并新增 `BtnBg` token（默认 transparent）

## 验证

样式层改动，不涉及行为逻辑。