### PR TITLE
fix(engine): make safe-area an env() opt-in so overlays cover full screen

### DIFF
--- a/src/Miko.Ionic/Components/Menu/MenuStyles.cs
+++ b/src/Miko.Ionic/Components/Menu/MenuStyles.cs
@@ -79,6 +79,12 @@ internal static class MenuStyles
                     ? new BorderSide(Length.Px(t.MenuBorderWidth), BorderStyle.Solid, t.MenuBorderColor)
                     : new BorderSide(Length.Px(0), BorderStyle.None, Color.Transparent),
                 ZIndex = 1001,
+                // The drawer panel itself spans the full screen height (so its surface reaches
+                // under the status/navigation bars), but its contents must clear those bars:
+                // env(safe-area-inset-*) pads the top/bottom. The drawer is a slide-in overlay,
+                // so unlike the host/backdrop it DOES opt into the inset for its content.
+                PaddingTop = Length.SafeAreaInsetTop,
+                PaddingBottom = Length.SafeAreaInsetBottom,
                 Transitions = new List<Transition>
                 {
                     Transition.For(x => x.Left).Duration(t.MenuAnimDuration).EaseOut(),

--- a/src/Miko.Ionic/Components/Page/PageStyles.cs
+++ b/src/Miko.Ionic/Components/Page/PageStyles.cs
@@ -46,13 +46,19 @@ internal static class PageStyles
                 ZIndex = 10,
             },
 
-            // ion-toolbar — full-width bar holding the title.
+            // ion-toolbar — full-width bar holding the title. The first toolbar in a header sits
+            // under the system status bar on mobile; env(safe-area-inset-*) pads its content down
+            // (and clear of a side notch) while the toolbar background still extends under the bar.
+            // On desktop / zero-inset platforms these env() lengths resolve to 0 (no-op).
             [".ion-toolbar"] = new()
             {
                 Display = Display.Block,
                 Width = Length.Percent(100),
                 BackgroundColor = t.ToolbarBackground,
                 Color = t.ToolbarColor,
+                PaddingTop = Length.SafeAreaInsetTop,
+                PaddingLeft = Length.SafeAreaInsetLeft,
+                PaddingRight = Length.SafeAreaInsetRight,
             },
 
             [".ion-toolbar .toolbar-container"] = new()

--- a/src/Miko.Ionic/Components/Tabs/TabStyles.cs
+++ b/src/Miko.Ionic/Components/Tabs/TabStyles.cs
@@ -39,7 +39,10 @@ internal static class TabStyles
                 OverflowY = Overflow.Hidden,
             },
 
-            // ion-tab-bar — the bar holding the tab buttons.
+            // ion-tab-bar — the bar holding the tab buttons. On mobile the bar sits at the bottom
+            // edge under the system navigation bar / home indicator; env(safe-area-inset-bottom)
+            // pads it so the buttons clear that band while the bar background fills behind it.
+            // Zero-inset platforms (desktop) resolve the env() length to 0 (no-op).
             [".ion-tab-bar"] = new()
             {
                 Display = Display.Flex,
@@ -50,6 +53,9 @@ internal static class TabStyles
                 BackgroundColor = t.TabBarBackground,
                 Color = t.TabBarColor,
                 TextAlign = TextAlign.Center,
+                PaddingBottom = Length.SafeAreaInsetBottom,
+                PaddingLeft = Length.SafeAreaInsetLeft,
+                PaddingRight = Length.SafeAreaInsetRight,
             },
 
             // slot="bottom" (default): border on top.

--- a/src/Miko/Common/Length.cs
+++ b/src/Miko/Common/Length.cs
@@ -16,18 +16,26 @@ public struct Length
     public static float RootFontSize { get; set; } = 16f;
 
     // 各单位分量。最终像素值 =
-    //   px + rem*RootFontSize + em*fontSize + number*fontSize + percent/100*containerSize。
+    //   px + rem*RootFontSize + em*fontSize + number*fontSize + percent/100*containerSize
+    //   + safe* * 对应方向的安全区 inset（在样式计算阶段由 ResolveSafeArea 折算）。
     // number 为无单位系数（用于无单位 line-height，按字体大小缩放）。
     private float _px;
     private float _em;
     private float _rem;
     private float _percent;
     private float _number;
+    // CSS env(safe-area-inset-*) 系数（通常为 1，可用 calc 缩放）。在已知安全区边距前不参与
+    // ToPixels；由 ResolveSafeArea 在样式计算阶段折算进 _px 后清零，使其后的布局透明无感。
+    private float _safeTop;
+    private float _safeRight;
+    private float _safeBottom;
+    private float _safeLeft;
     private bool _isAuto;
 
     public Length(float value, LengthUnit unit = LengthUnit.Px)
     {
         _px = _em = _rem = _percent = _number = 0;
+        _safeTop = _safeRight = _safeBottom = _safeLeft = 0;
         _isAuto = false;
 
         switch (unit)
@@ -49,6 +57,13 @@ public struct Length
     public static Length Number(float value) => new Length(value, LengthUnit.Number);
     public static Length Auto => new Length(0, LengthUnit.Auto);
 
+    // CSS env(safe-area-inset-*)：在已知安全区边距前为符号性长度，由 ResolveSafeArea 折算成 px。
+    // 内容元素用其做 padding（避开系统状态栏/导航栏），而全屏浮层不使用，从而仍覆盖整个屏幕。
+    public static Length SafeAreaInsetTop => new Length { _safeTop = 1 };
+    public static Length SafeAreaInsetRight => new Length { _safeRight = 1 };
+    public static Length SafeAreaInsetBottom => new Length { _safeBottom = 1 };
+    public static Length SafeAreaInsetLeft => new Length { _safeLeft = 1 };
+
     /// <summary>是否为 auto（auto 不参与算术，且不与具体长度混合）。</summary>
     public bool IsAuto => _isAuto;
 
@@ -66,6 +81,10 @@ public struct Length
             if (_rem != 0) nonZero++;
             if (_percent != 0) nonZero++;
             if (_number != 0) nonZero++;
+            if (_safeTop != 0) nonZero++;
+            if (_safeRight != 0) nonZero++;
+            if (_safeBottom != 0) nonZero++;
+            if (_safeLeft != 0) nonZero++;
             return nonZero <= 1;
         }
     }
@@ -104,6 +123,35 @@ public struct Length
         }
     }
 
+    /// <summary>该长度是否含未折算的 env(safe-area-inset-*) 分量。</summary>
+    public bool HasSafeAreaComponent =>
+        _safeTop != 0 || _safeRight != 0 || _safeBottom != 0 || _safeLeft != 0;
+
+    /// <summary>
+    /// 折算 env(safe-area-inset-*) 分量：将各方向系数乘以对应的安全区边距并并入 px 分量，
+    /// 然后清零安全区系数。其余分量（px/em/rem/percent/number）保持不变，因此可与
+    /// calc 风格的复合长度共存（如 <c>env(safe-area-inset-bottom) + 8px</c>）。
+    /// 在样式计算阶段调用一次即可，之后该长度的 ToPixels 行为与普通长度完全一致。
+    /// </summary>
+    public Length ResolveSafeArea(SafeAreaInsets insets)
+    {
+        if (_isAuto || !HasSafeAreaComponent) return this;
+
+        return new Length
+        {
+            _px = _px
+                + _safeTop * insets.Top
+                + _safeRight * insets.Right
+                + _safeBottom * insets.Bottom
+                + _safeLeft * insets.Left,
+            _em = _em,
+            _rem = _rem,
+            _percent = _percent,
+            _number = _number,
+            // 安全区分量已折算进 _px，清零避免重复折算。
+        };
+    }
+
     /// <summary>
     /// 计算实际像素值。
     /// </summary>
@@ -116,6 +164,8 @@ public struct Length
         if (_isAuto) return 0;
 
         float emBase = fontSize ?? RootFontSize;
+        // 未折算的 safe* 分量在此按 0 计（缺少安全区上下文）；正常路径下应已由
+        // ResolveSafeArea 在样式计算阶段折算进 _px。
         return _px
              + _rem * RootFontSize
              + _em * emBase
@@ -139,6 +189,10 @@ public struct Length
             _rem = x._rem + y._rem,
             _percent = x._percent + y._percent,
             _number = x._number + y._number,
+            _safeTop = x._safeTop + y._safeTop,
+            _safeRight = x._safeRight + y._safeRight,
+            _safeBottom = x._safeBottom + y._safeBottom,
+            _safeLeft = x._safeLeft + y._safeLeft,
         };
     }
 
@@ -152,6 +206,10 @@ public struct Length
             _rem = x._rem - y._rem,
             _percent = x._percent - y._percent,
             _number = x._number - y._number,
+            _safeTop = x._safeTop - y._safeTop,
+            _safeRight = x._safeRight - y._safeRight,
+            _safeBottom = x._safeBottom - y._safeBottom,
+            _safeLeft = x._safeLeft - y._safeLeft,
         };
     }
 
@@ -165,6 +223,10 @@ public struct Length
             _rem = -x._rem,
             _percent = -x._percent,
             _number = -x._number,
+            _safeTop = -x._safeTop,
+            _safeRight = -x._safeRight,
+            _safeBottom = -x._safeBottom,
+            _safeLeft = -x._safeLeft,
         };
     }
 
@@ -179,6 +241,10 @@ public struct Length
             _rem = x._rem * factor,
             _percent = x._percent * factor,
             _number = x._number * factor,
+            _safeTop = x._safeTop * factor,
+            _safeRight = x._safeRight * factor,
+            _safeBottom = x._safeBottom * factor,
+            _safeLeft = x._safeLeft * factor,
         };
     }
 
@@ -194,6 +260,10 @@ public struct Length
             _rem = x._rem / divisor,
             _percent = x._percent / divisor,
             _number = x._number / divisor,
+            _safeTop = x._safeTop / divisor,
+            _safeRight = x._safeRight / divisor,
+            _safeBottom = x._safeBottom / divisor,
+            _safeLeft = x._safeLeft / divisor,
         };
     }
 
@@ -204,6 +274,11 @@ public struct Length
         // 单一单位：沿用简洁写法（如 "16px"、"1.5rem"），保证与既有期望一致。
         if (IsSingleComponent)
         {
+            if (_safeTop != 0) return SafeAreaString("top", _safeTop);
+            if (_safeRight != 0) return SafeAreaString("right", _safeRight);
+            if (_safeBottom != 0) return SafeAreaString("bottom", _safeBottom);
+            if (_safeLeft != 0) return SafeAreaString("left", _safeLeft);
+
             return Unit switch
             {
                 LengthUnit.Px => $"{_px}px",
@@ -222,6 +297,16 @@ public struct Length
         if (_number != 0) parts.Add($"{_number}");
         if (_px != 0) parts.Add($"{_px}px");
         if (_percent != 0) parts.Add($"{_percent}%");
+        if (_safeTop != 0) parts.Add(SafeAreaString("top", _safeTop));
+        if (_safeRight != 0) parts.Add(SafeAreaString("right", _safeRight));
+        if (_safeBottom != 0) parts.Add(SafeAreaString("bottom", _safeBottom));
+        if (_safeLeft != 0) parts.Add(SafeAreaString("left", _safeLeft));
         return parts.Count == 0 ? "0px" : string.Join(" + ", parts);
+    }
+
+    private static string SafeAreaString(string side, float coeff)
+    {
+        string env = $"env(safe-area-inset-{side})";
+        return coeff == 1f ? env : $"{coeff} * {env}";
     }
 }

--- a/src/Miko/Layout/LayoutEngine.cs
+++ b/src/Miko/Layout/LayoutEngine.cs
@@ -17,26 +17,26 @@ public class LayoutEngine
     private readonly FlexLayout _flexLayout = new();
     private readonly TableLayout _tableLayout = new();
 
+    // 当前布局的安全区边距。在样式计算阶段用于折算各元素的 env(safe-area-inset-*) 长度。
+    // 不内缩视口本身——视口始终为全屏，仅“声明了 env() 的内容元素”据此添加内边距，
+    // 从而全屏浮层（菜单遮罩等）仍覆盖整个屏幕（见 ISSUE-054）。
+    private SafeAreaInsets _safeArea;
+
     /// <summary>
     /// 执行布局计算
     /// </summary>
     /// <param name="safeArea">
-    /// 安全区边距（逻辑像素）。非零时根元素在内缩后的视口矩形内布局，避免内容被
-    /// 系统状态栏/导航栏遮盖。默认无内缩（桌面）。
+    /// 安全区边距（逻辑像素）。通过 CSS <c>env(safe-area-inset-*)</c> 暴露给内容元素，
+    /// 使其可主动添加内边距避开系统状态栏/导航栏；视口本身不内缩。默认无安全区（桌面）。
     /// </param>
     public LayoutBox Layout(Element root, List<StyleSheet> styleSheets, float viewportWidth, float viewportHeight,
         SafeAreaInsets safeArea = default)
     {
-        // 安全区内缩后的可用视口：原点右下移 (Left, Top)，尺寸减去左右/上下边距。
-        // 百分比尺寸、约束、绝对/固定定位的包含块都以此为基准，使整棵树落在安全区内。
-        float originX = safeArea.Left;
-        float originY = safeArea.Top;
-        float availableWidth = Math.Max(0, viewportWidth - safeArea.Left - safeArea.Right);
-        float availableHeight = Math.Max(0, viewportHeight - safeArea.Top - safeArea.Bottom);
+        _safeArea = safeArea;
 
-        // 1. 样式计算：为每个元素计算最终样式（视口尺寸用安全区内的可用尺寸，
-        //    使 100vw/100% 不会把内容撑到系统栏下方）。
-        var viewport = new ViewportInfo(availableWidth, availableHeight);
+        // 视口为全屏：env(safe-area-inset-*) 由各内容元素按需折算成内边距，浮层不受影响。
+        // 1. 样式计算：为每个元素计算最终样式（并折算其 env() 安全区分量）。
+        var viewport = new ViewportInfo(viewportWidth, viewportHeight);
         ComputeStyles(root, styleSheets, viewport);
 
         // 2. 构建布局树：根据 display 属性过滤和组织
@@ -47,13 +47,12 @@ public class LayoutEngine
             throw new InvalidOperationException("Failed to build layout tree");
         }
 
-        // 3. 布局计算：计算每个盒子的位置和尺寸（从安全区原点开始）
-        var constraints = new LayoutConstraints(availableWidth, availableHeight);
-        CalculateLayout(layoutRoot, constraints, originX, originY);
+        // 3. 布局计算：从视口原点 (0,0) 开始，覆盖整个视口。
+        var constraints = new LayoutConstraints(viewportWidth, viewportHeight);
+        CalculateLayout(layoutRoot, constraints, 0f, 0f);
 
-        // 4. 定位调整：处理 relative/absolute 定位的偏移
-        // 根元素的初始包含块为安全区内缩后的视口
-        var viewportBlock = new RectF(originX, originY, availableWidth, availableHeight);
+        // 4. 定位调整：处理 relative/absolute 定位的偏移。根包含块为整个视口。
+        var viewportBlock = new RectF(0f, 0f, viewportWidth, viewportHeight);
         ApplyPositioning(layoutRoot, viewportBlock);
 
         return layoutRoot;
@@ -170,6 +169,9 @@ public class LayoutEngine
     private void ComputeStyles(Element element, List<StyleSheet> styleSheets, ViewportInfo viewport)
     {
         var computedStyle = _styleResolver.Resolve(element, styleSheets, viewport);
+
+        // 折算该元素声明的 env(safe-area-inset-*) 长度为像素（桌面/零安全区时为空操作）。
+        computedStyle.ResolveSafeArea(_safeArea);
 
         // 创建布局盒子并关联
         element.LayoutBox = new LayoutBox
@@ -304,6 +306,7 @@ public class LayoutEngine
 
         var pseudoElement = new PseudoElement { TextContent = matchedStyle.Content, Type = type };
         var computedStyle = ComputedStyle.FromStyle(matchedStyle);
+        computedStyle.ResolveSafeArea(_safeArea);
 
         pseudoElement.LayoutBox = new LayoutBox
         {

--- a/src/Miko/Styling/ComputedStyle.cs
+++ b/src/Miko/Styling/ComputedStyle.cs
@@ -272,4 +272,41 @@ public class ComputedStyle : Style
 
         return computed;
     }
+
+    /// <summary>
+    /// 折算所有长度属性中的 env(safe-area-inset-*) 分量为像素。由布局引擎在样式计算阶段、
+    /// 已知平台安全区边距时调用。仅影响显式使用了 env() 的属性（其余长度原样返回），
+    /// 因此对桌面（零安全区）或未使用 env() 的元素完全无副作用。
+    /// <para>
+    /// 注意：这只解析“内容元素主动声明的”安全区内边距等；不会内缩整个视口，故全屏浮层
+    /// （未使用 env() 的 absolute 100%×100% 元素）仍覆盖整个屏幕（见 ISSUE-054）。
+    /// </para>
+    /// </summary>
+    public void ResolveSafeArea(SafeAreaInsets insets)
+    {
+        if (insets.IsZero) return;
+
+        PaddingTop = PaddingTop.ResolveSafeArea(insets);
+        PaddingRight = PaddingRight.ResolveSafeArea(insets);
+        PaddingBottom = PaddingBottom.ResolveSafeArea(insets);
+        PaddingLeft = PaddingLeft.ResolveSafeArea(insets);
+
+        MarginTop = MarginTop.ResolveSafeArea(insets);
+        MarginRight = MarginRight.ResolveSafeArea(insets);
+        MarginBottom = MarginBottom.ResolveSafeArea(insets);
+        MarginLeft = MarginLeft.ResolveSafeArea(insets);
+
+        Top = Top.ResolveSafeArea(insets);
+        Right = Right.ResolveSafeArea(insets);
+        Bottom = Bottom.ResolveSafeArea(insets);
+        Left = Left.ResolveSafeArea(insets);
+
+        Width = Width.ResolveSafeArea(insets);
+        Height = Height.ResolveSafeArea(insets);
+        MinWidth = MinWidth.ResolveSafeArea(insets);
+        MinHeight = MinHeight.ResolveSafeArea(insets);
+        MaxWidth = MaxWidth.ResolveSafeArea(insets);
+        MaxHeight = MaxHeight.ResolveSafeArea(insets);
+        FlexBasis = FlexBasis.ResolveSafeArea(insets);
+    }
 }

--- a/tests/Miko.Tests/Common/LengthTests.cs
+++ b/tests/Miko.Tests/Common/LengthTests.cs
@@ -353,4 +353,72 @@ public class LengthTests
         // 复合长度列出各非零分量（顺序：em, rem, px, %）
         len.ToString().ShouldBe("1.5em + 0.5rem + 2px");
     }
+
+    // ---- env(safe-area-inset-*) support (ISSUE-054) ----
+
+    [Fact]
+    public void SafeAreaInset_HasSafeAreaComponent()
+    {
+        Length.SafeAreaInsetTop.HasSafeAreaComponent.ShouldBeTrue();
+        Length.SafeAreaInsetBottom.HasSafeAreaComponent.ShouldBeTrue();
+        Length.Px(10).HasSafeAreaComponent.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SafeAreaInset_BeforeResolve_ToPixelsIsZero()
+    {
+        // Unresolved env() has no safe-area context yet, so it contributes 0 px.
+        Length.SafeAreaInsetTop.ToPixels(0).ShouldBe(0);
+    }
+
+    [Fact]
+    public void ResolveSafeArea_FoldsEachSideIntoPixels()
+    {
+        var insets = new SafeAreaInsets(12, 48, 8, 24);
+
+        Length.SafeAreaInsetTop.ResolveSafeArea(insets).ToPixels(0).ShouldBe(48);
+        Length.SafeAreaInsetRight.ResolveSafeArea(insets).ToPixels(0).ShouldBe(8);
+        Length.SafeAreaInsetBottom.ResolveSafeArea(insets).ToPixels(0).ShouldBe(24);
+        Length.SafeAreaInsetLeft.ResolveSafeArea(insets).ToPixels(0).ShouldBe(12);
+    }
+
+    [Fact]
+    public void ResolveSafeArea_CompositeWithPx_AddsBoth()
+    {
+        // calc(env(safe-area-inset-bottom) + 8px) with a 24px bottom inset => 32px.
+        var len = Length.SafeAreaInsetBottom + Length.Px(8);
+        var resolved = len.ResolveSafeArea(new SafeAreaInsets(0, 0, 0, 24));
+
+        resolved.ToPixels(0).ShouldBe(32);
+        resolved.HasSafeAreaComponent.ShouldBeFalse();   // folded in, no longer symbolic
+    }
+
+    [Fact]
+    public void ResolveSafeArea_ZeroInsets_LeavesNonSafeComponentsUntouched()
+    {
+        var len = Length.SafeAreaInsetTop + Length.Px(5);
+        // Zero insets: the env() part contributes nothing, the px part remains.
+        var resolved = len.ResolveSafeArea(SafeAreaInsets.Zero);
+
+        resolved.ToPixels(0).ShouldBe(5);
+    }
+
+    [Fact]
+    public void ResolveSafeArea_Idempotent()
+    {
+        var insets = new SafeAreaInsets(0, 48, 0, 0);
+        var once = Length.SafeAreaInsetTop.ResolveSafeArea(insets);
+        var twice = once.ResolveSafeArea(insets);
+
+        // After folding, re-resolving must not double-count.
+        twice.ToPixels(0).ShouldBe(48);
+    }
+
+    [Fact]
+    public void SafeAreaInset_ToString_RendersEnv()
+    {
+        Length.SafeAreaInsetTop.ToString().ShouldBe("env(safe-area-inset-top)");
+        (Length.SafeAreaInsetBottom + Length.Px(8)).ToString()
+            .ShouldBe("8px + env(safe-area-inset-bottom)");
+    }
 }

--- a/tests/Miko.Tests/Core/SafeAreaInsetsEngineTests.cs
+++ b/tests/Miko.Tests/Core/SafeAreaInsetsEngineTests.cs
@@ -9,9 +9,10 @@ using SkiaSharp;
 namespace Miko.Tests.Core;
 
 /// <summary>
-/// Tests for <see cref="MikoEngine.SetSafeAreaInsets"/>: a change relays out the tree so the
-/// root content is inset into the safe area, repeated identical values are a no-op, and the
-/// root background color is exposed so the host can fill the system-bar bands to match.
+/// Tests for <see cref="MikoEngine.SetSafeAreaInsets"/>: a change relays out the tree, repeated
+/// identical values are a no-op, and the root background color is exposed so the host can fill
+/// the system-bar bands to match. Under the ISSUE-054 model the viewport is NOT shrunk — the
+/// root still fills the full screen; content opts into the inset via env(safe-area-inset-*).
 /// </summary>
 public class SafeAreaInsetsEngineTests : IDisposable
 {
@@ -48,9 +49,33 @@ public class SafeAreaInsetsEngineTests : IDisposable
         }
     };
 
-    [Fact]
-    public void SetSafeAreaInsets_RelaysOutRootIntoSafeArea()
+    // A root that pads its content into the safe area via env(safe-area-inset-*).
+    // box-sizing:border-box keeps the border box at viewport size while the content box insets.
+    private static StyleSheet SafeAreaPaddedSheet(Color bg) => new()
     {
+        Rules = new List<StyleRule>
+        {
+            new()
+            {
+                Selector = new ClassSelector("root"),
+                Style = new Style
+                {
+                    Display = Display.Block,
+                    BoxSizing = BoxSizing.BorderBox,
+                    Width = Length.Percent(100),
+                    Height = Length.Percent(100),
+                    BackgroundColor = bg,
+                    PaddingTop = Length.SafeAreaInsetTop,
+                    PaddingBottom = Length.SafeAreaInsetBottom,
+                },
+            },
+        }
+    };
+
+    [Fact]
+    public void SetSafeAreaInsets_RootStillFillsFullViewport()
+    {
+        // The viewport is not shrunk: a full-size root without env() padding fills the screen.
         var root = new DivElement { Class = "root" };
         var engine = new MikoEngine();
         engine.Initialize(root, new List<StyleSheet> { RootSheet(new Color(255, 255, 255)) }, _canvas, 390, 844);
@@ -60,7 +85,26 @@ public class SafeAreaInsetsEngineTests : IDisposable
 
         var layout = engine.GetCurrentLayout();
         layout.ShouldNotBeNull();
-        layout!.BoxModel.Content.Top.ShouldBe(48f);
+        layout!.BoxModel.Content.Top.ShouldBe(0f);
+        layout.BoxModel.Content.Height.ShouldBe(844f);
+    }
+
+    [Fact]
+    public void SetSafeAreaInsets_EnvPaddingInsetsContent()
+    {
+        // A root that opts into env() padding gets its content box inset after a relayout.
+        var root = new DivElement { Class = "root" };
+        var engine = new MikoEngine();
+        engine.Initialize(root, new List<StyleSheet> { SafeAreaPaddedSheet(new Color(255, 255, 255)) }, _canvas, 390, 844);
+
+        engine.SetSafeAreaInsets(new SafeAreaInsets(0, 48, 0, 24));
+        engine.Render(_canvas);
+
+        var layout = engine.GetCurrentLayout();
+        layout.ShouldNotBeNull();
+        layout!.BoxModel.BorderBox.Top.ShouldBe(0f);
+        layout.BoxModel.BorderBox.Height.ShouldBe(844f);
+        layout.BoxModel.Content.Top.ShouldBe(48f);
         layout.BoxModel.Content.Height.ShouldBe(844f - 48f - 24f);
     }
 
@@ -100,13 +144,14 @@ public class SafeAreaInsetsEngineTests : IDisposable
     {
         var root = new DivElement { Class = "root" };
         var engine = new MikoEngine();
-        engine.Initialize(root, new List<StyleSheet> { RootSheet(new Color(255, 255, 255)) }, _canvas, 390, 844);
+        engine.Initialize(root, new List<StyleSheet> { SafeAreaPaddedSheet(new Color(255, 255, 255)) }, _canvas, 390, 844);
 
         engine.SetSafeAreaInsets(new SafeAreaInsets(0, 48, 0, 24));
         engine.Render(_canvas);
         var before = engine.GetCurrentLayout();
 
-        // A changed value invalidates the root, so the next Update produces a fresh layout tree.
+        // A changed value invalidates the root, so the next Update produces a fresh layout tree
+        // with the new inset folded into the content padding.
         engine.SetSafeAreaInsets(new SafeAreaInsets(0, 60, 0, 30));
         engine.Update(_canvas);
         engine.GetCurrentLayout().ShouldNotBeSameAs(before);

--- a/tests/Miko.Tests/Layout/SafeAreaLayoutTests.cs
+++ b/tests/Miko.Tests/Layout/SafeAreaLayoutTests.cs
@@ -8,11 +8,11 @@ using Shouldly;
 namespace Miko.Tests.Layout;
 
 /// <summary>
-/// Verifies safe-area inset handling in <see cref="LayoutEngine.Layout"/>. When non-zero insets
-/// are supplied (from a mobile host's system-bar insets), the root is laid out inside the
-/// inset viewport rect — origin shifts to (left, top) and the available size shrinks by
-/// left+right / top+bottom — so content is not occluded by the status bar / navigation bar.
-/// Zero insets must reproduce the pre-safe-area behavior exactly.
+/// Verifies safe-area handling in <see cref="LayoutEngine.Layout"/>. Unlike the original
+/// (ISSUE-052) design that shrank the whole viewport to the inset rect, the layout viewport
+/// now stays full-screen (origin 0,0; full width/height). Safe-area insets are exposed through
+/// CSS <c>env(safe-area-inset-*)</c> length components that *content* opts into (via padding),
+/// so full-screen overlays still cover the entire screen (see ISSUE-054).
 /// </summary>
 public class SafeAreaLayoutTests
 {
@@ -39,8 +39,32 @@ public class SafeAreaLayoutTests
         }
     };
 
-    // A fixed-position child pinned to top:0 left:0 — resolves against the (inset) viewport block.
-    private static StyleSheet FixedChildSheet() => new()
+    // A root that pads its content into the safe area via env(safe-area-inset-*).
+    // box-sizing:border-box keeps the border box at viewport size while the content box insets.
+    private static StyleSheet SafeAreaPaddedSheet() => new()
+    {
+        Rules = new List<StyleRule>
+        {
+            new()
+            {
+                Selector = new ClassSelector("root"),
+                Style = new Style
+                {
+                    Display = Display.Block,
+                    BoxSizing = BoxSizing.BorderBox,
+                    Width = Length.Percent(100),
+                    Height = Length.Percent(100),
+                    PaddingTop = Length.SafeAreaInsetTop,
+                    PaddingBottom = Length.SafeAreaInsetBottom,
+                    PaddingLeft = Length.SafeAreaInsetLeft,
+                    PaddingRight = Length.SafeAreaInsetRight,
+                },
+            },
+        }
+    };
+
+    // A full-screen absolutely-positioned overlay (like the menu backdrop): no env() padding.
+    private static StyleSheet OverlaySheet() => new()
     {
         Rules = new List<StyleRule>
         {
@@ -55,12 +79,12 @@ public class SafeAreaLayoutTests
             },
             new()
             {
-                Selector = new ClassSelector("pinned"),
+                Selector = new ClassSelector("backdrop"),
                 Style = new Style
                 {
-                    Position = Position.Fixed,
+                    Position = Position.Absolute,
                     Top = Length.Px(0), Left = Length.Px(0),
-                    Width = Length.Px(50), Height = Length.Px(50),
+                    Width = Length.Percent(100), Height = Length.Percent(100),
                 },
             },
         }
@@ -85,7 +109,6 @@ public class SafeAreaLayoutTests
         var layout = _layoutEngine.Layout(root, new List<StyleSheet> { FullSizeRootSheet() },
             ViewportW, ViewportH, SafeAreaInsets.Zero);
 
-        // Default-parameter overload (no insets) must match zero insets exactly.
         layout.BoxModel.Content.Left.ShouldBe(0f);
         layout.BoxModel.Content.Top.ShouldBe(0f);
         layout.BoxModel.Content.Width.ShouldBe(ViewportW);
@@ -108,55 +131,78 @@ public class SafeAreaLayoutTests
     }
 
     [Fact]
-    public void NonZeroInsets_OffsetOriginAndShrinkSize()
+    public void NonZeroInsets_RootStillFillsFullViewport()
     {
+        // A full-size root WITHOUT env() padding must still fill the entire screen even when
+        // insets are non-zero — the viewport is not shrunk. This is what lets overlays cover
+        // the whole screen.
         const float top = 48f, bottom = 24f, left = 12f, right = 8f;
         var root = new DivElement { Class = "root" };
 
         var layout = _layoutEngine.Layout(root, new List<StyleSheet> { FullSizeRootSheet() },
             ViewportW, ViewportH, new SafeAreaInsets(left, top, right, bottom));
 
-        // Origin shifts into the safe area...
-        layout.BoxModel.Content.Left.ShouldBe(left);
+        layout.BoxModel.Content.Left.ShouldBe(0f);
+        layout.BoxModel.Content.Top.ShouldBe(0f);
+        layout.BoxModel.Content.Width.ShouldBe(ViewportW);
+        layout.BoxModel.Content.Height.ShouldBe(ViewportH);
+    }
+
+    [Fact]
+    public void EnvPadding_InsetsContentBox()
+    {
+        // A root that opts into env(safe-area-inset-*) padding: its border box still fills the
+        // viewport, but its content box is inset by the resolved insets.
+        const float top = 48f, bottom = 24f, left = 12f, right = 8f;
+        var root = new DivElement { Class = "root" };
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { SafeAreaPaddedSheet() },
+            ViewportW, ViewportH, new SafeAreaInsets(left, top, right, bottom));
+
+        // Border box covers the whole screen...
+        layout.BoxModel.BorderBox.Top.ShouldBe(0f);
+        layout.BoxModel.BorderBox.Height.ShouldBe(ViewportH);
+        layout.BoxModel.BorderBox.Width.ShouldBe(ViewportW);
+        // ...while the content box is padded into the safe area.
         layout.BoxModel.Content.Top.ShouldBe(top);
-        // ...and 100% width/height resolve against the inset (available) size.
-        layout.BoxModel.Content.Width.ShouldBe(ViewportW - left - right);
-        layout.BoxModel.Content.Height.ShouldBe(ViewportH - top - bottom);
-        // The content stays clear of the bottom/right system bars.
+        layout.BoxModel.Content.Left.ShouldBe(left);
         layout.BoxModel.Content.Bottom.ShouldBe(ViewportH - bottom, 0.5f);
         layout.BoxModel.Content.Right.ShouldBe(ViewportW - right, 0.5f);
     }
 
     [Fact]
-    public void TopInsetOnly_PushesContentBelowStatusBar()
+    public void EnvPadding_TopInsetOnly()
     {
         const float top = 48f;
         var root = new DivElement { Class = "root" };
 
-        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { FullSizeRootSheet() },
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { SafeAreaPaddedSheet() },
             ViewportW, ViewportH, new SafeAreaInsets(0, top, 0, 0));
 
-        layout.BoxModel.Content.Top.ShouldBe(top);
-        layout.BoxModel.Content.Width.ShouldBe(ViewportW);          // no horizontal inset
-        layout.BoxModel.Content.Height.ShouldBe(ViewportH - top);   // only the top is reserved
+        layout.BoxModel.Content.Top.ShouldBe(top);          // only the top is reserved
+        layout.BoxModel.Content.Left.ShouldBe(0f);
+        layout.BoxModel.Content.Height.ShouldBe(ViewportH - top);
+        layout.BoxModel.Content.Width.ShouldBe(ViewportW);  // no horizontal inset
     }
 
     [Fact]
-    public void FixedChild_ResolvesAgainstInsetViewportBlock()
+    public void Overlay_CoversFullScreen_DespiteInsets()
     {
-        const float top = 48f, left = 12f;
+        // The regression ISSUE-054 fixes: a full-screen overlay (menu backdrop) must cover the
+        // entire screen even with non-zero insets, so the dim layer reaches under the system bars.
+        const float top = 48f, bottom = 24f;
         var root = new DivElement { Class = "root" };
-        var pinned = new DivElement { Class = "pinned" };
-        root.AddChild(pinned);
+        var backdrop = new DivElement { Class = "backdrop" };
+        root.AddChild(backdrop);
 
-        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { FixedChildSheet() },
-            ViewportW, ViewportH, new SafeAreaInsets(left, top, 0, 0));
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { OverlaySheet() },
+            ViewportW, ViewportH, new SafeAreaInsets(0, top, 0, bottom));
 
-        var pinnedBox = FindByClass(layout, "pinned");
-        pinnedBox.ShouldNotBeNull();
-        // A fixed top:0 left:0 element pins to the safe-area corner, not the screen corner,
-        // so it isn't drawn under the status bar.
-        pinnedBox!.BoxModel.MarginBox.Top.ShouldBe(top);
-        pinnedBox.BoxModel.MarginBox.Left.ShouldBe(left);
+        var backdropBox = FindByClass(layout, "backdrop");
+        backdropBox.ShouldNotBeNull();
+        backdropBox!.BoxModel.BorderBox.Top.ShouldBe(0f);
+        backdropBox.BoxModel.BorderBox.Left.ShouldBe(0f);
+        backdropBox.BoxModel.BorderBox.Width.ShouldBe(ViewportW);
+        backdropBox.BoxModel.BorderBox.Height.ShouldBe(ViewportH);
     }
 }


### PR DESCRIPTION
Resolves ISSUE-054.

## Problem

The safe-area implementation from ISSUE-052 shrank the entire layout viewport to the inset rect at the root. This broke full-screen overlays: `.ion-menu-host` and `.ion-menu-backdrop` are `position:absolute; width:100%; height:100%`, so when laid out inside the shrunk rect their backdrop only covered the inset area — the status-bar / nav-bar bands stayed undimmed when the drawer opened.

## Approach

Switch to the CSS-correct model (matching Ionic): the layout viewport stays full-screen, and safe-area insets are exposed through `env(safe-area-inset-*)` length components that content opts into via padding. Overlays do not opt in, so they naturally cover the entire screen.

## Engine changes

- **`Length`** — adds `SafeAreaInsetTop/Right/Bottom/Left` factories and four matching coefficient components. `ResolveSafeArea(insets)` folds them into the px component (clearing the symbolic ones) and supports calc-style composites such as `env(safe-area-inset-bottom) + 8px`. Arithmetic operators and `ToString` propagate the new components.
- **`ComputedStyle.ResolveSafeArea`** — walks padding / margin / inset / width / height / min-max / flex-basis lengths.
- **`LayoutEngine`** — removes the root viewport inset; the viewport is back to `(0, 0, viewportW, viewportH)`. During `ComputeStyles` (and `CreatePseudoElementBox`) every computed style has its env() lengths resolved against the active insets, so the resolution is invisible to layout-time `ToPixels` and a no-op on desktop / zero-inset platforms.

## Ionic style updates

- `.ion-toolbar` — `padding-top: env(safe-area-inset-top)` plus left/right; the toolbar background still extends under the status bar.
- `.ion-tab-bar` — `padding-bottom: env(safe-area-inset-bottom)` plus left/right so buttons clear the navigation bar / home indicator.
- `.ion-menu-inner` — `padding-top` + `padding-bottom` env() insets so the drawer content avoids both bars.
- `.ion-menu-host` and `.ion-menu-backdrop` — deliberately do **not** opt in, so the dim layer covers the full screen.

## Test changes

- `SafeAreaLayoutTests` — rewritten for the new model: a full-size root *without* env() padding fills the entire screen even with non-zero insets; with env() padding the border box stays at the viewport while the content box insets; **a regression test verifies that an overlay covers the full screen under non-zero insets**.
- `SafeAreaInsetsEngineTests` — updated to assert the root no longer shrinks; `SetSafeAreaInsets` still drives a relayout for elements that do opt in.
- `LengthTests` — 7 new cases covering `HasSafeAreaComponent`, per-side resolution, calc composites, idempotency of `ResolveSafeArea`, and the new env() `ToString` rendering.

Full suite: 885 / 885 passing. The Android `MikoApp2.Ionic` sidemenu sample and the multiplatform template build clean.

## Backwards compatibility

`SetSafeAreaInsets` / `GetRootBackgroundColor` and the platform hosts (Android `MikoSurfaceView`, iOS `MikoGLView`, `MikoInteractionController.SetSafeAreaInsets`) are unchanged. The host still clears the GL surface with the root background color, which now naturally covers the system-bar bands because the root spans the full screen. Apps that previously relied on the implicit root inset must opt in with `box-sizing: border-box` + `padding: env(safe-area-inset-*)` (or use the Ionic components, which already do).