### PR TITLE
Template identity per project + readable Android status-bar icons

### DIFF
--- a/src/Miko.Android/MikoSurfaceView.cs
+++ b/src/Miko.Android/MikoSurfaceView.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Android.Content;
 using Android.Util;
 using Android.Views;
+using Miko.Common;
 using Miko.Events;
 using Miko.Hosting;
 using Miko.Platform;
@@ -23,10 +24,19 @@ public class MikoSurfaceView : SKGLSurfaceView
     private float _lastFrameTime;
     private bool _initialized;
 
+    // 用于在每帧根据根背景色亮度调整状态栏/导航栏图标外观（深/浅）。
+    // 持有 Activity 引用以便 Post 到 UI 线程修改 Window；上一次应用的“浅色背景”判定
+    // 用于去抖，避免每帧都触发跨线程调用。
+    // 完整限定 Activity 类型——本文件 using 了 System.Diagnostics（Stopwatch），与
+    // System.Diagnostics.Activity 同名冲突。
+    private readonly global::Android.App.Activity? _activity;
+    private bool? _lastLightAppearance;
+
     public MikoSurfaceView(Context context, MikoAppContext appContext) : base(context)
     {
         _context = appContext;
         _controller = appContext.Controller;
+        _activity = context as global::Android.App.Activity;
         _density = context.Resources?.DisplayMetrics?.Density ?? 1f;
         Log.Info("MikoSurfaceView",
             $"Screen density: {_density}, Physical size: {context.Resources?.DisplayMetrics?.WidthPixels}×{context.Resources?.DisplayMetrics?.HeightPixels}");
@@ -105,7 +115,82 @@ public class MikoSurfaceView : SKGLSurfaceView
             c.Scale(_density);
             _controller.Engine.Render(c);
             c.Restore();
+
+            // 根据根背景色亮度切换系统栏图标颜色。浅色背景下用深色图标（避免“白底白字”
+            // 看不见状态栏内容，见 ISSUE-056），深色背景下用浅色图标。无背景时回退到浅色
+            // 背景规则（与 surface 清屏的白色保持一致）。
+            SyncSystemBarAppearance(rootBg ?? Color.White);
         });
+    }
+
+    /// <summary>
+    /// 根据给定背景色亮度切换状态栏 / 导航栏图标外观（深/浅）。
+    /// 该调用必须在 UI 线程上执行（修改 Window/View 系统 UI 标志），因此从 GL 线程通过
+    /// <see cref="global::Android.App.Activity.RunOnUiThread(Action)"/> 转发；并按上一次
+    /// 应用的判定去抖，避免每帧都跨线程调度。
+    /// </summary>
+    private void SyncSystemBarAppearance(Color background)
+    {
+        if (_activity == null) return;
+
+        // 透明背景时把它视作浅色（与 GL clear 的白色回退一致）。
+        bool useDarkIcons = background.A == 0 || IsLight(background);
+        if (_lastLightAppearance == useDarkIcons) return;
+        _lastLightAppearance = useDarkIcons;
+
+        _activity.RunOnUiThread(() =>
+        {
+            var window = _activity.Window;
+            if (window == null) return;
+
+            // 各分支均已通过 Build.VERSION.SdkInt 守卫；分析器无法跨匿名方法跟踪平台版本，
+            // 故在此处显式抑制 CA1416/CA1422（与本文件 OnApplyWindowInsets 中相同模式）。
+#pragma warning disable CA1416, CA1422
+            if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.R)
+            {
+                // API 30+：通过 WindowInsetsController 切换系统栏外观。
+                // LightStatusBars / LightNavigationBars = 浅色背景下使用深色图标。
+                var controller = window.InsetsController;
+                if (controller == null) return;
+
+                var mask = WindowInsetsControllerAppearance.LightStatusBars
+                         | WindowInsetsControllerAppearance.LightNavigationBars;
+                var appearance = useDarkIcons ? mask : WindowInsetsControllerAppearance.None;
+                controller.SetSystemBarsAppearance((int)appearance, (int)mask);
+            }
+            else if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.M)
+            {
+                // API 23–29：通过 DecorView 的 SystemUiFlags 标志切换。
+                // Android O+ (API 26) 起还支持 LightNavigationBar；早于 O 时仅切换状态栏。
+                var decor = window.DecorView;
+                var flags = decor.SystemUiFlags;
+
+                if (useDarkIcons) flags |= SystemUiFlags.LightStatusBar;
+                else flags &= ~SystemUiFlags.LightStatusBar;
+
+                if (global::Android.OS.Build.VERSION.SdkInt >= global::Android.OS.BuildVersionCodes.O)
+                {
+                    if (useDarkIcons) flags |= SystemUiFlags.LightNavigationBar;
+                    else flags &= ~SystemUiFlags.LightNavigationBar;
+                }
+
+                decor.SystemUiFlags = flags;
+            }
+#pragma warning restore CA1416, CA1422
+        });
+    }
+
+    /// <summary>
+    /// 用 sRGB 相对亮度公式判定颜色是否“浅”——结果用于决定状态栏图标颜色。
+    /// 阈值 0.5 与 Material 设计指南一致；alpha 不参与（系统栏的内容色仅取决于其后方
+    /// surface 的实际着色，alpha 已在调用前被处理）。
+    /// </summary>
+    private static bool IsLight(Color c)
+    {
+        // 0.299*R + 0.587*G + 0.114*B 是 ITU-R BT.601 的快速近似（避免 sRGB 解码），
+        // 用于浅/深判定足够稳健。
+        float luminance = (0.299f * c.R + 0.587f * c.G + 0.114f * c.B) / 255f;
+        return luminance > 0.5f;
     }
 
     public override bool OnTouchEvent(MotionEvent? e)

--- a/templates/MikoMultiplatformApp/.template.config/template.json
+++ b/templates/MikoMultiplatformApp/.template.config/template.json
@@ -24,6 +24,31 @@
         { "choice": "tabs",     "description": "Ionic bottom tab bar with three routed tab pages." }
       ]
     },
+    "displayName": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "Human-readable application display name (Android label, iOS bundle display name, window title). Defaults to the project name.",
+      "defaultValue": "",
+      "replaces": ""
+    },
+    "appDisplayName": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "displayName",
+        "fallbackVariableName": "name"
+      },
+      "replaces": "Miko Multiplatform App"
+    },
+    "appIdSuffix": {
+      "type": "generated",
+      "generator": "casing",
+      "parameters": {
+        "source": "name",
+        "toLower": true
+      },
+      "replaces": "multiplatformapp"
+    },
     "useBlank":    { "type": "computed", "value": "(layout == \"blank\")" },
     "useSidemenu": { "type": "computed", "value": "(layout == \"sidemenu\")" },
     "useTabs":     { "type": "computed", "value": "(layout == \"tabs\")" },

--- a/templates/MikoRazorApp/.template.config/template.json
+++ b/templates/MikoRazorApp/.template.config/template.json
@@ -37,6 +37,22 @@
         { "choice": "tabs",     "description": "Ionic bottom tab bar with three routed tab pages." }
       ]
     },
+    "displayName": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "Human-readable application display name (window title). Defaults to the project name.",
+      "defaultValue": "",
+      "replaces": ""
+    },
+    "appDisplayName": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "displayName",
+        "fallbackVariableName": "name"
+      },
+      "replaces": "Miko Razor App"
+    },
     "useBlank":    { "type": "computed", "value": "(layout == \"blank\")" },
     "useSidemenu": { "type": "computed", "value": "(layout == \"sidemenu\")" },
     "useTabs":     { "type": "computed", "value": "(layout == \"tabs\")" },


### PR DESCRIPTION
Bundles two small but related polish fixes for newly-scaffolded apps. Resolves ISSUE-055 and ISSUE-056.

## ISSUE-055 — derive app id and display name from project name

`dotnet new`'s `sourceName: MikoMultiplatformApp` only rewrites the PascalCase token, so the lowercase bundle-id suffix and the spaced display string stayed hardcoded. Every generated project ended up with `com.miko.multiplatformapp` as its Android `applicationId` / iOS `CFBundleIdentifier` and "Miko Multiplatform App" as its label — installing two of them on a device collided on the same id.

Two generated symbols cover it without touching any source file:

- **`appDisplayName`** — `coalesce` over an optional `--displayName` parameter, falling back to `name`. Replaces the literal "Miko Multiplatform App" / "Miko Razor App" wherever it appears: Android `android:label` and `[Activity(Label = ...)]`, iOS `CFBundleDisplayName`, `builder.UseTitle(...)`, and the README title.
- **`appIdSuffix`** — `casing` generator, lowercased `name`. Rewrites the suffix so the id becomes `com.miko.<name>`. Multiplatform template only — the Razor/WinUI template has no bundle id.

Verified by instantiating both templates locally:

```
dotnet new miko-multiplatform -n MyApp1 --layout sidemenu
  -> ApplicationId = com.miko.myapp1, label/title = "MyApp1"

dotnet new miko-multiplatform -n Shopping --layout tabs --displayName "My Shopping List"
  -> ApplicationId = com.miko.shopping (from -n, independent of display name)
  -> label/title/CFBundleDisplayName = "My Shopping List"
  -> namespaces stay Shopping / Shopping.Android (no over-replacement)

dotnet new miko-razor -n MyRazorApp --displayName "My Razor Demo"
  -> UseTitle("My Razor Demo")
```

Leftover-literal scan came back clean. Note the CLI flag is `--displayName` / `-di` — the templating engine doesn't kebab-case symbol names. One thing worth flagging: the bundle-id suffix uses the raw lowercased project name, so a project name with characters illegal in a reverse-DNS segment (spaces, leading digits) produces an invalid `applicationId`. That mirrors how `dotnet new` handles namespaces in general; the standard `-n MyApp1` form works correctly.

## ISSUE-056 — readable status-bar icons on Android

Since ISSUE-052 the root background fills the entire Android surface (so the status-bar band matches the app), but the icons stayed in their default light color. A white app produced white-on-white, invisible status-bar content.

`MikoSurfaceView` already reads `Engine.GetRootBackgroundColor()` every frame to clear the GL surface — reuse the same value to drive the system-bar icon appearance:

- BT.601 luminance > 0.5 (or fully transparent — matches the white GL clear fallback) => dark icons; otherwise light.
- Debounced against the last applied decision, so the cross-thread post only fires when the choice actually changes, not every frame.
- API 30+ uses `Window.InsetsController.SetSystemBarsAppearance(LightStatusBars | LightNavigationBars, mask)`. API 23–29 falls back to `DecorView.SystemUiFlags |= LightStatusBar` (and `LightNavigationBar` from API 26+). Both run via `Activity.RunOnUiThread` because `Window` / `View` mutation isn't GL-thread safe.
- Version-gated calls trigger CA1416 / CA1422 (the analyzer can't follow `Build.VERSION.SdkInt` guards across the closure), so the disable pragma is scoped tightly — same pattern already in use in `OnApplyWindowInsets`. Compiler output confirms it covers exactly the new lines; the 7 remaining warnings on the build are all pre-existing on lines untouched by this change.

Routing this through the per-frame background read means status-bar icons track theme swaps, themed routes, and hot reload automatically — no app-side plumbing needed.

## Verified

- `dotnet build src/Miko.Android` — 0 errors.
- 885 / 885 engine tests still pass.
- Both templates instantiated and inspected end-to-end.