### PR TITLE
fix(platform): serialize input and render to stop concurrent DOM mutation crash

### DIFF
--- a/src/Miko.Android/MikoSurfaceView.cs
+++ b/src/Miko.Android/MikoSurfaceView.cs
@@ -50,21 +50,20 @@ public class MikoSurfaceView : SKGLSurfaceView
             _initialized = true;
         }
 
-        if (_controller.NeedsRebuild)
-        {
-            _controller.Rebuild(canvas, logicalWidth, logicalHeight);
-        }
-
         float currentTime = (float)_frameTimer.Elapsed.TotalSeconds;
         float deltaTime = currentTime - _lastFrameTime;
         _lastFrameTime = currentTime;
-        _controller.Update(deltaTime);
 
-        canvas.Clear(SKColors.White);
-        canvas.Save();
-        canvas.Scale(_density);
-        _controller.Engine.Render(canvas);
-        canvas.Restore();
+        // RenderFrame holds the input/render lock so touch-driven DOM mutations on the
+        // UI thread can't race the layout walk on this GL thread.
+        _controller.RenderFrame(canvas, logicalWidth, logicalHeight, deltaTime, c =>
+        {
+            c.Clear(SKColors.White);
+            c.Save();
+            c.Scale(_density);
+            _controller.Engine.Render(c);
+            c.Restore();
+        });
     }
 
     public override bool OnTouchEvent(MotionEvent? e)

--- a/src/Miko.Windowing/SilkDesktopHost.cs
+++ b/src/Miko.Windowing/SilkDesktopHost.cs
@@ -153,16 +153,14 @@ public sealed class SilkDesktopHost
         using var surface = SKSurface.Create(_grContext, target, GRSurfaceOrigin.BottomLeft, SKColorType.Rgba8888);
         var canvas = surface.Canvas;
 
-        if (_controller.NeedsRebuild)
+        // Goes through RenderFrame for parity with the mobile hosts. Desktop pumps input
+        // and render on one thread, so the lock is uncontended here.
+        _controller.RenderFrame(canvas, _width, _height, deltaTime, c =>
         {
-            _controller.Rebuild(canvas, _width, _height);
-        }
-
-        _controller.Update(deltaTime);
-
-        canvas.Clear(SKColors.White);
-        _controller.Engine.Render(canvas);
-        canvas.Flush();
+            c.Clear(SKColors.White);
+            _controller.Engine.Render(c);
+            c.Flush();
+        });
         _grContext.Flush();
     }
 

--- a/src/Miko.iOS/MikoGLView.cs
+++ b/src/Miko.iOS/MikoGLView.cs
@@ -53,21 +53,20 @@ public class MikoGLView : SKGLView
             _initialized = true;
         }
 
-        if (_controller.NeedsRebuild)
-        {
-            _controller.Rebuild(canvas, logicalWidth, logicalHeight);
-        }
-
         float currentTime = (float)_frameTimer.Elapsed.TotalSeconds;
         float deltaTime = currentTime - _lastFrameTime;
         _lastFrameTime = currentTime;
-        _controller.Update(deltaTime);
 
-        canvas.Clear(SKColors.White);
-        canvas.Save();
-        canvas.Scale((float)_scale);
-        _controller.Engine.Render(canvas);
-        canvas.Restore();
+        // RenderFrame holds the input/render lock so touch-driven DOM mutations on the
+        // UI thread can't race the layout walk on the render thread.
+        _controller.RenderFrame(canvas, logicalWidth, logicalHeight, deltaTime, c =>
+        {
+            c.Clear(SKColors.White);
+            c.Save();
+            c.Scale((float)_scale);
+            _controller.Engine.Render(c);
+            c.Restore();
+        });
     }
 
     // UITouch.LocationInView 返回的是逻辑点（point），与渲染所用的逻辑坐标一致，无需再除以缩放系数。

--- a/src/Miko/Platform/MikoInteractionController.cs
+++ b/src/Miko/Platform/MikoInteractionController.cs
@@ -47,6 +47,16 @@ public sealed class MikoInteractionController
     private bool _isDragging;
     private MikoEngine.ScrollbarHitResult? _draggingScrollbar;
 
+    // Serializes input handling against the render frame. On hosts that render on a
+    // dedicated thread (Android GLThread, iOS CADisplayLink) the render thread walks the
+    // DOM during layout (LayoutEngine.ComputeStyles enumerates Element.Children) while
+    // input events on the UI thread mutate the DOM synchronously (a click runs the
+    // component handler, which calls StateHasChanged and rewrites Children). Without this
+    // lock the two race and throw "Collection was modified; enumeration operation may not
+    // execute". The desktop (Silk) host pumps input and render on one thread, so it never
+    // hit this — but the lock is harmless there (uncontended, re-entrant).
+    private readonly object _sync = new();
+
     public MikoInteractionController(
         IOptions<MikoAppOptions> options,
         IServiceProvider serviceProvider,
@@ -138,10 +148,31 @@ public sealed class MikoInteractionController
         _engine.AnimationManager.Update(deltaTime);
     }
 
+    /// <summary>
+    /// 在输入/渲染锁的保护下执行一帧：先按需重建 DOM 树，再推进动画，最后调用
+    /// <paramref name="render"/> 绘制。平台宿主应通过本方法渲染，而非直接调用
+    /// <see cref="Rebuild"/>/<see cref="Update"/>/<c>Engine.Render</c>，以确保输入处理
+    /// 引发的 DOM 变更不会与布局/渲染对 DOM 的遍历并发执行。
+    /// </summary>
+    public void RenderFrame(SKCanvas canvas, float width, float height, float deltaTime, Action<SKCanvas> render)
+    {
+        lock (_sync)
+        {
+            if (_needsRebuild)
+                Rebuild(canvas, width, height);
+
+            Update(deltaTime);
+            render(canvas);
+        }
+    }
+
     /// <summary>视口尺寸变化。</summary>
     public void SetViewportSize(float width, float height)
     {
-        _engine.SetViewportSize(width, height);
+        lock (_sync)
+        {
+            _engine.SetViewportSize(width, height);
+        }
     }
 
     // ---------------------------------------------------------------------
@@ -151,103 +182,111 @@ public sealed class MikoInteractionController
     public void OnPointerDown(float x, float y, MouseButton button)
     {
         if (button != MouseButton.Left) return;
-        _mouseDownPosition = new System.Numerics.Vector2(x, y);
-
-        // Check scrollbar hit first
-        var scrollbarHit = _engine.HitTestScrollbar(x, y);
-        if (scrollbarHit != null)
+        lock (_sync)
         {
-            _logger.LogTrace("Scrollbar hit: type={HitType}, element={Tag}#{Id}, thumbOffset={Offset}, pos=({X}, {Y})",
-                scrollbarHit.HitType, scrollbarHit.Box.Element.TagName, scrollbarHit.Box.Element.Id ?? "",
-                scrollbarHit.ThumbOffset, x, y);
-            _draggingScrollbar = scrollbarHit;
-            _isDragging = true;
-            if (scrollbarHit.HitType == MikoEngine.ScrollbarHitType.VerticalThumb ||
-                scrollbarHit.HitType == MikoEngine.ScrollbarHitType.HorizontalThumb)
+            _mouseDownPosition = new System.Numerics.Vector2(x, y);
+
+            // Check scrollbar hit first
+            var scrollbarHit = _engine.HitTestScrollbar(x, y);
+            if (scrollbarHit != null)
             {
-                _mouseDownPosition = null; // suppress click handling
+                _logger.LogTrace("Scrollbar hit: type={HitType}, element={Tag}#{Id}, thumbOffset={Offset}, pos=({X}, {Y})",
+                    scrollbarHit.HitType, scrollbarHit.Box.Element.TagName, scrollbarHit.Box.Element.Id ?? "",
+                    scrollbarHit.ThumbOffset, x, y);
+                _draggingScrollbar = scrollbarHit;
+                _isDragging = true;
+                if (scrollbarHit.HitType == MikoEngine.ScrollbarHitType.VerticalThumb ||
+                    scrollbarHit.HitType == MikoEngine.ScrollbarHitType.HorizontalThumb)
+                {
+                    _mouseDownPosition = null; // suppress click handling
+                }
+                return;
             }
-            return;
-        }
 
-        var target = _engine.HitTest(x, y);
-        if (target is InputElement { Type: InputType.Range } rangeInput)
-        {
-            _isDragging = true;
-            _draggingRange = rangeInput;
-            UpdateRangeValue(rangeInput, x);
+            var target = _engine.HitTest(x, y);
+            if (target is InputElement { Type: InputType.Range } rangeInput)
+            {
+                _isDragging = true;
+                _draggingRange = rangeInput;
+                UpdateRangeValue(rangeInput, x);
+            }
         }
     }
 
     public void OnPointerUp(float x, float y, MouseButton button)
     {
         if (button != MouseButton.Left) return;
-
-        if (_isDragging)
+        lock (_sync)
         {
-            _isDragging = false;
-
-            // Handle scrollbar track click (not thumb drag)
-            if (_draggingScrollbar != null)
+            if (_isDragging)
             {
-                var hit = _draggingScrollbar;
-                _draggingScrollbar = null;
-                if (hit.HitType == MikoEngine.ScrollbarHitType.VerticalTrack ||
-                    hit.HitType == MikoEngine.ScrollbarHitType.HorizontalTrack)
+                _isDragging = false;
+
+                // Handle scrollbar track click (not thumb drag)
+                if (_draggingScrollbar != null)
                 {
-                    _logger.LogTrace("Scrollbar track click: type={HitType}, element={Tag}#{Id}, pos=({X}, {Y})",
-                        hit.HitType, hit.Box.Element.TagName, hit.Box.Element.Id ?? "", x, y);
-                    _engine.ScrollTrackClick(hit.Box, hit.HitType, x, y);
+                    var hit = _draggingScrollbar;
+                    _draggingScrollbar = null;
+                    if (hit.HitType == MikoEngine.ScrollbarHitType.VerticalTrack ||
+                        hit.HitType == MikoEngine.ScrollbarHitType.HorizontalTrack)
+                    {
+                        _logger.LogTrace("Scrollbar track click: type={HitType}, element={Tag}#{Id}, pos=({X}, {Y})",
+                            hit.HitType, hit.Box.Element.TagName, hit.Box.Element.Id ?? "", x, y);
+                        _engine.ScrollTrackClick(hit.Box, hit.HitType, x, y);
+                    }
                 }
+
+                _draggingRange = null;
+                _mouseDownPosition = null;
+                return;
             }
 
-            _draggingRange = null;
+            if (_mouseDownPosition == null) return;
+
+            var position = _mouseDownPosition.Value;
             _mouseDownPosition = null;
-            return;
+
+            var target = _engine.HitTest(position.X, position.Y);
+            if (target == null)
+            {
+                SetFocusCore(null);
+                return;
+            }
+
+            HandleClick(target, position.X, position.Y);
         }
-
-        if (_mouseDownPosition == null) return;
-
-        var position = _mouseDownPosition.Value;
-        _mouseDownPosition = null;
-
-        var target = _engine.HitTest(position.X, position.Y);
-        if (target == null)
-        {
-            SetFocus(null);
-            return;
-        }
-
-        HandleClick(target, position.X, position.Y);
     }
 
     public void OnPointerMove(float x, float y)
     {
-        if (_isDragging && _draggingScrollbar != null)
+        lock (_sync)
         {
-            var hit = _draggingScrollbar;
-            if (hit.HitType == MikoEngine.ScrollbarHitType.VerticalThumb)
+            if (_isDragging && _draggingScrollbar != null)
             {
-                _logger.LogTrace("Scrollbar thumb drag: vertical, element={Tag}#{Id}, mouseY={Y}",
-                    hit.Box.Element.TagName, hit.Box.Element.Id ?? "", y);
-                _engine.DragVerticalThumb(hit.Box, y, hit.ThumbOffset);
+                var hit = _draggingScrollbar;
+                if (hit.HitType == MikoEngine.ScrollbarHitType.VerticalThumb)
+                {
+                    _logger.LogTrace("Scrollbar thumb drag: vertical, element={Tag}#{Id}, mouseY={Y}",
+                        hit.Box.Element.TagName, hit.Box.Element.Id ?? "", y);
+                    _engine.DragVerticalThumb(hit.Box, y, hit.ThumbOffset);
+                }
+                else if (hit.HitType == MikoEngine.ScrollbarHitType.HorizontalThumb)
+                {
+                    _logger.LogTrace("Scrollbar thumb drag: horizontal, element={Tag}#{Id}, mouseX={X}",
+                        hit.Box.Element.TagName, hit.Box.Element.Id ?? "", x);
+                    _engine.DragHorizontalThumb(hit.Box, x, hit.ThumbOffset);
+                }
+                return;
             }
-            else if (hit.HitType == MikoEngine.ScrollbarHitType.HorizontalThumb)
+
+            if (_isDragging && _draggingRange != null)
             {
-                _logger.LogTrace("Scrollbar thumb drag: horizontal, element={Tag}#{Id}, mouseX={X}",
-                    hit.Box.Element.TagName, hit.Box.Element.Id ?? "", x);
-                _engine.DragHorizontalThumb(hit.Box, x, hit.ThumbOffset);
+                UpdateRangeValue(_draggingRange, x);
+                return;
             }
-            return;
-        }
 
-        if (_isDragging && _draggingRange != null)
-        {
-            UpdateRangeValue(_draggingRange, x);
-            return;
+            UpdateCursor(x, y);
         }
-
-        UpdateCursor(x, y);
     }
 
     /// <summary>
@@ -256,8 +295,11 @@ public sealed class MikoInteractionController
     /// </summary>
     public void OnScroll(float x, float y, float deltaX, float deltaY)
     {
-        _logger.LogTrace("OnScroll: pos=({PosX}, {PosY}), delta=({DeltaX}, {DeltaY})", x, y, deltaX, deltaY);
-        _engine.ScrollBy(x, y, deltaX, deltaY);
+        lock (_sync)
+        {
+            _logger.LogTrace("OnScroll: pos=({PosX}, {PosY}), delta=({DeltaX}, {DeltaY})", x, y, deltaX, deltaY);
+            _engine.ScrollBy(x, y, deltaX, deltaY);
+        }
     }
 
     /// <summary>
@@ -321,7 +363,7 @@ public sealed class MikoInteractionController
         else
         {
             CloseAllSelects();
-            SetFocus(null);
+            SetFocusCore(null);
         }
     }
 
@@ -333,7 +375,7 @@ public sealed class MikoInteractionController
         {
             case InputType.Text:
             case InputType.Password:
-                SetFocus(inputElement);
+                SetFocusCore(inputElement);
                 inputElement.MoveCursorToEnd();
                 break;
             case InputType.Checkbox:
@@ -351,7 +393,7 @@ public sealed class MikoInteractionController
 
     private void HandleSelectClick(SelectElement selectElement)
     {
-        SetFocus(selectElement);
+        SetFocusCore(selectElement);
         selectElement.Toggle();
     }
 
@@ -437,6 +479,14 @@ public sealed class MikoInteractionController
     /// <summary>设置当前焦点元素，触发 blur/focus 事件。</summary>
     public void SetFocus(Element? newFocus)
     {
+        lock (_sync)
+        {
+            SetFocusCore(newFocus);
+        }
+    }
+
+    private void SetFocusCore(Element? newFocus)
+    {
         if (_focusedElement == newFocus) return;
 
         var oldFocus = _focusedElement;
@@ -478,30 +528,33 @@ public sealed class MikoInteractionController
     /// <summary>键按下。返回 true 表示该按键已被全局处理器消费。</summary>
     public bool OnKeyDown(MikoKey key, MikoKeyModifiers mods)
     {
-        foreach (var handler in _options.GlobalKeyDownHandlers)
+        lock (_sync)
         {
-            if (handler(key)) return true;
+            foreach (var handler in _options.GlobalKeyDownHandlers)
+            {
+                if (handler(key)) return true;
+            }
+
+            if (_focusedElement is not InputElement input) return false;
+            if (input.Type != InputType.Text && input.Type != InputType.Password) return false;
+
+            var keyName = key.ToString();
+            bool ctrl = mods.HasFlag(MikoKeyModifiers.Control);
+
+            var keyArgs = new KeyboardEventArgs
+            {
+                Target = input,
+                Key = keyName,
+                CtrlKey = ctrl,
+                ShiftKey = mods.HasFlag(MikoKeyModifiers.Shift),
+                AltKey = mods.HasFlag(MikoKeyModifiers.Alt),
+                Bubbles = true
+            };
+            _eventDispatcher.Dispatch(input, EventTypes.KeyDown, keyArgs);
+
+            ProcessKeyAction(key);
+            return false;
         }
-
-        if (_focusedElement is not InputElement input) return false;
-        if (input.Type != InputType.Text && input.Type != InputType.Password) return false;
-
-        var keyName = key.ToString();
-        bool ctrl = mods.HasFlag(MikoKeyModifiers.Control);
-
-        var keyArgs = new KeyboardEventArgs
-        {
-            Target = input,
-            Key = keyName,
-            CtrlKey = ctrl,
-            ShiftKey = mods.HasFlag(MikoKeyModifiers.Shift),
-            AltKey = mods.HasFlag(MikoKeyModifiers.Alt),
-            Bubbles = true
-        };
-        _eventDispatcher.Dispatch(input, EventTypes.KeyDown, keyArgs);
-
-        ProcessKeyAction(key);
-        return false;
     }
 
     /// <summary>键释放（当前无状态需要清理，保留以备扩展与对称性）。</summary>
@@ -516,7 +569,10 @@ public sealed class MikoInteractionController
     /// <summary>由平台层在按键重复时调用，重新执行编辑动作。</summary>
     public void RepeatKey(MikoKey key)
     {
-        ProcessKeyAction(key);
+        lock (_sync)
+        {
+            ProcessKeyAction(key);
+        }
     }
 
     private void ProcessKeyAction(MikoKey key)
@@ -562,15 +618,18 @@ public sealed class MikoInteractionController
     /// <summary>文本输入（已组合的字符）。控制字符会被忽略。</summary>
     public void OnTextInput(string text)
     {
-        if (_focusedElement is not InputElement input) return;
-        if (input.Type != InputType.Text && input.Type != InputType.Password) return;
-
-        foreach (var character in text)
+        lock (_sync)
         {
-            if (char.IsControl(character)) continue;
-            input.InsertText(character.ToString());
+            if (_focusedElement is not InputElement input) return;
+            if (input.Type != InputType.Text && input.Type != InputType.Password) return;
+
+            foreach (var character in text)
+            {
+                if (char.IsControl(character)) continue;
+                input.InsertText(character.ToString());
+            }
+            DispatchInputEvent(input);
         }
-        DispatchInputEvent(input);
     }
 
     private void DispatchInputEvent(InputElement input)

--- a/tests/Miko.Tests/Platform/ConcurrentInputRenderTests.cs
+++ b/tests/Miko.Tests/Platform/ConcurrentInputRenderTests.cs
@@ -1,0 +1,114 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Events;
+using Miko.Hosting;
+using Miko.Platform;
+using Shouldly;
+using SkiaSharp;
+using Xunit;
+
+namespace Miko.Tests.Platform;
+
+/// <summary>
+/// 回归测试：ISSUE-051 —— 在多线程宿主（Android GLThread / iOS CADisplayLink）上，
+/// 渲染线程遍历 DOM（LayoutEngine.ComputeStyles 枚举 Element.Children）的同时，
+/// UI 线程的输入处理同步修改 DOM（点击触发 StateHasChanged 重写 Children），
+/// 二者并发会抛出 "Collection was modified; enumeration operation may not execute"。
+/// MikoInteractionController 通过输入/渲染锁将二者串行化来修复该问题。
+/// </summary>
+public class ConcurrentInputRenderTests
+{
+    private static MikoInteractionController CreateController(MikoAppOptions options, MikoEngine engine)
+    {
+        return new MikoInteractionController(
+            Options.Create(options),
+            new EmptyServiceProvider(),
+            engine,
+            new EventDispatcher(),
+            new HotReloadService(NullLogger<HotReloadService>.Instance),
+            NullLogger<MikoInteractionController>.Instance);
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    // A root element whose child list is rewritten on demand, mirroring what a Razor
+    // component's StateHasChanged does to parent.Children during an input handler.
+    private static Element BuildMutableRoot(out Action mutate)
+    {
+        var root = new DivElement();
+        for (int i = 0; i < 8; i++)
+            root.AddChild(new DivElement { TextContent = $"child {i}" });
+
+        int counter = 0;
+        mutate = () =>
+        {
+            // Replace the whole child collection, like StateHasChanged rebuilding a subtree.
+            root.Children.Clear();
+            int n = 4 + (++counter % 8);
+            for (int i = 0; i < n; i++)
+                root.AddChild(new DivElement { TextContent = $"child {i} v{counter}" });
+        };
+        return root;
+    }
+
+    [Fact]
+    public void RenderFrame_ConcurrentWithDomMutatingInput_DoesNotThrow()
+    {
+        var root = BuildMutableRoot(out var mutate);
+
+        // A global key handler stands in for any input that synchronously mutates the DOM
+        // (e.g. a click -> component handler -> StateHasChanged). OnKeyDown runs it under
+        // the same lock RenderFrame uses, so it must serialize against layout.
+        var options = new MikoAppOptions
+        {
+            RootComponentFactory = () => root,
+            GlobalKeyDownHandlers = { _ => { mutate(); return true; } }
+        };
+
+        var engine = new MikoEngine();
+        var controller = CreateController(options, engine);
+
+        using var surface = SKSurface.Create(new SKImageInfo(400, 400));
+        var canvas = surface.Canvas;
+        controller.Initialize(canvas, 400, 400);
+
+        Exception? failure = null;
+        using var cts = new CancellationTokenSource();
+
+        // Render thread: continuously lay out + render the tree.
+        var renderThread = new Thread(() =>
+        {
+            try
+            {
+                while (!cts.IsCancellationRequested)
+                    controller.RenderFrame(canvas, 400, 400, 0.016f, c => engine.Render(c));
+            }
+            catch (Exception ex) { failure = ex; cts.Cancel(); }
+        });
+
+        // Input thread: hammer the DOM-mutating handler, like fast repeated taps.
+        var inputThread = new Thread(() =>
+        {
+            try
+            {
+                for (int i = 0; i < 2000 && !cts.IsCancellationRequested; i++)
+                    controller.OnKeyDown(MikoKey.Enter, MikoKeyModifiers.None);
+            }
+            catch (Exception ex) { failure = ex; cts.Cancel(); }
+        });
+
+        renderThread.Start();
+        inputThread.Start();
+
+        inputThread.Join(TimeSpan.FromSeconds(30)).ShouldBeTrue("input thread should finish");
+        cts.Cancel();
+        renderThread.Join(TimeSpan.FromSeconds(30)).ShouldBeTrue("render thread should stop");
+
+        failure.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## 概述

修复 [ISSUE-051](issues/ISSUE-051.md)：使用 `MikoMultiplatformApp` 模板创建的安卓应用，**连续快速点击按钮时崩溃**，报错：

```
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
  at System.Collections.Generic.List`1+Enumerator[Miko.Core.Element].MoveNext
  at Miko.Layout.LayoutEngine.ComputeStyles
  at Miko.Core.MikoEngine.Render
  at Miko.Android.MikoSurfaceView.OnPaintSurface  (GLThread)
```

## 崩溃原因

这是一个**多线程并发修改集合**的竞态：

- **渲染线程**（Android 的 `GLThread` / iOS 的 `CADisplayLink`）在 `OnPaintSurface` → `Engine.Render` → `LayoutEngine.ComputeStyles` 中**遍历** `Element.Children`（`List<Element>`）。
- **UI 线程**在 `OnTouchEvent` → `OnPointerUp` → 派发 click → Razor `@onclick` 处理器 → `StateHasChanged()` 中**同步修改** `parent.Children`（`Clear()` / `Children[i] = ...`）。

两者无任何同步地并发访问同一个 `List<Element>`，于是枚举器抛出 `InvalidOperationException`。点击越快，渲染帧与触摸事件重叠的概率越高，所以"快点崩溃、慢点正常"。

桌面（Silk.NET）应用正常，是因为它在**单线程**上同时泵入输入事件与渲染回调——点击处理器（含 DOM 变更）总是在下一帧渲染开始前执行完毕，不存在竞态。

## 修复

在共享的、平台无关的 `MikoInteractionController` 中引入一把**输入/渲染锁**：

- 所有输入入口（`OnPointerDown/Up/Move`、`OnScroll`、`OnKeyDown`、`RepeatKey`、`OnTextInput`、`SetFocus`）都在该锁下执行。
- 新增 `RenderFrame(canvas, w, h, dt, render)`，把每帧的"按需重建 → 推进动画 → 渲染"序列收拢到同一把锁内；三个平台宿主（桌面/Android/iOS）均改为通过它渲染。

这样输入派发引发的 DOM 变更与布局/渲染对 DOM 的遍历相互排斥，从根本上消除竞态。桌面宿主单线程运行，这把锁无竞争、零开销。

## 验证

- 新增回归测试 `ConcurrentInputRenderTests`：在一个线程持续 `RenderFrame`、另一个线程高频触发会修改 DOM 的输入处理器。
  - **去掉锁**时，它稳定复现 issue 中的 `System.InvalidOperationException: Collection was modified`；
  - **加上锁**后通过。
- `dotnet test` —— **828 passed, 0 failed**
- `dotnet build miko.slnx`（含 Android/iOS）—— **0 errors**
