### PR TITLE
feat(engine): safe-area insets so mobile content clears system bars

### DIFF
--- a/src/Miko.Android/MikoSurfaceView.cs
+++ b/src/Miko.Android/MikoSurfaceView.cs
@@ -33,6 +33,46 @@ public class MikoSurfaceView : SKGLSurfaceView
 
         // 连续渲染，使动画与热重载得以推进。
         RenderMode = global::Android.Opengl.Rendermode.Continuously;
+
+        // 接收系统窗口 inset 以便计算安全区（edge-to-edge 下系统栏会覆盖内容）。
+        SetFitsSystemWindows(false);
+    }
+
+    /// <summary>
+    /// 系统窗口 inset 变化（首次 attach、旋转、系统栏显隐）时回调。读取状态栏/导航栏
+    /// 的 inset（物理像素），换算为逻辑像素后推给引擎作为安全区，使内容不被系统 UI 遮盖。
+    /// </summary>
+    public override WindowInsets? OnApplyWindowInsets(WindowInsets? insets)
+    {
+        if (insets != null)
+        {
+            int left, top, right, bottom;
+
+            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.R)
+            {
+                // API 30+：用类型化 inset（状态栏 + 导航栏 + 刘海）。
+                var bars = insets.GetInsets(
+                    WindowInsets.Type.SystemBars() | WindowInsets.Type.DisplayCutout());
+                left = bars.Left;
+                top = bars.Top;
+                right = bars.Right;
+                bottom = bars.Bottom;
+            }
+            else
+            {
+                // API 21–29：回退到已废弃的 system-window inset。
+#pragma warning disable CA1422 // 旧 API 在新平台标记过时，此处为向后兼容有意调用
+                left = insets.SystemWindowInsetLeft;
+                top = insets.SystemWindowInsetTop;
+                right = insets.SystemWindowInsetRight;
+                bottom = insets.SystemWindowInsetBottom;
+#pragma warning restore CA1422
+            }
+
+            _controller.SetSafeAreaInsets(left / _density, top / _density, right / _density, bottom / _density);
+        }
+
+        return base.OnApplyWindowInsets(insets);
     }
 
     protected override void OnPaintSurface(SKPaintGLSurfaceEventArgs e)
@@ -58,7 +98,9 @@ public class MikoSurfaceView : SKGLSurfaceView
         // UI thread can't race the layout walk on this GL thread.
         _controller.RenderFrame(canvas, logicalWidth, logicalHeight, deltaTime, c =>
         {
-            c.Clear(SKColors.White);
+            // 用根背景色填充整个 surface，使安全区内的系统栏带与内容背景一致（而非白边）。
+            var rootBg = _controller.Engine.GetRootBackgroundColor();
+            c.Clear(rootBg?.ToSKColor() ?? SKColors.White);
             c.Save();
             c.Scale(_density);
             _controller.Engine.Render(c);

--- a/src/Miko.iOS/MikoGLView.cs
+++ b/src/Miko.iOS/MikoGLView.cs
@@ -37,6 +37,18 @@ public class MikoGLView : SKGLView
         PaintSurface += OnPaintSurface;
     }
 
+    /// <summary>
+    /// 安全区变化（刘海、Home 指示条、旋转）时回调。<see cref="UIView.SafeAreaInsets"/>
+    /// 已是逻辑点，与渲染坐标一致，直接推给引擎作为安全区，使内容不被系统 UI 遮盖。
+    /// </summary>
+    public override void SafeAreaInsetsDidChange()
+    {
+        base.SafeAreaInsetsDidChange();
+        var insets = SafeAreaInsets;
+        _controller.SetSafeAreaInsets(
+            (float)insets.Left, (float)insets.Top, (float)insets.Right, (float)insets.Bottom);
+    }
+
     private void OnPaintSurface(object? sender, SKPaintGLSurfaceEventArgs e)
     {
         var canvas = e.Surface.Canvas;
@@ -61,7 +73,9 @@ public class MikoGLView : SKGLView
         // UI thread can't race the layout walk on the render thread.
         _controller.RenderFrame(canvas, logicalWidth, logicalHeight, deltaTime, c =>
         {
-            c.Clear(SKColors.White);
+            // 用根背景色填充整个 surface，使安全区内的系统栏带与内容背景一致（而非白边）。
+            var rootBg = _controller.Engine.GetRootBackgroundColor();
+            c.Clear(rootBg?.ToSKColor() ?? SKColors.White);
             c.Save();
             c.Scale((float)_scale);
             _controller.Engine.Render(c);

--- a/src/Miko/Common/SafeAreaInsets.cs
+++ b/src/Miko/Common/SafeAreaInsets.cs
@@ -1,0 +1,13 @@
+namespace Miko.Common;
+
+/// <summary>
+/// 安全区边距（逻辑像素）。由平台宿主从 OS 系统栏（状态栏、导航栏）获取，
+/// 传递给引擎以防止内容被系统 UI 遮盖。
+/// </summary>
+public readonly record struct SafeAreaInsets(float Left, float Top, float Right, float Bottom)
+{
+    /// <summary>无安全区（桌面平台或未初始化时的默认值）。</summary>
+    public static readonly SafeAreaInsets Zero = new(0, 0, 0, 0);
+
+    public bool IsZero => Left == 0 && Top == 0 && Right == 0 && Bottom == 0;
+}

--- a/src/Miko/Core/MikoEngine.cs
+++ b/src/Miko/Core/MikoEngine.cs
@@ -49,6 +49,7 @@ public class MikoEngine
     private LayoutBox? _currentLayout;
     private float _viewportWidth;
     private float _viewportHeight;
+    private SafeAreaInsets _safeArea;
 
     public void Initialize(Element root, List<StyleSheet> styleSheets, SKCanvas canvas, float viewportWidth, float viewportHeight)
     {
@@ -72,14 +73,14 @@ public class MikoEngine
         // Capture old styles from transferred LayoutBoxes (before layout replaces them)
         var oldStyles = CaptureTransitionableStyles(root);
 
-        _currentLayout = _layoutEngine.Layout(root, _styleSheets, viewportWidth, viewportHeight);
+        _currentLayout = _layoutEngine.Layout(root, _styleSheets, viewportWidth, viewportHeight, _safeArea);
 
         if (oldStyles.Elements.Count > 0 || oldStyles.PseudoElements.Count > 0)
         {
             bool transitionsTriggered = DetectAndTriggerTransitions(root, oldStyles);
             if (transitionsTriggered)
             {
-                _currentLayout = _layoutEngine.Layout(root, _styleSheets, viewportWidth, viewportHeight);
+                _currentLayout = _layoutEngine.Layout(root, _styleSheets, viewportWidth, viewportHeight, _safeArea);
             }
         }
 
@@ -130,7 +131,7 @@ public class MikoEngine
         {
             var dirtyRegions = _dirtyManager.GetDirtyRegions();
             var oldLayout = _currentLayout;
-            _currentLayout = _layoutEngine.Layout(_root, _styleSheets, _viewportWidth, _viewportHeight);
+            _currentLayout = _layoutEngine.Layout(_root, _styleSheets, _viewportWidth, _viewportHeight, _safeArea);
             RestoreScrollState(oldLayout, _currentLayout);
 
             // 脏区域过多时，增量渲染会退化为多次全树遍历，成本超过一次全量渲染，
@@ -157,13 +158,13 @@ public class MikoEngine
 
         var oldStyles = CaptureTransitionableStyles(_root);
         var oldLayout = _currentLayout;
-        _currentLayout = _layoutEngine.Layout(_root, _styleSheets, _viewportWidth, _viewportHeight);
+        _currentLayout = _layoutEngine.Layout(_root, _styleSheets, _viewportWidth, _viewportHeight, _safeArea);
 
         bool transitionsTriggered = DetectAndTriggerTransitions(_root, oldStyles);
         if (transitionsTriggered)
         {
             // 重新布局，使用 transition 起始值（已写入 inline style）
-            _currentLayout = _layoutEngine.Layout(_root, _styleSheets, _viewportWidth, _viewportHeight);
+            _currentLayout = _layoutEngine.Layout(_root, _styleSheets, _viewportWidth, _viewportHeight, _safeArea);
         }
 
         RestoreScrollState(oldLayout, _currentLayout);
@@ -242,6 +243,26 @@ public class MikoEngine
         }
     }
 
+    /// <summary>当前安全区边距（逻辑像素）。</summary>
+    public SafeAreaInsets SafeAreaInsets => _safeArea;
+
+    /// <summary>
+    /// 设置安全区边距（逻辑像素）。由平台宿主从系统状态栏/导航栏获取后传入。
+    /// 值发生变化时触发完整重新布局，使根元素内缩到安全区内。
+    /// </summary>
+    public void SetSafeAreaInsets(SafeAreaInsets insets)
+    {
+        if (_safeArea == insets) return;
+
+        _safeArea = insets;
+
+        // 安全区变化需要完整重新布局（与视口变化同理）
+        if (_root != null)
+        {
+            InvalidateElement(_root);
+        }
+    }
+
     /// <summary>
     /// 添加样式表
     /// </summary>
@@ -265,6 +286,17 @@ public class MikoEngine
     /// 获取根元素
     /// </summary>
     public Element? GetRoot() => _root;
+
+    /// <summary>
+    /// 根元素的已解析背景色。平台宿主用它填充整个 surface（含安全区系统栏带），
+    /// 使状态栏/导航栏后方的颜色与内容背景一致。根背景透明时返回 null。
+    /// </summary>
+    public Color? GetRootBackgroundColor()
+    {
+        var bg = _currentLayout?.ComputedStyle.BackgroundColor;
+        if (bg == null || bg.Value.A == 0) return null;
+        return bg;
+    }
 
     /// <summary>
     /// 在指定坐标处进行命中测试，返回最深层的元素

--- a/src/Miko/Layout/LayoutEngine.cs
+++ b/src/Miko/Layout/LayoutEngine.cs
@@ -20,10 +20,23 @@ public class LayoutEngine
     /// <summary>
     /// 执行布局计算
     /// </summary>
-    public LayoutBox Layout(Element root, List<StyleSheet> styleSheets, float viewportWidth, float viewportHeight)
+    /// <param name="safeArea">
+    /// 安全区边距（逻辑像素）。非零时根元素在内缩后的视口矩形内布局，避免内容被
+    /// 系统状态栏/导航栏遮盖。默认无内缩（桌面）。
+    /// </param>
+    public LayoutBox Layout(Element root, List<StyleSheet> styleSheets, float viewportWidth, float viewportHeight,
+        SafeAreaInsets safeArea = default)
     {
-        // 1. 样式计算：为每个元素计算最终样式
-        var viewport = new ViewportInfo(viewportWidth, viewportHeight);
+        // 安全区内缩后的可用视口：原点右下移 (Left, Top)，尺寸减去左右/上下边距。
+        // 百分比尺寸、约束、绝对/固定定位的包含块都以此为基准，使整棵树落在安全区内。
+        float originX = safeArea.Left;
+        float originY = safeArea.Top;
+        float availableWidth = Math.Max(0, viewportWidth - safeArea.Left - safeArea.Right);
+        float availableHeight = Math.Max(0, viewportHeight - safeArea.Top - safeArea.Bottom);
+
+        // 1. 样式计算：为每个元素计算最终样式（视口尺寸用安全区内的可用尺寸，
+        //    使 100vw/100% 不会把内容撑到系统栏下方）。
+        var viewport = new ViewportInfo(availableWidth, availableHeight);
         ComputeStyles(root, styleSheets, viewport);
 
         // 2. 构建布局树：根据 display 属性过滤和组织
@@ -34,13 +47,13 @@ public class LayoutEngine
             throw new InvalidOperationException("Failed to build layout tree");
         }
 
-        // 3. 布局计算：计算每个盒子的位置和尺寸
-        var constraints = new LayoutConstraints(viewportWidth, viewportHeight);
-        CalculateLayout(layoutRoot, constraints, 0, 0);
+        // 3. 布局计算：计算每个盒子的位置和尺寸（从安全区原点开始）
+        var constraints = new LayoutConstraints(availableWidth, availableHeight);
+        CalculateLayout(layoutRoot, constraints, originX, originY);
 
         // 4. 定位调整：处理 relative/absolute 定位的偏移
-        // 根元素的初始包含块为视口
-        var viewportBlock = new RectF(0, 0, viewportWidth, viewportHeight);
+        // 根元素的初始包含块为安全区内缩后的视口
+        var viewportBlock = new RectF(originX, originY, availableWidth, availableHeight);
         ApplyPositioning(layoutRoot, viewportBlock);
 
         return layoutRoot;

--- a/src/Miko/Platform/MikoInteractionController.cs
+++ b/src/Miko/Platform/MikoInteractionController.cs
@@ -175,6 +175,18 @@ public sealed class MikoInteractionController
         }
     }
 
+    /// <summary>
+    /// 安全区边距变化（逻辑像素）。平台宿主从系统状态栏/导航栏 inset 换算为逻辑像素后调用，
+    /// 使根内容内缩到安全区内，避免被系统 UI 遮盖。
+    /// </summary>
+    public void SetSafeAreaInsets(float left, float top, float right, float bottom)
+    {
+        lock (_sync)
+        {
+            _engine.SetSafeAreaInsets(new SafeAreaInsets(left, top, right, bottom));
+        }
+    }
+
     // ---------------------------------------------------------------------
     // 指针输入（坐标为已根据像素密度换算后的逻辑坐标）
     // ---------------------------------------------------------------------

--- a/templates/MikoMultiplatformApp/MikoMultiplatformApp.Android/MainActivity.cs
+++ b/templates/MikoMultiplatformApp/MikoMultiplatformApp.Android/MainActivity.cs
@@ -4,12 +4,26 @@ using Miko.Android;
 
 namespace MikoMultiplatformApp.Android;
 
-[Activity(Label = "Miko Multiplatform App", MainLauncher = true)]
+// Theme.Material.Light.NoActionBar hides Android's native title/action bar so the Ionic
+// layout's own IonHeader is the only header on screen (it would otherwise stack a second
+// bar above it). It's a built-in platform theme, so no Resources/values/styles.xml is needed.
+[Activity(
+    Label = "Miko Multiplatform App",
+    MainLauncher = true,
+    Theme = "@android:style/Theme.Material.Light.NoActionBar")]
 public class MainActivity : Activity
 {
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
+
+        // Draw edge-to-edge so Miko owns the full surface; the engine reserves a safe area
+        // from the system-bar insets (see MikoSurfaceView.OnApplyWindowInsets) so content is
+        // not occluded. Default on Android 15 (API 35); set explicitly for API 30+.
+        if (OperatingSystem.IsAndroidVersionAtLeast(30))
+        {
+            Window?.SetDecorFitsSystemWindows(false);
+        }
 
         // Reuse the shared app configuration; Miko.Android drives rendering and touch input.
         SetContentView(MikoAndroidApp.CreateView(this, MikoMultiplatformApp.App.CreateContext));

--- a/tests/Miko.Tests/Core/SafeAreaInsetsEngineTests.cs
+++ b/tests/Miko.Tests/Core/SafeAreaInsetsEngineTests.cs
@@ -1,0 +1,141 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Core;
+
+/// <summary>
+/// Tests for <see cref="MikoEngine.SetSafeAreaInsets"/>: a change relays out the tree so the
+/// root content is inset into the safe area, repeated identical values are a no-op, and the
+/// root background color is exposed so the host can fill the system-bar bands to match.
+/// </summary>
+public class SafeAreaInsetsEngineTests : IDisposable
+{
+    private readonly SKBitmap _bitmap;
+    private readonly SKCanvas _canvas;
+
+    public SafeAreaInsetsEngineTests()
+    {
+        _bitmap = new SKBitmap(390, 844);
+        _canvas = new SKCanvas(_bitmap);
+    }
+
+    public void Dispose()
+    {
+        _canvas.Dispose();
+        _bitmap.Dispose();
+    }
+
+    private static StyleSheet RootSheet(Color bg) => new()
+    {
+        Rules = new List<StyleRule>
+        {
+            new()
+            {
+                Selector = new ClassSelector("root"),
+                Style = new Style
+                {
+                    Display = Display.Block,
+                    Width = Length.Percent(100),
+                    Height = Length.Percent(100),
+                    BackgroundColor = bg,
+                },
+            },
+        }
+    };
+
+    [Fact]
+    public void SetSafeAreaInsets_RelaysOutRootIntoSafeArea()
+    {
+        var root = new DivElement { Class = "root" };
+        var engine = new MikoEngine();
+        engine.Initialize(root, new List<StyleSheet> { RootSheet(new Color(255, 255, 255)) }, _canvas, 390, 844);
+
+        engine.SetSafeAreaInsets(new SafeAreaInsets(0, 48, 0, 24));
+        engine.Render(_canvas);
+
+        var layout = engine.GetCurrentLayout();
+        layout.ShouldNotBeNull();
+        layout!.BoxModel.Content.Top.ShouldBe(48f);
+        layout.BoxModel.Content.Height.ShouldBe(844f - 48f - 24f);
+    }
+
+    [Fact]
+    public void SetSafeAreaInsets_ExposedViaProperty()
+    {
+        var root = new DivElement { Class = "root" };
+        var engine = new MikoEngine();
+        engine.Initialize(root, new List<StyleSheet> { RootSheet(new Color(255, 255, 255)) }, _canvas, 390, 844);
+
+        var insets = new SafeAreaInsets(12, 48, 8, 24);
+        engine.SetSafeAreaInsets(insets);
+
+        engine.SafeAreaInsets.ShouldBe(insets);
+    }
+
+    [Fact]
+    public void SetSafeAreaInsets_SameValue_DoesNotRelayout()
+    {
+        var root = new DivElement { Class = "root" };
+        var engine = new MikoEngine();
+        engine.Initialize(root, new List<StyleSheet> { RootSheet(new Color(255, 255, 255)) }, _canvas, 390, 844);
+
+        engine.SetSafeAreaInsets(new SafeAreaInsets(0, 48, 0, 24));
+        engine.Render(_canvas);                  // apply relayout + clear dirty regions
+        var before = engine.GetCurrentLayout();
+
+        // Setting the identical value must not invalidate the root; Update only relays out when
+        // dirty regions exist, so the layout-tree reference stays the same.
+        engine.SetSafeAreaInsets(new SafeAreaInsets(0, 48, 0, 24));
+        engine.Update(_canvas);
+        engine.GetCurrentLayout().ShouldBeSameAs(before);
+    }
+
+    [Fact]
+    public void SetSafeAreaInsets_DifferentValue_Relayouts()
+    {
+        var root = new DivElement { Class = "root" };
+        var engine = new MikoEngine();
+        engine.Initialize(root, new List<StyleSheet> { RootSheet(new Color(255, 255, 255)) }, _canvas, 390, 844);
+
+        engine.SetSafeAreaInsets(new SafeAreaInsets(0, 48, 0, 24));
+        engine.Render(_canvas);
+        var before = engine.GetCurrentLayout();
+
+        // A changed value invalidates the root, so the next Update produces a fresh layout tree.
+        engine.SetSafeAreaInsets(new SafeAreaInsets(0, 60, 0, 30));
+        engine.Update(_canvas);
+        engine.GetCurrentLayout().ShouldNotBeSameAs(before);
+        engine.GetCurrentLayout()!.BoxModel.Content.Top.ShouldBe(60f);
+    }
+
+    [Fact]
+    public void GetRootBackgroundColor_ReturnsResolvedColor()
+    {
+        var root = new DivElement { Class = "root" };
+        var engine = new MikoEngine();
+        var bg = new Color(18, 52, 86);
+        engine.Initialize(root, new List<StyleSheet> { RootSheet(bg) }, _canvas, 390, 844);
+
+        var result = engine.GetRootBackgroundColor();
+        result.ShouldNotBeNull();
+        result!.Value.R.ShouldBe((byte)18);
+        result.Value.G.ShouldBe((byte)52);
+        result.Value.B.ShouldBe((byte)86);
+    }
+
+    [Fact]
+    public void GetRootBackgroundColor_TransparentRoot_ReturnsNull()
+    {
+        var root = new DivElement { Class = "root" };
+        var engine = new MikoEngine();
+        // No background color rule -> root defaults to transparent.
+        engine.Initialize(root, new List<StyleSheet>(), _canvas, 390, 844);
+
+        engine.GetRootBackgroundColor().ShouldBeNull();
+    }
+}

--- a/tests/Miko.Tests/Layout/SafeAreaLayoutTests.cs
+++ b/tests/Miko.Tests/Layout/SafeAreaLayoutTests.cs
@@ -1,0 +1,162 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Layout;
+
+/// <summary>
+/// Verifies safe-area inset handling in <see cref="LayoutEngine.Layout"/>. When non-zero insets
+/// are supplied (from a mobile host's system-bar insets), the root is laid out inside the
+/// inset viewport rect — origin shifts to (left, top) and the available size shrinks by
+/// left+right / top+bottom — so content is not occluded by the status bar / navigation bar.
+/// Zero insets must reproduce the pre-safe-area behavior exactly.
+/// </summary>
+public class SafeAreaLayoutTests
+{
+    private const float ViewportW = 390f;
+    private const float ViewportH = 844f;
+
+    private readonly LayoutEngine _layoutEngine = new();
+
+    // A root that fills 100% × 100% of its containing block.
+    private static StyleSheet FullSizeRootSheet() => new()
+    {
+        Rules = new List<StyleRule>
+        {
+            new()
+            {
+                Selector = new ClassSelector("root"),
+                Style = new Style
+                {
+                    Display = Display.Block,
+                    Width = Length.Percent(100),
+                    Height = Length.Percent(100),
+                },
+            },
+        }
+    };
+
+    // A fixed-position child pinned to top:0 left:0 — resolves against the (inset) viewport block.
+    private static StyleSheet FixedChildSheet() => new()
+    {
+        Rules = new List<StyleRule>
+        {
+            new()
+            {
+                Selector = new ClassSelector("root"),
+                Style = new Style
+                {
+                    Display = Display.Block, Position = Position.Relative,
+                    Width = Length.Percent(100), Height = Length.Percent(100),
+                },
+            },
+            new()
+            {
+                Selector = new ClassSelector("pinned"),
+                Style = new Style
+                {
+                    Position = Position.Fixed,
+                    Top = Length.Px(0), Left = Length.Px(0),
+                    Width = Length.Px(50), Height = Length.Px(50),
+                },
+            },
+        }
+    };
+
+    private static LayoutBox? FindByClass(LayoutBox box, string cls)
+    {
+        if (box.Element.Class == cls) return box;
+        foreach (var child in box.Children)
+        {
+            var found = FindByClass(child, cls);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    [Fact]
+    public void ZeroInsets_MatchesViewport()
+    {
+        var root = new DivElement { Class = "root" };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { FullSizeRootSheet() },
+            ViewportW, ViewportH, SafeAreaInsets.Zero);
+
+        // Default-parameter overload (no insets) must match zero insets exactly.
+        layout.BoxModel.Content.Left.ShouldBe(0f);
+        layout.BoxModel.Content.Top.ShouldBe(0f);
+        layout.BoxModel.Content.Width.ShouldBe(ViewportW);
+        layout.BoxModel.Content.Height.ShouldBe(ViewportH);
+    }
+
+    [Fact]
+    public void DefaultOverload_EqualsZeroInsets()
+    {
+        var root = new DivElement { Class = "root" };
+
+        // No insets argument → SafeAreaInsets default(struct) == Zero.
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { FullSizeRootSheet() },
+            ViewportW, ViewportH);
+
+        layout.BoxModel.Content.Left.ShouldBe(0f);
+        layout.BoxModel.Content.Top.ShouldBe(0f);
+        layout.BoxModel.Content.Width.ShouldBe(ViewportW);
+        layout.BoxModel.Content.Height.ShouldBe(ViewportH);
+    }
+
+    [Fact]
+    public void NonZeroInsets_OffsetOriginAndShrinkSize()
+    {
+        const float top = 48f, bottom = 24f, left = 12f, right = 8f;
+        var root = new DivElement { Class = "root" };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { FullSizeRootSheet() },
+            ViewportW, ViewportH, new SafeAreaInsets(left, top, right, bottom));
+
+        // Origin shifts into the safe area...
+        layout.BoxModel.Content.Left.ShouldBe(left);
+        layout.BoxModel.Content.Top.ShouldBe(top);
+        // ...and 100% width/height resolve against the inset (available) size.
+        layout.BoxModel.Content.Width.ShouldBe(ViewportW - left - right);
+        layout.BoxModel.Content.Height.ShouldBe(ViewportH - top - bottom);
+        // The content stays clear of the bottom/right system bars.
+        layout.BoxModel.Content.Bottom.ShouldBe(ViewportH - bottom, 0.5f);
+        layout.BoxModel.Content.Right.ShouldBe(ViewportW - right, 0.5f);
+    }
+
+    [Fact]
+    public void TopInsetOnly_PushesContentBelowStatusBar()
+    {
+        const float top = 48f;
+        var root = new DivElement { Class = "root" };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { FullSizeRootSheet() },
+            ViewportW, ViewportH, new SafeAreaInsets(0, top, 0, 0));
+
+        layout.BoxModel.Content.Top.ShouldBe(top);
+        layout.BoxModel.Content.Width.ShouldBe(ViewportW);          // no horizontal inset
+        layout.BoxModel.Content.Height.ShouldBe(ViewportH - top);   // only the top is reserved
+    }
+
+    [Fact]
+    public void FixedChild_ResolvesAgainstInsetViewportBlock()
+    {
+        const float top = 48f, left = 12f;
+        var root = new DivElement { Class = "root" };
+        var pinned = new DivElement { Class = "pinned" };
+        root.AddChild(pinned);
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { FixedChildSheet() },
+            ViewportW, ViewportH, new SafeAreaInsets(left, top, 0, 0));
+
+        var pinnedBox = FindByClass(layout, "pinned");
+        pinnedBox.ShouldNotBeNull();
+        // A fixed top:0 left:0 element pins to the safe-area corner, not the screen corner,
+        // so it isn't drawn under the status bar.
+        pinnedBox!.BoxModel.MarginBox.Top.ShouldBe(top);
+        pinnedBox.BoxModel.MarginBox.Left.ShouldBe(left);
+    }
+}


### PR DESCRIPTION
## Summary

Android and iOS Miko apps render edge-to-edge, so the translucent **status bar** (top) and **navigation bar** (bottom) overlay and occlude app content. This PR adds an engine-level **safe-area** concept: the root element is laid out inside an inset viewport rect, keeping content clear of the system bars.

The approach is layout-algorithm- and component-library-agnostic — it works uniformly for blank / Bootstrap / Ionic / tabs / sidemenu layouts, and updates automatically on rotation.

## Changes

**Engine core**
- `Common/SafeAreaInsets.cs` — new `readonly record struct` (logical px, Left/Top/Right/Bottom).
- `LayoutEngine.Layout` — accepts `SafeAreaInsets` (default `Zero`): origin shifts to `(left, top)` and the available size shrinks by `left+right` / `top+bottom`. Constraints, percentage sizes, and the `fixed`/`absolute` containing block all resolve against the inset rect.
- `MikoEngine` — `_safeArea` field, `SetSafeAreaInsets` (relayouts only on change, mirroring `SetViewportSize`), `SafeAreaInsets` property, and `GetRootBackgroundColor()` so the host can fill the system-bar bands with the content background color (rather than white).
- `MikoInteractionController.SetSafeAreaInsets` — lock-guarded forwarding to the engine.

**Platform hosts**
- Android `MikoSurfaceView` — `OnApplyWindowInsets` reads system-bar + display-cutout insets (API 30+) with a pre-30 fallback, converts to logical px, and pushes them to the engine (event-driven, handles rotation); clears the surface with the root background color.
- iOS `MikoGLView` — `SafeAreaInsetsDidChange` parity (UIKit insets are already logical points); same background fill.
- Multiplatform Android template `MainActivity` — `NoActionBar` theme + edge-to-edge (`SetDecorFitsSystemWindows` on API 30+) so an Ionic layout's own header is the only bar on screen.

## Background-band color (design choice)

The host fills the whole surface with the root element's background color, so the bands behind the system bars match the content background instead of showing white. A transparent root falls back to white.

> Note: making a colored toolbar bleed fully behind the status bar (true native-Ionic behavior) would require per-component `env(safe-area-inset-*)`-style padding. That is a larger follow-up and is intentionally out of scope here.

## Tests

11 new unit tests (`SafeAreaLayoutTests`, `SafeAreaInsetsEngineTests`) cover:
- origin offset + size shrink for non-zero insets
- zero-inset / default-overload regression (matches prior behavior exactly)
- `fixed` element resolving against the inset containing block
- relayout-on-change vs no-op-on-same-value semantics
- root background color exposure (resolved color / null for transparent)

All **876** tests pass. `Miko`, `Miko.Android`, and `Miko.iOS` build cleanly.
