### PR TITLE
feat(video): <video> element with FFmpeg backend; render on a dedicated thread

### DIFF
--- a/src/Miko.Windowing/Miko.Windowing.csproj
+++ b/src/Miko.Windowing/Miko.Windowing.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <IsPackable>true</IsPackable>
     <PackageId>Miko.Windowing</PackageId>
@@ -34,6 +35,11 @@
     <PackageReference Include="Silk.NET.OpenGL" Version="2.22.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <!-- FFmpeg 托管绑定（高层 API）。视频后端的软解基线实现使用。 -->
+    <PackageReference Include="Sdcb.FFmpeg" Version="7.0.0" />
+    <!-- Windows x64 原生 FFmpeg 运行时，使 demo 无需手动安装 FFmpeg 即可运行。 -->
+    <PackageReference Include="Sdcb.FFmpeg.runtime.windows-x64" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Miko.Windowing/SilkDesktopHost.cs
+++ b/src/Miko.Windowing/SilkDesktopHost.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,8 +14,21 @@ using SkiaSharp;
 namespace Miko.Windowing;
 
 /// <summary>
-/// 基于 Silk.NET 的桌面（Windows/Linux/macOS）宿主。拥有窗口、OpenGL 上下文与原生输入，
-/// 驱动渲染循环，并把归一化后的输入事件转发给 <see cref="MikoInteractionController"/>。
+/// 基于 Silk.NET 的桌面（Windows/Linux/macOS）宿主。
+/// <para>
+/// 线程模型：主线程只泵原生消息（<see cref="IView.DoEvents"/>），把输入/缩放事件**入队**；
+/// 一个专用**渲染线程**持有 GL 上下文，每帧排空队列、转发输入给
+/// <see cref="MikoInteractionController"/>，再渲染并交换缓冲。
+/// </para>
+/// <para>
+/// 这样做的原因（见 ISSUE-059）：Windows 上拖动标题栏/缩放边框会进入模态 move/size 消息循环，
+/// 阻塞主线程的 <c>DoEvents</c> 直到松手。若渲染也在主线程（Silk 默认的 <c>Run()</c>），
+/// 拖动期间画面会冻结、动画与视频卡住。把渲染移到独立线程后，主线程被模态循环卡住时渲染照常进行。
+/// </para>
+/// <para>
+/// 同步采用**消息队列**而非锁：DOM 与引擎只被渲染线程这一个线程触碰（输入经队列在渲染线程消费），
+/// 从根上避免跨线程 DOM 竞争。
+/// </para>
 /// </summary>
 public sealed class SilkDesktopHost
 {
@@ -26,20 +40,32 @@ public sealed class SilkDesktopHost
     private IInputContext? _inputContext;
     private GL? _gl;
     private GRContext? _grContext;
+
+    // 仅渲染线程读写（队列消费时更新），无需同步。
     private int _width;
     private int _height;
 
-    // 按键重复（属于窗口层关注点）
+    // 主线程 → 渲染线程的输入/缩放消息队列。
+    private readonly ConcurrentQueue<InputMessage> _messages = new();
+
+    // 渲染线程 → 主线程的“最新光标”反向通道（只关心最新值，故用单字段而非队列）。
+    private volatile StandardCursor _pendingCursor = StandardCursor.Default;
+    private StandardCursor _appliedCursor = StandardCursor.Default;
+
+    private Thread? _renderThread;
+    private volatile bool _stopRequested;
+
+    // 渲染线程帧计时。
+    private readonly Stopwatch _frameTimer = new();
+    private float _lastFrameTime;
+
+    // 按键重复（主线程按节拍入队 RepeatKey 消息；判定逻辑保持在窗口层）。
     private Key? _heldKey;
-    private IKeyboard? _heldKeyboard;
-    private readonly Stopwatch _keyHoldTimer = new();
     private bool _keyRepeatStarted;
+    private readonly Stopwatch _keyHoldTimer = new();
     private const long KeyRepeatDelayMs = 500;
     private const long KeyRepeatIntervalMs = 33;
 
-    private readonly Stopwatch _frameTimer = new();
-    private float _lastFrameTime;
-    private StandardCursor _currentCursor = StandardCursor.Default;
     private IMouse? _primaryMouse;
 
     public SilkDesktopHost(MikoAppContext context, ILogger<SilkDesktopHost>? logger = null)
@@ -59,35 +85,58 @@ public sealed class SilkDesktopHost
         {
             Title = _context.Options.Title,
             Size = new Vector2D<int>(_context.Options.Width, _context.Options.Height),
-            API = GraphicsAPI.Default
+            API = GraphicsAPI.Default,
+            // 我们自行管理 GL 上下文与缓冲交换（上下文要转移到渲染线程）。
+            IsContextControlDisabled = true,
+            ShouldSwapAutomatically = false,
         };
 
         _window = Window.Create(options);
         _window.Load += OnLoad;
-        _window.Update += OnUpdate;
-        _window.Render += OnRender;
         _window.Resize += OnResize;
-        _window.Closing += OnClose;
 
         _logger.LogInformation("Starting Miko application: {Title}", _context.Options.Title);
-        _window.Run();
+
+        // 不用 _window.Run()（它在单线程上泵消息+渲染）。改为手动：
+        // 主线程 Initialize + 泵消息，渲染在独立线程。
+        _window.Initialize();
+
+        // 主线程释放 GL 上下文，交给渲染线程 MakeCurrent。
+        _window.GLContext?.Clear();
+
+        _renderThread = new Thread(RenderLoop)
+        {
+            IsBackground = true,
+            Name = "miko-render",
+        };
+        _renderThread.Start();
+
+        // 主线程消息泵：处理输入/缩放/关闭，并应用渲染线程请求的光标。
+        // 拖动/缩放时 DoEvents 会阻塞在模态循环里——但渲染在另一线程，画面不冻结。
+        while (!_window.IsClosing)
+        {
+            _window.DoEvents();
+            PumpKeyRepeat();
+            ApplyPendingCursor();
+            Thread.Sleep(1);
+        }
+
+        // 关闭：停止并等待渲染线程（它会在自己线程内释放 GL 资源）。
+        _stopRequested = true;
+        _renderThread.Join();
+
+        _window.DoEvents();
+        _inputContext?.Dispose();
+        _window.Reset();
         _window.Dispose();
     }
 
+    /// <summary>
+    /// 主线程：创建输入上下文并订阅原生输入。GL/引擎初始化不在这里——它们需要在
+    /// 持有 GL 上下文的渲染线程进行（见 <see cref="RenderLoop"/> 的 InitGraphics）。
+    /// </summary>
     private void OnLoad()
     {
-        _gl = _window!.CreateOpenGL();
-
-        var grInterface = GRGlInterface.Create(name =>
-        {
-            if (_window!.GLContext!.TryGetProcAddress(name, out var addr))
-                return addr;
-            return IntPtr.Zero;
-        });
-
-        _grContext = GRContext.CreateGl(grInterface);
-        _logger.LogInformation("OpenGL context initialized");
-
         _inputContext = _window!.CreateInput();
         foreach (var mouse in _inputContext.Mice)
         {
@@ -104,41 +153,59 @@ public sealed class SilkDesktopHost
             keyboard.KeyUp += OnKeyUp;
             keyboard.KeyChar += OnKeyChar;
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // 渲染线程
+    // ---------------------------------------------------------------------
+
+    private void RenderLoop()
+    {
+        InitGraphics();
+        _frameTimer.Start();
+
+        while (!_stopRequested)
+        {
+            // 1. 排空输入队列（DOM 在此变更，与随后的渲染同线程）。
+            DrainMessages();
+
+            // 2. 渲染一帧。
+            RenderFrame();
+
+            // 3. 交换缓冲（我们接管了自动交换）。
+            _window!.GLContext?.SwapBuffers();
+        }
+
+        // 在持有上下文的本线程释放 GL 资源与视频会话。
+        _controller.Engine.DisposeVideoSessions();
+        _grContext?.Dispose();
+        _gl?.Dispose();
+        _window!.GLContext?.Clear();
+    }
+
+    private void InitGraphics()
+    {
+        _window!.GLContext?.MakeCurrent();
+
+        _gl = _window.CreateOpenGL();
+
+        var grInterface = GRGlInterface.Create(name =>
+            _window.GLContext!.TryGetProcAddress(name, out var addr) ? addr : IntPtr.Zero);
+
+        _grContext = GRContext.CreateGl(grInterface);
+        _logger.LogInformation("OpenGL context initialized on render thread");
+
+        // 把 GPU 上下文交给引擎，供视频帧源把解码 GPU 资源零拷贝包装为图像。
+        _controller.Engine.GraphicsContext = _grContext;
 
         _context.RegisterFonts();
 
         using var tempSurface = SKSurface.Create(new SKImageInfo(_width, _height));
         _controller.Initialize(tempSurface.Canvas, _width, _height);
         _controller.RunPostInitHooks();
-
-        _frameTimer.Start();
     }
 
-    private void OnUpdate(double _)
-    {
-        if (_heldKey == null || _heldKeyboard == null) return;
-
-        var elapsed = _keyHoldTimer.ElapsedMilliseconds;
-        if (!_keyRepeatStarted)
-        {
-            if (elapsed >= KeyRepeatDelayMs)
-            {
-                _keyRepeatStarted = true;
-                _keyHoldTimer.Restart();
-                _controller.RepeatKey(SilkKeyMap.ToMikoKey(_heldKey.Value));
-            }
-        }
-        else
-        {
-            if (elapsed >= KeyRepeatIntervalMs)
-            {
-                _keyHoldTimer.Restart();
-                _controller.RepeatKey(SilkKeyMap.ToMikoKey(_heldKey.Value));
-            }
-        }
-    }
-
-    private void OnRender(double _)
+    private void RenderFrame()
     {
         if (_grContext == null || _gl == null) return;
 
@@ -153,8 +220,8 @@ public sealed class SilkDesktopHost
         using var surface = SKSurface.Create(_grContext, target, GRSurfaceOrigin.BottomLeft, SKColorType.Rgba8888);
         var canvas = surface.Canvas;
 
-        // Goes through RenderFrame for parity with the mobile hosts. Desktop pumps input
-        // and render on one thread, so the lock is uncontended here.
+        // RenderFrame 内部仍走 _sync（对桌面已不竞争，因为输入也在本线程消费），
+        // 与移动端保持一致。
         _controller.RenderFrame(canvas, _width, _height, deltaTime, c =>
         {
             c.Clear(SKColors.White);
@@ -164,29 +231,76 @@ public sealed class SilkDesktopHost
         _grContext.Flush();
     }
 
+    /// <summary>渲染线程：排空主线程投递的输入/缩放消息并转发给控制器。</summary>
+    private void DrainMessages()
+    {
+        while (_messages.TryDequeue(out var msg))
+        {
+            switch (msg.Kind)
+            {
+                case MessageKind.PointerDown:
+                    _controller.OnPointerDown(msg.X, msg.Y, msg.Button);
+                    break;
+                case MessageKind.PointerUp:
+                    _controller.OnPointerUp(msg.X, msg.Y, msg.Button);
+                    break;
+                case MessageKind.PointerMove:
+                    _controller.OnPointerMove(msg.X, msg.Y);
+                    break;
+                case MessageKind.Scroll:
+                    _controller.OnScroll(msg.X, msg.Y, msg.DeltaX, msg.DeltaY);
+                    break;
+                case MessageKind.KeyDown:
+                    _controller.OnKeyDown(msg.Key, msg.Modifiers);
+                    break;
+                case MessageKind.KeyUp:
+                    _controller.OnKeyUp(msg.Key, msg.Modifiers);
+                    break;
+                case MessageKind.RepeatKey:
+                    _controller.RepeatKey(msg.Key);
+                    break;
+                case MessageKind.TextInput:
+                    _controller.OnTextInput(msg.Text!);
+                    break;
+                case MessageKind.Resize:
+                    ApplyResize((int)msg.X, (int)msg.Y);
+                    break;
+            }
+        }
+    }
+
+    private void ApplyResize(int width, int height)
+    {
+        _width = width;
+        _height = height;
+        _gl?.Viewport(new Vector2D<int>(width, height));
+        _controller.SetViewportSize(width, height);
+        _logger.LogDebug("Viewport resized to {Width}x{Height}", width, height);
+    }
+
+    // ---------------------------------------------------------------------
+    // 主线程：原生输入回调 → 入队
+    // ---------------------------------------------------------------------
+
     private void OnResize(Vector2D<int> size)
     {
-        _width = size.X;
-        _height = size.Y;
-        _gl?.Viewport(size);
-        _controller.SetViewportSize(size.X, size.Y);
-        _logger.LogDebug("Viewport resized to {Width}x{Height}", size.X, size.Y);
+        _messages.Enqueue(InputMessage.Resize(size.X, size.Y));
     }
 
     private void OnMouseDown(IMouse mouse, MouseButton button)
     {
-        _controller.OnPointerDown(mouse.Position.X, mouse.Position.Y, SilkKeyMap.ToMikoButton(button));
+        _messages.Enqueue(InputMessage.Pointer(MessageKind.PointerDown, mouse.Position.X, mouse.Position.Y, SilkKeyMap.ToMikoButton(button)));
     }
 
     private void OnMouseUp(IMouse mouse, MouseButton button)
     {
-        _controller.OnPointerUp(mouse.Position.X, mouse.Position.Y, SilkKeyMap.ToMikoButton(button));
+        _messages.Enqueue(InputMessage.Pointer(MessageKind.PointerUp, mouse.Position.X, mouse.Position.Y, SilkKeyMap.ToMikoButton(button)));
     }
 
     private void OnMouseMove(IMouse mouse, System.Numerics.Vector2 position)
     {
         _primaryMouse = mouse;
-        _controller.OnPointerMove(position.X, position.Y);
+        _messages.Enqueue(InputMessage.Pointer(MessageKind.PointerMove, position.X, position.Y, default));
     }
 
     private void OnMouseScroll(IMouse mouse, ScrollWheel scrollWheel)
@@ -194,21 +308,20 @@ public sealed class SilkDesktopHost
         // Silk 滚轮单位换算为像素增量（保持原行为：每格 40px，方向反转）
         float deltaY = scrollWheel.Y * -40f;
         float deltaX = scrollWheel.X * -40f;
-        _controller.OnScroll(mouse.Position.X, mouse.Position.Y, deltaX, deltaY);
+        _messages.Enqueue(InputMessage.ScrollMsg(mouse.Position.X, mouse.Position.Y, deltaX, deltaY));
     }
 
     private void OnKeyDown(IKeyboard keyboard, Key key, int scancode)
     {
         var mikoKey = SilkKeyMap.ToMikoKey(key);
         var mods = SilkKeyMap.GetModifiers(keyboard);
+        _messages.Enqueue(InputMessage.Keyboard(MessageKind.KeyDown, mikoKey, mods));
 
-        bool consumed = _controller.OnKeyDown(mikoKey, mods);
-        if (consumed) return;
-
+        // 全局键消费判定原本在 OnKeyDown 返回值里——现已异步入队，无法在此得知是否被消费。
+        // 仍按可重复键启动重复定时；若该键被全局处理器消费，控制器的 RepeatKey 对其为 no-op。
         if (MikoInteractionController.IsRepeatableKey(mikoKey))
         {
             _heldKey = key;
-            _heldKeyboard = keyboard;
             _keyRepeatStarted = false;
             _keyHoldTimer.Restart();
         }
@@ -219,32 +332,102 @@ public sealed class SilkDesktopHost
         if (_heldKey == key)
         {
             _heldKey = null;
-            _heldKeyboard = null;
             _keyHoldTimer.Stop();
         }
-        _controller.OnKeyUp(SilkKeyMap.ToMikoKey(key), SilkKeyMap.GetModifiers(keyboard));
+        _messages.Enqueue(InputMessage.Keyboard(MessageKind.KeyUp, SilkKeyMap.ToMikoKey(key), SilkKeyMap.GetModifiers(keyboard)));
     }
 
     private void OnKeyChar(IKeyboard keyboard, char character)
     {
-        _controller.OnTextInput(character.ToString());
+        _messages.Enqueue(InputMessage.TextInputMsg(character.ToString()));
     }
 
+    /// <summary>主线程按节拍把 RepeatKey 入队（判定逻辑保持在窗口层）。</summary>
+    private void PumpKeyRepeat()
+    {
+        if (_heldKey == null) return;
+
+        var elapsed = _keyHoldTimer.ElapsedMilliseconds;
+        if (!_keyRepeatStarted)
+        {
+            if (elapsed >= KeyRepeatDelayMs)
+            {
+                _keyRepeatStarted = true;
+                _keyHoldTimer.Restart();
+                _messages.Enqueue(InputMessage.Repeat(SilkKeyMap.ToMikoKey(_heldKey.Value)));
+            }
+        }
+        else if (elapsed >= KeyRepeatIntervalMs)
+        {
+            _keyHoldTimer.Restart();
+            _messages.Enqueue(InputMessage.Repeat(SilkKeyMap.ToMikoKey(_heldKey.Value)));
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // 光标（引擎→窗口，反向通道）
+    // ---------------------------------------------------------------------
+
+    /// <summary>渲染线程触发（命中测试在渲染帧内）：只记录最新光标，由主线程应用。</summary>
     private void OnCursorChanged(Cursor cursor)
     {
-        var standardCursor = SilkKeyMap.ToStandardCursor(cursor);
-        if (standardCursor == _currentCursor) return;
-        _currentCursor = standardCursor;
-
-        if (_primaryMouse == null) return;
-        _primaryMouse.Cursor.Type = CursorType.Standard;
-        _primaryMouse.Cursor.StandardCursor = standardCursor;
+        _pendingCursor = SilkKeyMap.ToStandardCursor(cursor);
     }
 
-    private void OnClose()
+    /// <summary>主线程：应用渲染线程请求的最新光标（GLFW 光标须在主线程设置）。</summary>
+    private void ApplyPendingCursor()
     {
-        _inputContext?.Dispose();
-        _grContext?.Dispose();
-        _gl?.Dispose();
+        var desired = _pendingCursor;
+        if (desired == _appliedCursor || _primaryMouse == null) return;
+        _appliedCursor = desired;
+        _primaryMouse.Cursor.Type = CursorType.Standard;
+        _primaryMouse.Cursor.StandardCursor = desired;
+    }
+
+    // ---------------------------------------------------------------------
+    // 输入消息
+    // ---------------------------------------------------------------------
+
+    private enum MessageKind
+    {
+        PointerDown, PointerUp, PointerMove, Scroll,
+        KeyDown, KeyUp, RepeatKey, TextInput, Resize,
+    }
+
+    /// <summary>主线程 → 渲染线程的输入/缩放消息（轻量值类型，避免每事件分配）。</summary>
+    private readonly struct InputMessage
+    {
+        public readonly MessageKind Kind;
+        public readonly float X, Y, DeltaX, DeltaY;
+        public readonly Miko.Events.MouseButton Button;
+        public readonly MikoKey Key;
+        public readonly MikoKeyModifiers Modifiers;
+        public readonly string? Text;
+
+        private InputMessage(MessageKind kind, float x, float y, float dx, float dy,
+            Miko.Events.MouseButton button, MikoKey key, MikoKeyModifiers mods, string? text)
+        {
+            Kind = kind; X = x; Y = y; DeltaX = dx; DeltaY = dy;
+            Button = button; Key = key; Modifiers = mods; Text = text;
+        }
+
+        public static InputMessage Pointer(MessageKind kind, float x, float y, Miko.Events.MouseButton button)
+            => new(kind, x, y, 0, 0, button, default, default, null);
+
+        public static InputMessage ScrollMsg(float x, float y, float dx, float dy)
+            => new(MessageKind.Scroll, x, y, dx, dy, default, default, default, null);
+
+        public static InputMessage Keyboard(MessageKind kind, MikoKey key, MikoKeyModifiers mods)
+            => new(kind, 0, 0, 0, 0, default, key, mods, null);
+
+        public static InputMessage Repeat(MikoKey key)
+            => new(MessageKind.RepeatKey, 0, 0, 0, 0, default, key, default, null);
+
+        public static InputMessage TextInputMsg(string text)
+            => new(MessageKind.TextInput, 0, 0, 0, 0, default, default, default, text);
+
+        // Resize 复用 X/Y 携带宽/高。
+        public static InputMessage Resize(int width, int height)
+            => new(MessageKind.Resize, width, height, 0, 0, default, default, default, null);
     }
 }

--- a/src/Miko.Windowing/Video/FFmpegVideoBackend.cs
+++ b/src/Miko.Windowing/Video/FFmpegVideoBackend.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Miko.Platform.Video;
+
+namespace Miko.Windowing.Video;
+
+/// <summary>
+/// 桌面（当前仅 Windows）FFmpeg 视频后端。Phase 1 为软解基线（CPU 解码 + 纹理上传），
+/// 架构上为 Phase 2 的 D3D11VA 零拷贝硬解预留（见 ISSUE-058 §2.1）。
+/// <para>
+/// 原生 FFmpeg 二进制由 <c>Sdcb.FFmpeg.runtime.windows-x64</c> 提供并随输出复制，
+/// 因此无需用户单独安装 FFmpeg。
+/// </para>
+/// </summary>
+public sealed class FFmpegVideoBackend : IVideoBackend
+{
+    private readonly ILogger<FFmpegVideoBackend> _logger;
+
+    public FFmpegVideoBackend(ILogger<FFmpegVideoBackend>? logger = null)
+    {
+        _logger = logger ?? NullLogger<FFmpegVideoBackend>.Instance;
+    }
+
+    public VideoBackendCapabilities Capabilities { get; } = new VideoBackendCapabilities(
+        HardwareDecode: false,   // Phase 1 软解；Phase 2 切 D3D11VA 后置 true
+        Hdr: false,
+        SupportedMimeTypes: new[] { "video/mp4", "video/webm", "video/ogg", "video/x-matroska" });
+
+    public IVideoSession CreateSession(VideoSourceDescriptor source, VideoSessionOptions options)
+    {
+        _logger.LogInformation("Creating FFmpeg video session for {Uri}", source.Uri);
+        var session = new FFmpegVideoSession(source, options, _logger);
+        session.Start();
+        return session;
+    }
+}

--- a/src/Miko.Windowing/Video/FFmpegVideoFrameSource.cs
+++ b/src/Miko.Windowing/Video/FFmpegVideoFrameSource.cs
@@ -1,0 +1,90 @@
+using Miko.Platform.Video;
+using SkiaSharp;
+
+namespace Miko.Windowing.Video;
+
+/// <summary>
+/// 软解基线的帧源：持有最近一帧的 RGBA 像素缓冲，在渲染线程把它包装成 <see cref="SKImage"/>。
+/// <para>
+/// 这是 Phase 1 的 CPU 上传实现：解码线程产出 RGBA 字节缓冲，渲染线程一次性上传为纹理图像。
+/// Phase 2 的零拷贝硬解会在同一 <see cref="IVideoFrameSource"/> 契约下替换为
+/// 「解码线程只入队 GPU 句柄、渲染线程零拷贝包装」的实现，调用方无需改动。
+/// </para>
+/// <para>
+/// 线程模型：<see cref="PushFrame"/> 在解码线程调用，<see cref="AcquireCurrentFrame"/>/
+/// <see cref="ReleaseCurrentFrame"/> 在渲染线程调用，两者以 <see cref="_lock"/> 互斥。
+/// 仅保留「最近一帧」，渲染慢于解码时自动丢弃旧帧（基线策略，避免无界堆积）。
+/// </para>
+/// </summary>
+internal sealed class FFmpegVideoFrameSource : IVideoFrameSource, IDisposable
+{
+    private readonly object _lock = new();
+
+    // 最近一帧的 RGBA 缓冲与尺寸（CPU 端）。
+    private byte[]? _pendingPixels;
+    private int _pendingWidth;
+    private int _pendingHeight;
+    private bool _hasNewFrame;
+
+    // 渲染线程持有的当前帧图像，新帧到达时替换并释放旧图像。
+    private SKImage? _currentImage;
+    private bool _disposed;
+
+    /// <summary>
+    /// 解码线程推入一帧 RGBA8888 像素（紧凑排列，stride = width*4）。
+    /// 缓冲由调用方拥有，这里浅引用——调用方应在每帧使用独立缓冲或在下次推帧前不复用。
+    /// </summary>
+    public void PushFrame(byte[] rgba, int width, int height)
+    {
+        lock (_lock)
+        {
+            if (_disposed) return;
+            _pendingPixels = rgba;
+            _pendingWidth = width;
+            _pendingHeight = height;
+            _hasNewFrame = true;
+        }
+    }
+
+    public SKImage? AcquireCurrentFrame(GRContext? grContext)
+    {
+        lock (_lock)
+        {
+            if (_disposed) return _currentImage;
+
+            // 有新帧则上传为图像，替换旧图像。
+            if (_hasNewFrame && _pendingPixels != null)
+            {
+                _hasNewFrame = false;
+
+                var info = new SKImageInfo(_pendingWidth, _pendingHeight, SKColorType.Rgba8888, SKAlphaType.Opaque);
+                // FromPixelCopy 一次性把 CPU 像素拷入图像；绘制到 GPU 画布时由 Skia 上传为纹理。
+                var newImage = SKImage.FromPixelCopy(info, _pendingPixels);
+                if (newImage != null)
+                {
+                    _currentImage?.Dispose();
+                    _currentImage = newImage;
+                }
+            }
+
+            return _currentImage;
+        }
+    }
+
+    public void ReleaseCurrentFrame()
+    {
+        // 基线实现持有图像直到下一帧替换，这里无需逐帧释放。
+    }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _currentImage?.Dispose();
+            _currentImage = null;
+            _pendingPixels = null;
+        }
+    }
+}

--- a/src/Miko.Windowing/Video/FFmpegVideoSession.cs
+++ b/src/Miko.Windowing/Video/FFmpegVideoSession.cs
@@ -1,0 +1,282 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Miko.Platform.Video;
+using Sdcb.FFmpeg.Codecs;
+using Sdcb.FFmpeg.Formats;
+using Sdcb.FFmpeg.Raw;
+using Sdcb.FFmpeg.Swscales;
+using Sdcb.FFmpeg.Utils;
+
+namespace Miko.Windowing.Video;
+
+/// <summary>
+/// FFmpeg 软解会话（Phase 1 基线）。在自有解码线程上解复用 + 软解视频轨，
+/// 把帧转换为 RGBA 后推给 <see cref="FFmpegVideoFrameSource"/>，并按 PTS 与时钟节流。
+/// <para>
+/// 范围限定：本基线只解码视频轨并按墙钟时间呈现；音频与精确 A/V 同步留待后续
+/// （见 ISSUE-058 方案 §2.1：音频经 OpenAL/XAudio2，以音频时钟为主时钟）。
+/// 这样可在最小依赖下打通「元素 → 布局 → 合成 → 帧节流」全链路。
+/// </para>
+/// </summary>
+internal sealed class FFmpegVideoSession : IVideoSession
+{
+    private readonly VideoSourceDescriptor _source;
+    private readonly VideoSessionOptions _options;
+    private readonly ILogger _logger;
+    private readonly FFmpegVideoFrameSource _frameSource = new();
+
+    private Thread? _decodeThread;
+    private volatile bool _stopRequested;
+    private volatile VideoSessionState _state = VideoSessionState.Idle;
+
+    // 播放控制（由解码线程读取）。
+    private volatile bool _playRequested;
+    private volatile bool _loop;
+    private long _seekRequestTicks = -1;          // -1 表示无 seek 请求
+    private readonly object _controlLock = new();
+
+    private TimeSpan _duration;
+    private long _positionTicks;                  // Interlocked 访问
+    private int _videoWidth;
+    private int _videoHeight;
+
+    public FFmpegVideoSession(VideoSourceDescriptor source, VideoSessionOptions options, ILogger? logger)
+    {
+        _source = source;
+        _options = options;
+        _logger = logger ?? NullLogger.Instance;
+        _loop = options.Loop;
+        _playRequested = options.AutoPlay;
+    }
+
+    public IVideoFrameSource FrameSource => _frameSource;
+    public VideoSessionState State => _state;
+    public TimeSpan Duration => _duration;
+    public TimeSpan Position => TimeSpan.FromTicks(Interlocked.Read(ref _positionTicks));
+    public int VideoWidth => _videoWidth;
+    public int VideoHeight => _videoHeight;
+
+    public event Action<VideoSessionEvent>? Event;
+
+    /// <summary>启动解码线程。由后端在创建后立即调用。</summary>
+    public void Start()
+    {
+        _state = VideoSessionState.Loading;
+        _decodeThread = new Thread(DecodeLoop)
+        {
+            IsBackground = true,
+            Name = $"miko-video-decode",
+        };
+        _decodeThread.Start();
+    }
+
+    // ---- 控制 --------------------------------------------------------------
+
+    public void Play() { _playRequested = true; if (_state == VideoSessionState.Paused) _state = VideoSessionState.Playing; }
+    public void Pause() { _playRequested = false; if (_state == VideoSessionState.Playing) _state = VideoSessionState.Paused; }
+    public void SetLoop(bool loop) => _loop = loop;
+
+    public void Seek(TimeSpan position)
+    {
+        lock (_controlLock) { _seekRequestTicks = position.Ticks; }
+    }
+
+    // 音频未接入：以下控制在基线中为 no-op，保留以满足契约并便于 Phase 2 接线。
+    public void SetVolume(float volume) { }
+    public void SetMuted(bool muted) { }
+    public void SetPlaybackRate(float rate) { }
+
+    // ---- 解码循环 ----------------------------------------------------------
+
+    private void DecodeLoop()
+    {
+        FormatContext? fc = null;
+        CodecContext? decoder = null;
+        VideoFrameConverter? converter = null;
+        using var packet = new Packet();
+        using var decoded = new Frame();
+        using var rgbaFrame = new Frame();
+
+        try
+        {
+            fc = FormatContext.OpenInputUrl(_source.Uri);
+            fc.LoadStreamInfo();
+
+            MediaStream stream = fc.FindBestStream(AVMediaType.Video);
+            int videoStreamIndex = stream.Index;
+
+            // FindBestStream 找到视频轨即保证 Codecpar 有效。
+            var codecpar = stream.Codecpar!;
+            var codec = Codec.FindDecoderById(codecpar.CodecId);
+            decoder = new CodecContext(codec);
+            decoder.FillParameters(codecpar);
+            decoder.Open(codec);
+
+            _videoWidth = decoder.Width;
+            _videoHeight = decoder.Height;
+            _duration = fc.Duration > 0
+                ? TimeSpan.FromSeconds(fc.Duration / (double)ffmpeg.AV_TIME_BASE)
+                : TimeSpan.Zero;
+
+            // 目标 RGBA 帧缓冲（与解码尺寸一致）。
+            rgbaFrame.Width = _videoWidth;
+            rgbaFrame.Height = _videoHeight;
+            rgbaFrame.Format = (int)AVPixelFormat.Rgba;
+            rgbaFrame.EnsureBuffer();
+
+            converter = new VideoFrameConverter();
+
+            _state = _playRequested ? VideoSessionState.Playing : VideoSessionState.Ready;
+            Raise(new VideoSessionEvent.Loaded(_videoWidth, _videoHeight, _duration));
+
+            // 时间基：把帧 PTS 换算到秒，用于按墙钟节流。
+            double timeBase = stream.TimeBase.Num / (double)stream.TimeBase.Den;
+
+            var playbackClock = System.Diagnostics.Stopwatch.StartNew();
+            double clockOriginSeconds = 0;       // 播放时钟原点对应的媒体秒数
+            bool clockStarted = false;
+
+            while (!_stopRequested)
+            {
+                // 处理 seek 请求
+                long seekTicks;
+                lock (_controlLock) { seekTicks = _seekRequestTicks; _seekRequestTicks = -1; }
+                if (seekTicks >= 0)
+                {
+                    long ts = (long)(TimeSpan.FromTicks(seekTicks).TotalSeconds / timeBase);
+                    fc.SeekFrame(ts, videoStreamIndex, AVSEEK_FLAG.Backward);
+                    FlushDecoder(decoder);
+                    clockStarted = false;
+                }
+
+                // 暂停：空转等待
+                if (!_playRequested)
+                {
+                    _state = VideoSessionState.Paused;
+                    Thread.Sleep(15);
+                    continue;
+                }
+                if (_state == VideoSessionState.Paused) _state = VideoSessionState.Playing;
+
+                // 读一个包
+                var readResult = fc.ReadFrame(packet);
+                if (readResult == CodecResult.EOF)
+                {
+                    if (_loop)
+                    {
+                        fc.SeekFrame(0, videoStreamIndex, AVSEEK_FLAG.Backward);
+                        FlushDecoder(decoder);
+                        clockStarted = false;
+                        continue;
+                    }
+                    _state = VideoSessionState.Ended;
+                    Raise(new VideoSessionEvent.Ended());
+                    // 停在结尾，等待 seek/play 控制
+                    while (!_stopRequested && _state == VideoSessionState.Ended)
+                    {
+                        lock (_controlLock) { if (_seekRequestTicks >= 0) break; }
+                        Thread.Sleep(15);
+                    }
+                    continue;
+                }
+
+                try
+                {
+                    if (packet.StreamIndex != videoStreamIndex)
+                        continue;
+
+                    decoder.SendPacket(packet);
+
+                    while (!_stopRequested)
+                    {
+                        var recv = decoder.ReceiveFrame(decoded);
+                        if (recv == CodecResult.Again || recv == CodecResult.EOF)
+                            break;
+
+                        // 帧 PTS（秒）
+                        long ptsRaw = decoded.BestEffortTimestamp;
+                        double frameSeconds = ptsRaw == ffmpeg.AV_NOPTS_VALUE ? 0 : ptsRaw * timeBase;
+
+                        // 按墙钟节流：把播放时钟对齐到首帧媒体时间，之后等待直到该帧到点。
+                        if (!clockStarted)
+                        {
+                            clockStarted = true;
+                            clockOriginSeconds = frameSeconds;
+                            playbackClock.Restart();
+                        }
+                        double targetElapsed = frameSeconds - clockOriginSeconds;
+                        double actualElapsed = playbackClock.Elapsed.TotalSeconds;
+                        double waitSeconds = targetElapsed - actualElapsed;
+                        if (waitSeconds > 0.001)
+                            Thread.Sleep((int)Math.Min(waitSeconds * 1000, 1000));
+
+                        // 转换为 RGBA 并推送
+                        converter.ConvertFrame(decoded, rgbaFrame, SWS.Bilinear);
+                        PushRgba(rgbaFrame);
+
+                        Interlocked.Exchange(ref _positionTicks, TimeSpan.FromSeconds(frameSeconds).Ticks);
+                        Raise(new VideoSessionEvent.FrameAvailable(TimeSpan.FromSeconds(frameSeconds)));
+                    }
+                }
+                finally
+                {
+                    packet.Unref();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _state = VideoSessionState.Error;
+            _logger.LogError(ex, "Video decode failed for {Uri}", _source.Uri);
+            Raise(new VideoSessionEvent.Error(ex.Message, ex));
+        }
+        finally
+        {
+            converter?.Free();
+            decoder?.Free();
+            fc?.Free();
+        }
+    }
+
+    /// <summary>把 RGBA 帧的紧凑像素拷出并推给帧源。</summary>
+    private unsafe void PushRgba(Frame rgbaFrame)
+    {
+        int w = rgbaFrame.Width;
+        int h = rgbaFrame.Height;
+        int stride = rgbaFrame.Linesize[0];
+        byte* src = (byte*)rgbaFrame.Data[0];
+
+        var buffer = new byte[w * h * 4];
+        fixed (byte* dst = buffer)
+        {
+            if (stride == w * 4)
+            {
+                // 无行填充：整块拷贝
+                Buffer.MemoryCopy(src, dst, buffer.Length, buffer.Length);
+            }
+            else
+            {
+                // 有行填充：逐行拷贝去除 padding
+                for (int y = 0; y < h; y++)
+                    Buffer.MemoryCopy(src + y * stride, dst + y * w * 4, w * 4, w * 4);
+            }
+        }
+
+        _frameSource.PushFrame(buffer, w, h);
+    }
+
+    /// <summary>清空解码器内部缓冲（seek / loop 后调用）。Sdcb 未暴露高层包装，直接调 raw API。</summary>
+    private static unsafe void FlushDecoder(CodecContext decoder)
+    {
+        ffmpeg.avcodec_flush_buffers((AVCodecContext*)decoder.DangerousGetHandle());
+    }
+
+    private void Raise(VideoSessionEvent evt) => Event?.Invoke(evt);
+
+    public void Dispose()
+    {
+        _stopRequested = true;
+        _decodeThread?.Join(500);
+        _frameSource.Dispose();
+    }
+}

--- a/src/Miko.Windowing/Video/VideoServiceExtensions.cs
+++ b/src/Miko.Windowing/Video/VideoServiceExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+using Miko.Hosting;
+using Miko.Platform.Video;
+
+namespace Miko.Windowing.Video;
+
+/// <summary>
+/// 视频后端的 DI 注册扩展。桌面应用在构建时调用 <see cref="UseFFmpegVideo"/> 启用
+/// <c>&lt;video&gt;</c> 播放。未调用时 <c>&lt;video&gt;</c> 元素仅显示背景/poster。
+/// </summary>
+public static class VideoServiceExtensions
+{
+    /// <summary>
+    /// 注册 FFmpeg 视频后端（软解基线）。控制器初始化时会从 DI 解析并注入引擎。
+    /// </summary>
+    public static MikoAppBuilder UseFFmpegVideo(this MikoAppBuilder builder)
+    {
+        builder.Services.AddSingleton<IVideoBackend, FFmpegVideoBackend>();
+        return builder;
+    }
+}

--- a/src/Miko/Components/RenderTreeBuilder.cs
+++ b/src/Miko/Components/RenderTreeBuilder.cs
@@ -37,6 +37,7 @@ public class RenderTreeBuilder
         ["ol"] = () => new OlElement(),
         ["li"] = () => new LiElement(),
         ["img"] = () => new ImageElement(),
+        ["video"] = () => new VideoElement(),
         ["table"] = () => new TableElement(),
         ["thead"] = () => new TheadElement(),
         ["tbody"] = () => new TbodyElement(),
@@ -93,8 +94,29 @@ public class RenderTreeBuilder
                     _ => InputType.Text,
                 };
                 break;
+            case "src" when element is ImageElement img:
+                img.Source = value; break;
+            case "src" when element is VideoElement video:
+                video.Source = value; break;
+            case "poster" when element is VideoElement video:
+                video.Poster = value; break;
+            case "autoplay" when element is VideoElement video:
+                video.AutoPlay = ParseHtmlBool(value); break;
+            case "loop" when element is VideoElement video:
+                video.Loop = ParseHtmlBool(value); break;
+            case "muted" when element is VideoElement video:
+                video.Muted = ParseHtmlBool(value); break;
+            case "controls" when element is VideoElement video:
+                video.Controls = ParseHtmlBool(value); break;
         }
     }
+
+    /// <summary>
+    /// HTML 布尔属性：存在即为真。Razor 通常以 <c>autoplay="true"</c>/<c>="false"</c> 传值，
+    /// 因此显式的 "false" 视为假，其余（含空串、"true"、属性名本身）视为真。
+    /// </summary>
+    private static bool ParseHtmlBool(string? value)
+        => !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase);
 
     public void AddAttribute(int seq, string name, object? value)
     {

--- a/src/Miko/Core/DomElements/MediaElements.cs
+++ b/src/Miko/Core/DomElements/MediaElements.cs
@@ -1,3 +1,4 @@
+using Miko.Platform.Video;
 using SkiaSharp;
 
 namespace Miko.Core.DomElements;
@@ -10,4 +11,47 @@ public class ImageElement : Element
     public override string TagName => "img";
     public string? Source { get; set; }
     public SKBitmap? Bitmap { get; internal set; }
+}
+
+/// <summary>
+/// 视频元素。Miko 只负责把"当前帧"作为一张 GPU 图像合成进盒模型；
+/// 解复用与编解码由平台后端（<see cref="IVideoBackend"/>）实现。
+/// <para>
+/// 它是一个 replaced 元素，行为对齐 <see cref="ImageElement"/>：完全参与
+/// Block/Flex/定位/overflow 裁剪/opacity/transform 链路，其它元素可覆盖在其上。
+/// </para>
+/// </summary>
+public class VideoElement : Element
+{
+    public override string TagName => "video";
+
+    // ---- 声明式属性（HTML 风格）-------------------------------------------
+    public string? Source { get; set; }
+    public bool AutoPlay { get; set; }
+    public bool Loop { get; set; }
+    public bool Muted { get; set; }
+
+    /// <summary>是否渲染默认控件层。预留扩展点，当前版本不绘制原生控件。</summary>
+    public bool Controls { get; set; }
+
+    /// <summary>首帧到达前显示的占位图源（与 <see cref="ImageElement"/> 同路径解码）。</summary>
+    public string? Poster { get; set; }
+
+    // ---- 引擎内部状态 ------------------------------------------------------
+
+    /// <summary>
+    /// 由渲染引擎在首次见到该元素时通过 <see cref="IVideoBackend"/> 创建并赋值；
+    /// 元素从树中移除时由引擎 <see cref="IVideoSession.Dispose"/>。
+    /// </summary>
+    internal IVideoSession? Session { get; set; }
+
+    /// <summary>占位图已解码的位图（首帧前绘制）。</summary>
+    internal SKBitmap? PosterBitmap { get; set; }
+
+    /// <summary>
+    /// replaced 元素内禀尺寸，会话 <c>Loaded</c> 后由引擎写入并触发重排。
+    /// 未知时为 null，布局回退到默认 300×150（HTML 规范）。
+    /// </summary>
+    internal int? IntrinsicWidth { get; set; }
+    internal int? IntrinsicHeight { get; set; }
 }

--- a/src/Miko/Core/MikoEngine.cs
+++ b/src/Miko/Core/MikoEngine.cs
@@ -5,6 +5,7 @@ using Miko.Common;
 using Miko.Core.DomElements;
 using Miko.Events;
 using Miko.Layout;
+using Miko.Platform.Video;
 using Miko.Rendering;
 using Miko.Styling;
 using SkiaSharp;
@@ -51,6 +52,29 @@ public class MikoEngine
     private float _viewportHeight;
     private SafeAreaInsets _safeArea;
 
+    /// <summary>
+    /// 视频后端。由平台宿主在初始化时从 DI 注入（未注册视频后端时为 null，
+    /// <c>&lt;video&gt;</c> 元素将只显示背景/poster）。
+    /// </summary>
+    public IVideoBackend? VideoBackend { get; set; }
+
+    /// <summary>
+    /// 当前 GPU 上下文。GPU 宿主（桌面 OpenGL / 移动 GLES/Metal）每帧设置，
+    /// 供视频帧源把解码 GPU 资源零拷贝包装为图像；转发给底层渲染引擎。
+    /// </summary>
+    public GRContext? GraphicsContext
+    {
+        get => _renderEngine.GraphicsContext;
+        set => _renderEngine.GraphicsContext = value;
+    }
+
+    // 已激活的视频会话，按元素身份索引；用于跨重建复用与移除时回收。
+    private readonly Dictionary<VideoElement, IVideoSession> _videoSessions = new();
+
+    // 外部线程（视频解码线程等）投递的失效请求，在帧开始时于主线程排空。
+    private readonly List<Element> _pendingInvalidations = new();
+    private readonly object _pendingInvalidationsLock = new();
+
     public void Initialize(Element root, List<StyleSheet> styleSheets, SKCanvas canvas, float viewportWidth, float viewportHeight)
     {
         // Transfer old LayoutBox references to new elements for transition detection
@@ -83,6 +107,9 @@ public class MikoEngine
                 _currentLayout = _layoutEngine.Layout(root, _styleSheets, viewportWidth, viewportHeight, _safeArea);
             }
         }
+
+        // 同步视频会话（创建新元素的会话、回收已移除元素的会话）。
+        SyncVideoSessions(root);
 
         _renderEngine.Render(_currentLayout);
         ScanAndStartAnimations(root);
@@ -125,6 +152,10 @@ public class MikoEngine
     {
         if (_root == null) throw new InvalidOperationException("Engine not initialized. Call Initialize first.");
 
+        // 排空跨线程失效请求（视频解码线程投递的新帧/加载完成）。
+        DrainPendingInvalidations();
+        SyncVideoSessions(_root);
+
         _renderEngine.SetCanvas(canvas);
 
         if (_dirtyManager.HasDirtyRegions())
@@ -154,6 +185,9 @@ public class MikoEngine
     {
         if (_root == null) throw new InvalidOperationException("Engine not initialized. Call Initialize first.");
 
+        // 排空跨线程失效请求（如视频解码线程投递的新帧/加载完成）。
+        DrainPendingInvalidations();
+
         _renderEngine.SetCanvas(canvas);
 
         var oldStyles = CaptureTransitionableStyles(_root);
@@ -167,6 +201,9 @@ public class MikoEngine
             _currentLayout = _layoutEngine.Layout(_root, _styleSheets, _viewportWidth, _viewportHeight, _safeArea);
         }
 
+        // 同步视频会话（DOM 可能在 Razor 重渲染中增删 <video>）。
+        SyncVideoSessions(_root);
+
         RestoreScrollState(oldLayout, _currentLayout);
         _renderEngine.Render(_currentLayout);
         _dirtyManager.Clear();
@@ -178,6 +215,38 @@ public class MikoEngine
     public void InvalidateElement(Element element)
     {
         _dirtyManager.MarkDirty(element);
+    }
+
+    /// <summary>
+    /// 线程安全的失效入口。供外部线程（视频解码线程、异步资源加载等）调用：
+    /// 仅把元素入队，真正的标脏在下一帧主循环（<see cref="DrainPendingInvalidations"/>）执行，
+    /// 避免与布局/渲染对 DOM 的遍历并发。
+    /// </summary>
+    public void PostInvalidate(Element element)
+    {
+        lock (_pendingInvalidationsLock)
+        {
+            _pendingInvalidations.Add(element);
+        }
+    }
+
+    /// <summary>是否有待处理的跨线程失效请求（平台宿主据此决定是否需要再绘制一帧）。</summary>
+    public bool HasPendingInvalidations
+    {
+        get { lock (_pendingInvalidationsLock) return _pendingInvalidations.Count > 0; }
+    }
+
+    private void DrainPendingInvalidations()
+    {
+        List<Element>? batch = null;
+        lock (_pendingInvalidationsLock)
+        {
+            if (_pendingInvalidations.Count == 0) return;
+            batch = new List<Element>(_pendingInvalidations);
+            _pendingInvalidations.Clear();
+        }
+        foreach (var element in batch)
+            _dirtyManager.MarkDirty(element);
     }
 
     public AnimationManager AnimationManager => _animationManager;
@@ -651,6 +720,140 @@ public class MikoEngine
             child.SetParent(element);
             EnsureParentReferences(child);
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // 视频会话生命周期
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// 同步视频会话与当前 DOM 树：为新出现的 <see cref="VideoElement"/> 创建会话并接管，
+    /// 为已消失的元素回收会话。在每次布局后调用，使会话随元素增删而增删。
+    /// </summary>
+    private void SyncVideoSessions(Element root)
+    {
+        if (VideoBackend == null) return;
+
+        // 收集当前树中所有 VideoElement
+        var present = new HashSet<VideoElement>();
+        CollectVideoElements(root, present);
+
+        // 1. 回收已不在树中的会话
+        if (_videoSessions.Count > 0)
+        {
+            var removed = new List<VideoElement>();
+            foreach (var (element, session) in _videoSessions)
+            {
+                if (!present.Contains(element))
+                {
+                    session.Dispose();
+                    element.Session = null;
+                    removed.Add(element);
+                }
+            }
+            foreach (var element in removed)
+                _videoSessions.Remove(element);
+        }
+
+        // 2. 为新元素创建会话
+        foreach (var video in present)
+        {
+            EnsurePosterDecoded(video);
+
+            if (video.Session != null) continue;
+            if (string.IsNullOrEmpty(video.Source)) continue;
+
+            CreateVideoSession(video);
+        }
+    }
+
+    /// <summary>
+    /// 惰性解码本地 poster 文件（首帧前占位）。仅处理可读的本地文件路径；
+    /// 远程 URL 的获取交由应用层设置 <see cref="VideoElement.PosterBitmap"/>。失败时静默忽略。
+    /// </summary>
+    private static void EnsurePosterDecoded(VideoElement video)
+    {
+        if (video.PosterBitmap != null) return;
+        if (string.IsNullOrEmpty(video.Poster)) return;
+        if (!File.Exists(video.Poster)) return;
+
+        try
+        {
+            using var stream = File.OpenRead(video.Poster);
+            video.PosterBitmap = SKBitmap.Decode(stream);
+        }
+        catch
+        {
+            // poster 解码失败不应影响播放，回退到背景色。
+        }
+    }
+
+    private void CreateVideoSession(VideoElement video)
+    {
+        try
+        {
+            var session = VideoBackend!.CreateSession(
+                new VideoSourceDescriptor(video.Source!),
+                new VideoSessionOptions(
+                    AutoPlay: video.AutoPlay,
+                    Muted: video.Muted,
+                    Loop: video.Loop));
+
+            video.Session = session;
+            _videoSessions[video] = session;
+
+            // 事件可能在解码线程触发，统一通过 PostInvalidate 把重绘转交主循环。
+            session.Event += evt => OnVideoSessionEvent(video, evt);
+
+            _logger.LogDebug("Video session created for <video src=\"{Src}\">", video.Source);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create video session for <video src=\"{Src}\">", video.Source);
+        }
+    }
+
+    private void OnVideoSessionEvent(VideoElement video, VideoSessionEvent evt)
+    {
+        switch (evt)
+        {
+            case VideoSessionEvent.Loaded loaded:
+                // 写入内禀尺寸并触发重排（auto 尺寸的 video 将按真实纵横比布局）。
+                video.IntrinsicWidth = loaded.Width;
+                video.IntrinsicHeight = loaded.Height;
+                PostInvalidate(video);
+                break;
+
+            case VideoSessionEvent.FrameAvailable:
+                // 新帧到达：标脏该元素，下一帧合成最新帧。
+                PostInvalidate(video);
+                break;
+
+            case VideoSessionEvent.Ended:
+                PostInvalidate(video);
+                break;
+
+            case VideoSessionEvent.Error error:
+                _logger.LogError(error.Cause, "Video error on <video src=\"{Src}\">: {Message}",
+                    video.Source, error.Message);
+                break;
+        }
+    }
+
+    private static void CollectVideoElements(Element element, HashSet<VideoElement> sink)
+    {
+        if (element is VideoElement video)
+            sink.Add(video);
+        foreach (var child in element.Children)
+            CollectVideoElements(child, sink);
+    }
+
+    /// <summary>释放所有视频会话。平台宿主关闭时调用。</summary>
+    public void DisposeVideoSessions()
+    {
+        foreach (var session in _videoSessions.Values)
+            session.Dispose();
+        _videoSessions.Clear();
     }
 
     private void ScanAndStartAnimations(Element element)

--- a/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
@@ -41,6 +41,11 @@ public class BlockLayout
             style.PaddingLeft.ToPixels(containerWidth, fs)
         );
 
+        // replaced 元素（video）的内禀尺寸：用于 width/height 为 auto 时回退，
+        // 并支持只给一边时按内禀纵横比补全另一边（与 <img> 行为对齐）。
+        var (intrinsicW, intrinsicH) = GetReplacedIntrinsicSize(box.Element);
+        bool isReplaced = intrinsicW > 0 && intrinsicH > 0;
+
         // 2. 计算 width
         float contentWidth;
         if (!style.Width.IsAuto)
@@ -50,6 +55,23 @@ public class BlockLayout
             {
                 contentWidth -= box.BoxModel.Border.Horizontal + box.BoxModel.Padding.Horizontal;
                 contentWidth = Math.Max(0, contentWidth);
+            }
+        }
+        else if (isReplaced)
+        {
+            // width auto 的 replaced 元素：
+            // - height 也 auto 时用内禀宽；
+            // - height 指定时按纵横比反推宽（保持 video 不变形）。
+            if (style.Height.IsAuto)
+            {
+                contentWidth = intrinsicW;
+            }
+            else
+            {
+                float h = style.Height.ToPixels(constraints.AvailableHeight ?? 0, fs);
+                if (style.BoxSizing == BoxSizing.BorderBox)
+                    h = Math.Max(0, h - box.BoxModel.Border.Vertical - box.BoxModel.Padding.Vertical);
+                contentWidth = h * intrinsicW / intrinsicH;
             }
         }
         else if (constraints.IsInfiniteWidth || containerWidth <= 0)
@@ -261,6 +283,13 @@ public class BlockLayout
                 contentHeight = Math.Max(0, contentHeight);
             }
         }
+        else if (isReplaced)
+        {
+            // height auto 的 replaced 元素：width 指定时按纵横比反推高，否则用内禀高。
+            contentHeight = style.Width.IsAuto
+                ? intrinsicH
+                : contentWidth * intrinsicH / intrinsicW;
+        }
         else if (constraints.AvailableHeight.HasValue &&
                  (style.OverflowY == Overflow.Auto || style.OverflowY == Overflow.Scroll || style.OverflowY == Overflow.Hidden))
         {
@@ -425,6 +454,22 @@ public class BlockLayout
     private static bool IsInlineOrInlineBlock(LayoutBox child)
     {
         return child.Type == LayoutType.Inline || child.Type == LayoutType.InlineBlock;
+    }
+
+    /// <summary>
+    /// replaced 元素（目前仅 video）的内禀尺寸（CSS 像素）。
+    /// 媒体已加载时返回真实尺寸；未知时回退到 HTML 默认 300×150。
+    /// 非 replaced 元素返回 (0, 0)。
+    /// </summary>
+    internal static (float width, float height) GetReplacedIntrinsicSize(Core.Element element)
+    {
+        if (element is Core.DomElements.VideoElement video)
+        {
+            float w = video.IntrinsicWidth ?? 300;
+            float h = video.IntrinsicHeight ?? 150;
+            return (w, h);
+        }
+        return (0, 0);
     }
 
     /// <summary>

--- a/src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs
@@ -88,6 +88,10 @@ public class InlineLayout
         float contentWidth;
         float contentHeight;
 
+        // replaced 元素（video）的内禀尺寸，用于 inline replaced 的盒尺寸（与 <img> 行为对齐）。
+        var (intrinsicW, intrinsicH) = BlockLayout.GetReplacedIntrinsicSize(box.Element);
+        bool isReplaced = intrinsicW > 0 && intrinsicH > 0;
+
         if (!style.Width.IsAuto)
         {
             contentWidth = style.Width.ToPixels(containerWidth, fs);
@@ -95,6 +99,21 @@ public class InlineLayout
             {
                 contentWidth -= box.BoxModel.Border.Horizontal + box.BoxModel.Padding.Horizontal;
                 contentWidth = Math.Max(0, contentWidth);
+            }
+        }
+        else if (isReplaced)
+        {
+            // width auto：height 指定时按纵横比反推宽，否则用内禀宽。
+            if (style.Height.IsAuto)
+            {
+                contentWidth = intrinsicW;
+            }
+            else
+            {
+                float h = style.Height.ToPixels(constraints.AvailableHeight ?? 0, fs);
+                if (style.BoxSizing == BoxSizing.BorderBox)
+                    h = Math.Max(0, h - box.BoxModel.Border.Vertical - box.BoxModel.Padding.Vertical);
+                contentWidth = h * intrinsicW / intrinsicH;
             }
         }
         else if (box.Children.Count == 0 && hasOwnText)
@@ -116,6 +135,13 @@ public class InlineLayout
                 contentHeight -= box.BoxModel.Border.Vertical + box.BoxModel.Padding.Vertical;
                 contentHeight = Math.Max(0, contentHeight);
             }
+        }
+        else if (isReplaced)
+        {
+            // height auto：width 指定时按纵横比反推高，否则用内禀高。
+            contentHeight = style.Width.IsAuto
+                ? intrinsicH
+                : contentWidth * intrinsicH / intrinsicW;
         }
         else if (BlockLayout.GetTextFormControlContentHeight(box) is float formControlHeight)
         {

--- a/src/Miko/Platform/MikoInteractionController.cs
+++ b/src/Miko/Platform/MikoInteractionController.cs
@@ -72,6 +72,10 @@ public sealed class MikoInteractionController
         _hotReloadService = hotReloadService;
         _logger = logger;
 
+        // 视频后端为可选服务：注册了平台后端（如桌面 FFmpegVideoBackend）时注入引擎，
+        // 否则 <video> 元素仅显示背景/poster。
+        _engine.VideoBackend = serviceProvider.GetService<Platform.Video.IVideoBackend>();
+
         if (_options.RouteAssemblies != null || _options.RouteConfigurator != null)
         {
             _router = new Router();

--- a/src/Miko/Platform/Video/IVideoBackend.cs
+++ b/src/Miko/Platform/Video/IVideoBackend.cs
@@ -1,0 +1,23 @@
+namespace Miko.Platform.Video;
+
+/// <summary>
+/// 视频后端工厂。由各平台宿主在启动时注册到 DI 容器（<c>IServiceCollection</c>）。
+/// 渲染引擎只通过本接口创建/销毁播放会话，自身不感知具体平台的解复用与编解码实现。
+/// <para>
+/// 桌面（Miko.Windowing）以 FFmpeg 实现；移动端（未来 Miko.Android / Miko.iOS）
+/// 分别以 MediaCodec / AVFoundation 实现。三者对外形态一致（见 <see cref="IVideoFrameSource"/>），
+/// 区别仅在解码与 GPU 资源来源。
+/// </para>
+/// </summary>
+public interface IVideoBackend
+{
+    /// <summary>
+    /// 为一个 <c>VideoElement</c> 创建播放会话。<paramref name="source"/> 可以是本地文件路径、
+    /// http(s) URL 或自定义 scheme。实现者负责解复用、解码与 GPU 资源分配。
+    /// 会话创建后处于 <see cref="VideoSessionState.Loading"/>，加载完成通过事件通知。
+    /// </summary>
+    IVideoSession CreateSession(VideoSourceDescriptor source, VideoSessionOptions options);
+
+    /// <summary>后端能力查询（硬件解码、HDR、受支持的 MIME 类型等），用于上层降级策略。</summary>
+    VideoBackendCapabilities Capabilities { get; }
+}

--- a/src/Miko/Platform/Video/IVideoFrameSource.cs
+++ b/src/Miko/Platform/Video/IVideoFrameSource.cs
@@ -1,0 +1,32 @@
+using SkiaSharp;
+
+namespace Miko.Platform.Video;
+
+/// <summary>
+/// 渲染线程对视频帧的视图：提供"当前应显示的一帧"作为 GPU 资源。
+/// 不暴露 CPU 像素，从契约上引导零拷贝实现。
+/// <para>
+/// 重要约束：Skia 的 <see cref="GRContext"/> 非线程安全，所有 <c>SKImage.FromTexture</c> 等
+/// GPU 资源包装必须在渲染线程进行。因此后端解码线程只负责把 GPU 资源句柄
+/// （D3D11 共享句柄 / DMA-BUF FD / CVPixelBuffer）放入内部队列，<see cref="AcquireCurrentFrame"/>
+/// 在渲染线程被调用时才真正包装成 <see cref="SKImage"/>。软解后端则在此处一次性上传纹理。
+/// </para>
+/// </summary>
+public interface IVideoFrameSource
+{
+    /// <summary>
+    /// 获取当前帧。返回的 <see cref="SKImage"/> 由帧源拥有并管理生命周期，调用方不得 Dispose。
+    /// 尚无可用帧时（首帧前 / seek 中）返回 <c>null</c>，由上层回退到 poster 或背景。
+    /// <para>
+    /// 仅在渲染线程调用。<paramref name="grContext"/> 为当前渲染所用的 GPU 上下文；
+    /// 离屏/软件渲染（无 GPU 上下文）时为 <c>null</c>，实现应回退到 CPU 光栅图像。
+    /// </para>
+    /// </summary>
+    SKImage? AcquireCurrentFrame(GRContext? grContext);
+
+    /// <summary>
+    /// 通知后端当前帧已被本帧渲染消费，可用于解码节流与 GPU 资源引用计数。
+    /// 与 <see cref="AcquireCurrentFrame"/> 成对调用。
+    /// </summary>
+    void ReleaseCurrentFrame();
+}

--- a/src/Miko/Platform/Video/IVideoSession.cs
+++ b/src/Miko/Platform/Video/IVideoSession.cs
@@ -1,0 +1,48 @@
+namespace Miko.Platform.Video;
+
+/// <summary>
+/// 单个 <c>VideoElement</c> 对应的播放会话。生命周期与该元素绑定：元素首次进入渲染树时由引擎创建，
+/// 元素从树中移除时由引擎 <see cref="System.IDisposable.Dispose"/>。
+/// <para>
+/// 控制方法（Play/Pause/Seek…）从主线程调用；解码与帧产出在后端自有线程进行，
+/// 通过 <see cref="Event"/> 回调通知。回调可能在后端线程触发，订阅方需自行保证线程安全
+/// （引擎侧通过 <c>MikoEngine.PostInvalidate</c> 把失效请求转交主循环）。
+/// </para>
+/// </summary>
+public interface IVideoSession : IDisposable
+{
+    // ---- 控制（主线程调用）---------------------------------------------------
+    void Play();
+    void Pause();
+    void Seek(TimeSpan position);
+
+    /// <param name="volume">0..1，超出范围由实现钳制。</param>
+    void SetVolume(float volume);
+    void SetMuted(bool muted);
+
+    /// <param name="rate">播放速率，1.0 为正常速度。</param>
+    void SetPlaybackRate(float rate);
+    void SetLoop(bool loop);
+
+    // ---- 状态（属性返回当前快照）-------------------------------------------
+    VideoSessionState State { get; }
+    TimeSpan Duration { get; }
+    TimeSpan Position { get; }
+
+    /// <summary>媒体内禀像素宽，用于 replaced 元素的内禀尺寸/纵横比。加载完成前为 0。</summary>
+    int VideoWidth { get; }
+
+    /// <summary>媒体内禀像素高。加载完成前为 0。</summary>
+    int VideoHeight { get; }
+
+    /// <summary>
+    /// 帧源：渲染引擎在合成阶段调用以取当前帧。该调用必须轻量且不阻塞解码线程
+    /// （见 <see cref="IVideoFrameSource"/>）。
+    /// </summary>
+    IVideoFrameSource FrameSource { get; }
+
+    /// <summary>
+    /// 会话事件（Loaded / FrameAvailable / Ended / Error）。可能在后端线程触发。
+    /// </summary>
+    event Action<VideoSessionEvent>? Event;
+}

--- a/src/Miko/Platform/Video/VideoTypes.cs
+++ b/src/Miko/Platform/Video/VideoTypes.cs
@@ -1,0 +1,50 @@
+namespace Miko.Platform.Video;
+
+/// <summary>视频源描述。<paramref name="Uri"/> 为本地路径或 http(s) URL；MIME 可选，用于后端选择解码器。</summary>
+public sealed record VideoSourceDescriptor(string Uri, string? MimeType = null);
+
+/// <summary>会话创建选项，对应 <c>&lt;video&gt;</c> 的 autoplay / muted / loop 等属性。</summary>
+public sealed record VideoSessionOptions(
+    bool AutoPlay = false,
+    bool Muted = false,
+    bool Loop = false,
+    float InitialVolume = 1.0f,
+    bool PreferHardwareDecode = true);
+
+/// <summary>后端能力。上层据此决定是否降级（如不支持硬解时仍可软解，或不支持某 MIME 时回退占位）。</summary>
+public sealed record VideoBackendCapabilities(
+    bool HardwareDecode,
+    bool Hdr,
+    IReadOnlyList<string> SupportedMimeTypes);
+
+/// <summary>会话状态机。</summary>
+public enum VideoSessionState
+{
+    /// <summary>初始态，尚未开始加载。</summary>
+    Idle,
+    /// <summary>正在解复用/打开解码器/缓冲首帧。</summary>
+    Loading,
+    /// <summary>已就绪（已知时长与尺寸），等待播放。</summary>
+    Ready,
+    Playing,
+    Paused,
+    /// <summary>播放至结尾（未开启 loop）。</summary>
+    Ended,
+    Error,
+}
+
+/// <summary>会话事件。可能在后端解码线程触发，订阅方需注意线程边界。</summary>
+public abstract record VideoSessionEvent
+{
+    /// <summary>媒体已加载，已知内禀尺寸与时长。引擎据此写入元素内禀尺寸并触发重排。</summary>
+    public sealed record Loaded(int Width, int Height, TimeSpan Duration) : VideoSessionEvent;
+
+    /// <summary>新解码帧可供显示（PTS 已到呈现时机）。引擎据此把对应元素标脏。</summary>
+    public sealed record FrameAvailable(TimeSpan Pts) : VideoSessionEvent;
+
+    /// <summary>播放结束。</summary>
+    public sealed record Ended : VideoSessionEvent;
+
+    /// <summary>发生错误（打开失败 / 解码错误等）。</summary>
+    public sealed record Error(string Message, Exception? Cause) : VideoSessionEvent;
+}

--- a/src/Miko/Rendering/Painter.cs
+++ b/src/Miko/Rendering/Painter.cs
@@ -466,6 +466,21 @@ public class Painter
     }
 
     /// <summary>
+    /// 绘制一张 <see cref="SKImage"/>（可能由 GPU 纹理零拷贝包装而来，如视频帧）。
+    /// <paramref name="srcRect"/> 为源采样矩形（用于 object-fit 裁剪），null 表示整图。
+    /// </summary>
+    public void DrawImage(SKImage image, RectF dstRect, RectF? srcRect = null)
+    {
+        if (image == null) return;
+
+        using var paint = new SKPaint { IsAntialias = true };
+        if (srcRect is { } src)
+            _canvas.DrawImage(image, src.ToSKRect(), dstRect.ToSKRect(), paint);
+        else
+            _canvas.DrawImage(image, dstRect.ToSKRect(), paint);
+    }
+
+    /// <summary>
     /// 保存画布状态
     /// </summary>
     public int Save() => _canvas.Save();

--- a/src/Miko/Rendering/RenderEngine.cs
+++ b/src/Miko/Rendering/RenderEngine.cs
@@ -20,6 +20,13 @@ public class RenderEngine
 
     private SKCanvas? _canvas;
     private Painter? _painter;
+
+    /// <summary>
+    /// 当前渲染所用的 GPU 上下文。GPU 宿主在拥有 <see cref="GRContext"/> 时设置，
+    /// 供视频帧源把解码 GPU 资源零拷贝包装为 <see cref="SKImage"/>。
+    /// 离屏/软件渲染下为 null，视频帧源应回退到 CPU 光栅图像。
+    /// </summary>
+    public GRContext? GraphicsContext { get; set; }
     private List<RectF>? _dirtyRegions;
     private readonly List<(LayoutBox box, SelectElement select, float scrollOffsetX, float scrollOffsetY)> _pendingDropdowns = new();
     private float _currentScrollOffsetX;
@@ -590,6 +597,64 @@ public class RenderEngine
         {
             _painter.DrawImage(imageElement.Bitmap, box.BoxModel.Content);
         }
+
+        // 渲染视频帧
+        if (element is Miko.Core.DomElements.VideoElement videoElement)
+        {
+            RenderVideoFrame(box, videoElement);
+        }
+    }
+
+    /// <summary>
+    /// 把视频当前帧合成进内容盒。帧是一张 GPU 图像，DrawImage 后即与其它元素进入同一
+    /// Skia 命令流，自动获得 overflow 裁剪、圆角、opacity、transform 与兄弟覆盖等链路。
+    /// 首帧前回退到 poster 占位图，无 poster 时仅保留背景色（已在 RenderBackground 绘制）。
+    /// </summary>
+    private void RenderVideoFrame(LayoutBox box, Miko.Core.DomElements.VideoElement video)
+    {
+        if (_painter == null) return;
+
+        var content = box.BoxModel.Content;
+        if (content.Width <= 0 || content.Height <= 0) return;
+
+        var frame = video.Session?.FrameSource.AcquireCurrentFrame(GraphicsContext);
+        if (frame != null)
+        {
+            try
+            {
+                // 视频默认 object-fit: contain（letterbox），保持纵横比不变形。
+                var dst = FitContain(frame.Width, frame.Height, content);
+                _painter.DrawImage(frame, dst);
+            }
+            finally
+            {
+                video.Session!.FrameSource.ReleaseCurrentFrame();
+            }
+            return;
+        }
+
+        // 首帧前：绘制 poster 占位图（若已解码）。
+        if (video.PosterBitmap != null)
+        {
+            var dst = FitContain(video.PosterBitmap.Width, video.PosterBitmap.Height, content);
+            _painter.DrawImage(video.PosterBitmap, dst);
+        }
+    }
+
+    /// <summary>
+    /// 计算 object-fit: contain 的目标矩形：在 <paramref name="content"/> 内按源纵横比
+    /// 等比缩放并居中，产生上下或左右的 letterbox 空白（由背景色填充）。
+    /// </summary>
+    private static RectF FitContain(float srcW, float srcH, RectF content)
+    {
+        if (srcW <= 0 || srcH <= 0) return content;
+
+        float scale = Math.Min(content.Width / srcW, content.Height / srcH);
+        float w = srcW * scale;
+        float h = srcH * scale;
+        float x = content.X + (content.Width - w) / 2f;
+        float y = content.Y + (content.Height - h) / 2f;
+        return new RectF(x, y, w, h);
     }
 
     /// <summary>

--- a/src/Miko/Styling/StyleResolver.cs
+++ b/src/Miko/Styling/StyleResolver.cs
@@ -241,6 +241,15 @@ public class StyleResolver
                 style.BorderStyle ??= Common.BorderStyle.None;
                 break;
 
+            case "video":
+                // Browser default: display: inline, black background (letterbox bars + 首帧前底色)。
+                // 内禀尺寸不写入样式，由布局在缺省时回退到 300×150（见 BlockLayout replaced 处理）。
+                style.Display ??= Common.Display.Inline;
+                style.BorderWidth ??= Common.Length.Px(0);
+                style.BorderStyle ??= Common.BorderStyle.None;
+                style.BackgroundColor ??= Common.Color.Black;
+                break;
+
             case "select":
                 // Browser default: display: inline-block, border: 1px solid
                 // Padding for text and dropdown arrow

--- a/tests/Miko.Tests/Core/VideoElementTests.cs
+++ b/tests/Miko.Tests/Core/VideoElementTests.cs
@@ -1,0 +1,157 @@
+using Miko.Common;
+using Miko.Components;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Core;
+
+/// <summary>
+/// VideoElement 的标签构建、默认样式与 replaced 内禀尺寸布局测试。
+/// </summary>
+public class VideoElementTests
+{
+    private readonly LayoutEngine _layoutEngine = new();
+
+    // ---- 标签 / 属性构建 ---------------------------------------------------
+
+    [Fact]
+    public void RenderTreeBuilder_VideoTag_BuildsVideoElement()
+    {
+        var builder = new RenderTreeBuilder();
+        builder.OpenElement(0, "video");
+        builder.AddAttribute(1, "src", "movie.mp4");
+        builder.AddAttribute(2, "autoplay", "true");
+        builder.AddAttribute(3, "loop", "true");
+        builder.AddAttribute(4, "muted", "true");
+        builder.AddAttribute(5, "poster", "poster.png");
+        builder.CloseElement();
+
+        var root = builder.Build();
+
+        var video = root.ShouldBeOfType<VideoElement>();
+        video.TagName.ShouldBe("video");
+        video.Source.ShouldBe("movie.mp4");
+        video.AutoPlay.ShouldBeTrue();
+        video.Loop.ShouldBeTrue();
+        video.Muted.ShouldBeTrue();
+        video.Poster.ShouldBe("poster.png");
+    }
+
+    [Fact]
+    public void RenderTreeBuilder_VideoBooleanFalse_IsFalse()
+    {
+        var builder = new RenderTreeBuilder();
+        builder.OpenElement(0, "video");
+        builder.AddAttribute(1, "src", "movie.mp4");
+        builder.AddAttribute(2, "autoplay", "false");
+        builder.CloseElement();
+
+        var video = builder.Build().ShouldBeOfType<VideoElement>();
+        video.AutoPlay.ShouldBeFalse();
+    }
+
+    // ---- 默认样式 ----------------------------------------------------------
+
+    [Fact]
+    public void Resolve_VideoElement_DefaultsToBlackBackgroundAndNoBorder()
+    {
+        var computed = new StyleResolver().Resolve(new VideoElement(), []);
+
+        computed.BorderTopWidth.Value.ShouldBe(0);
+        computed.BorderTopStyle.ShouldBe(BorderStyle.None);
+        computed.BackgroundColor.ShouldBe(Color.Black);
+    }
+
+    // ---- replaced 内禀尺寸布局 --------------------------------------------
+
+    [Fact]
+    public void Layout_VideoNoIntrinsic_NoStyle_FallsBackToDefault300x150()
+    {
+        var video = new VideoElement();
+
+        var box = LayoutVideo(video);
+
+        box.BoxModel.Content.Width.ShouldBe(300);
+        box.BoxModel.Content.Height.ShouldBe(150);
+    }
+
+    [Fact]
+    public void Layout_VideoWithIntrinsic_UsesIntrinsicSize()
+    {
+        var video = new VideoElement();
+        SetIntrinsic(video, 640, 360);
+
+        var box = LayoutVideo(video);
+
+        box.BoxModel.Content.Width.ShouldBe(640);
+        box.BoxModel.Content.Height.ShouldBe(360);
+    }
+
+    [Fact]
+    public void Layout_VideoWidthOnly_DerivesHeightFromAspectRatio()
+    {
+        var video = new VideoElement();
+        SetIntrinsic(video, 640, 360);   // 16:9
+
+        var box = LayoutVideo(video, new Style { Display = Display.Block, Width = Length.Px(320) });
+
+        box.BoxModel.Content.Width.ShouldBe(320);
+        box.BoxModel.Content.Height.ShouldBe(180);   // 320 * 360/640
+    }
+
+    [Fact]
+    public void Layout_VideoHeightOnly_DerivesWidthFromAspectRatio()
+    {
+        var video = new VideoElement();
+        SetIntrinsic(video, 640, 360);
+
+        var box = LayoutVideo(video, new Style { Display = Display.Block, Height = Length.Px(180) });
+
+        box.BoxModel.Content.Height.ShouldBe(180);
+        box.BoxModel.Content.Width.ShouldBe(320);    // 180 * 640/360
+    }
+
+    [Fact]
+    public void Layout_VideoExplicitWidthHeight_OverridesIntrinsic()
+    {
+        var video = new VideoElement();
+        SetIntrinsic(video, 640, 360);
+
+        var box = LayoutVideo(video, new Style { Display = Display.Block, Width = Length.Px(500), Height = Length.Px(400) });
+
+        box.BoxModel.Content.Width.ShouldBe(500);
+        box.BoxModel.Content.Height.ShouldBe(400);
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private LayoutBox LayoutVideo(VideoElement video, Style? style = null)
+    {
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new TagSelector("video"),
+                        Style = style ?? new Style { Display = Display.Block }
+                    }
+                }
+            }
+        };
+
+        return _layoutEngine.Layout(video, styleSheets, 800, 600);
+    }
+
+    private static void SetIntrinsic(VideoElement video, int w, int h)
+    {
+        // IntrinsicWidth/Height 是 internal，测试程序集通过 InternalsVisibleTo 访问。
+        video.IntrinsicWidth = w;
+        video.IntrinsicHeight = h;
+    }
+}

--- a/tests/Miko.Tests/Core/VideoSessionLifecycleTests.cs
+++ b/tests/Miko.Tests/Core/VideoSessionLifecycleTests.cs
@@ -1,0 +1,213 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Platform.Video;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Core;
+
+/// <summary>
+/// 视频会话生命周期：用 fake 后端验证引擎在渲染时创建会话、写入内禀尺寸、
+/// 处理跨线程失效，并在元素离开树时回收会话——不依赖真实 FFmpeg。
+/// </summary>
+public class VideoSessionLifecycleTests : IDisposable
+{
+    private readonly SKBitmap _bitmap = new(800, 600);
+    private readonly SKCanvas _canvas;
+
+    public VideoSessionLifecycleTests() => _canvas = new SKCanvas(_bitmap);
+
+    public void Dispose()
+    {
+        _canvas.Dispose();
+        _bitmap.Dispose();
+    }
+
+    private static List<StyleSheet> VideoSheet() => new()
+    {
+        new StyleSheet
+        {
+            Rules = new List<StyleRule>
+            {
+                new() { Selector = new TagSelector("div"), Style = new Style { Display = Display.Block } },
+                new() { Selector = new TagSelector("video"), Style = new Style { Display = Display.Block } },
+            }
+        }
+    };
+
+    [Fact]
+    public void Initialize_WithVideoElement_CreatesSession()
+    {
+        var backend = new FakeVideoBackend();
+        var engine = new MikoEngine { VideoBackend = backend };
+        var video = new VideoElement { Source = "movie.mp4" };
+        var root = new DivElement { Children = { video } };
+
+        engine.Initialize(root, VideoSheet(), _canvas, 800, 600);
+
+        backend.CreatedSessions.Count.ShouldBe(1);
+        backend.CreatedSessions[0].SourceUri.ShouldBe("movie.mp4");
+        video.Session.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void VideoWithoutSource_DoesNotCreateSession()
+    {
+        var backend = new FakeVideoBackend();
+        var engine = new MikoEngine { VideoBackend = backend };
+        var root = new DivElement { Children = { new VideoElement() } };
+
+        engine.Initialize(root, VideoSheet(), _canvas, 800, 600);
+
+        backend.CreatedSessions.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void LoadedEvent_WritesIntrinsicSize_AndRelayoutUsesIt()
+    {
+        var backend = new FakeVideoBackend();
+        var engine = new MikoEngine { VideoBackend = backend };
+        var video = new VideoElement { Source = "movie.mp4" };
+        var root = new DivElement { Children = { video } };
+
+        engine.Initialize(root, VideoSheet(), _canvas, 800, 600);
+
+        // 首帧前回退到默认 300×150
+        engine.GetCurrentLayout().ShouldNotBeNull();
+        FindBox(engine.GetCurrentLayout()!, video)!.BoxModel.Content.Width.ShouldBe(300);
+
+        // 后端报告媒体尺寸（模拟解码线程事件）
+        backend.CreatedSessions[0].RaiseLoaded(1280, 720, TimeSpan.FromSeconds(10));
+
+        // 跨线程失效在下一次 Render 时排空并重排
+        engine.Render(_canvas);
+
+        video.IntrinsicWidth.ShouldBe(1280);
+        video.IntrinsicHeight.ShouldBe(720);
+        FindBox(engine.GetCurrentLayout()!, video)!.BoxModel.Content.Width.ShouldBe(1280);
+    }
+
+    [Fact]
+    public void VideoRemovedFromTree_DisposesSession()
+    {
+        var backend = new FakeVideoBackend();
+        var engine = new MikoEngine { VideoBackend = backend };
+        var video = new VideoElement { Source = "movie.mp4" };
+        var root = new DivElement { Children = { video } };
+
+        engine.Initialize(root, VideoSheet(), _canvas, 800, 600);
+        var session = backend.CreatedSessions[0];
+        session.Disposed.ShouldBeFalse();
+
+        // 移除 video 后重新渲染：会话应被回收
+        root.Children.Clear();
+        engine.Render(_canvas);
+
+        session.Disposed.ShouldBeTrue();
+        video.Session.ShouldBeNull();
+    }
+
+    [Fact]
+    public void DisposeVideoSessions_DisposesAll()
+    {
+        var backend = new FakeVideoBackend();
+        var engine = new MikoEngine { VideoBackend = backend };
+        var root = new DivElement
+        {
+            Children =
+            {
+                new VideoElement { Source = "a.mp4" },
+                new VideoElement { Source = "b.mp4" },
+            }
+        };
+
+        engine.Initialize(root, VideoSheet(), _canvas, 800, 600);
+        backend.CreatedSessions.Count.ShouldBe(2);
+
+        engine.DisposeVideoSessions();
+
+        backend.CreatedSessions.ShouldAllBe(s => s.Disposed);
+    }
+
+    [Fact]
+    public void PostInvalidate_IsThreadSafeEntryPoint()
+    {
+        var engine = new MikoEngine();
+        var root = new DivElement();
+        engine.Initialize(root, VideoSheet(), _canvas, 800, 600);
+
+        engine.HasPendingInvalidations.ShouldBeFalse();
+        engine.PostInvalidate(root);
+        engine.HasPendingInvalidations.ShouldBeTrue();
+
+        // Render 排空待处理失效
+        engine.Render(_canvas);
+        engine.HasPendingInvalidations.ShouldBeFalse();
+    }
+
+    private static LayoutBox? FindBox(LayoutBox box, Element element)
+    {
+        if (box.Element == element) return box;
+        foreach (var child in box.Children)
+        {
+            var found = FindBox(child, element);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    // ---- fakes -------------------------------------------------------------
+
+    private sealed class FakeVideoBackend : IVideoBackend
+    {
+        public List<FakeVideoSession> CreatedSessions { get; } = new();
+
+        public VideoBackendCapabilities Capabilities { get; } =
+            new(HardwareDecode: false, Hdr: false, SupportedMimeTypes: new[] { "video/mp4" });
+
+        public IVideoSession CreateSession(VideoSourceDescriptor source, VideoSessionOptions options)
+        {
+            var session = new FakeVideoSession(source.Uri);
+            CreatedSessions.Add(session);
+            return session;
+        }
+    }
+
+    private sealed class FakeVideoSession : IVideoSession
+    {
+        public string SourceUri { get; }
+        public bool Disposed { get; private set; }
+
+        public FakeVideoSession(string uri) => SourceUri = uri;
+
+        public void RaiseLoaded(int w, int h, TimeSpan duration)
+            => Event?.Invoke(new VideoSessionEvent.Loaded(w, h, duration));
+
+        public IVideoFrameSource FrameSource { get; } = new FakeFrameSource();
+        public VideoSessionState State => VideoSessionState.Ready;
+        public TimeSpan Duration => TimeSpan.Zero;
+        public TimeSpan Position => TimeSpan.Zero;
+        public int VideoWidth => 0;
+        public int VideoHeight => 0;
+        public event Action<VideoSessionEvent>? Event;
+
+        public void Play() { }
+        public void Pause() { }
+        public void Seek(TimeSpan position) { }
+        public void SetVolume(float volume) { }
+        public void SetMuted(bool muted) { }
+        public void SetPlaybackRate(float rate) { }
+        public void SetLoop(bool loop) { }
+        public void Dispose() => Disposed = true;
+    }
+
+    private sealed class FakeFrameSource : IVideoFrameSource
+    {
+        public SKImage? AcquireCurrentFrame(GRContext? grContext) => null;
+        public void ReleaseCurrentFrame() { }
+    }
+}


### PR DESCRIPTION
## 概述

新增 `<video>` 标签支持（ISSUE-058），并修复拖动/缩放窗口时渲染冻结的问题（ISSUE-059）。两者共享桌面窗口宿主，故合并为一个 PR。

## 视频（`Miko` 核心，平台无关）

- **抽象接口** `Platform/Video/`：`IVideoBackend` / `IVideoSession` / `IVideoFrameSource`（+ source/options/capabilities/state/event records）。帧源契约只暴露 `SKImage`，并把 GPU 资源包装限定在渲染线程，为后续零拷贝硬解留口。
- **`VideoElement`** + `RenderTreeBuilder` 标签/属性注册（`src/poster/autoplay/loop/muted/controls`）。
- **布局 / 合成**：Block/Inline 的 replaced 内禀尺寸（按纵横比补全、缺省 300×150）、默认样式、`Painter.DrawImage(SKImage)` 重载、`RenderEngine` 的 `object-fit: contain` 合成——自动继承 overflow 裁剪 / 圆角 / opacity / transform / 兄弟覆盖。
- **`MikoEngine`** 会话生命周期（随 DOM 增删创建/回收）、线程安全 `PostInvalidate`、`Loaded` 驱动内禀尺寸重排。

## Windows 后端（`Miko.Windowing`）

- `FFmpegVideoBackend` / `Session` / `FrameSource`：基于 `Sdcb.FFmpeg` 的**软解基线**，PTS 墙钟节流，支持 play/pause/seek/loop；原生库经 `Sdcb.FFmpeg.runtime.windows-x64` 随输出复制，无需手动安装 FFmpeg。`UseFFmpegVideo()` DI 注册。
- 仅实现 Windows；Linux/macOS 共用该宿主但未启用平台特定硬解路径。零拷贝硬解（D3D11VA + WGL_NV_DX_interop2）在同一 `IVideoFrameSource` 契约下作为后续。

## 渲染线程（ISSUE-059）

拖动标题栏/缩放边框时 Windows 进入模态 move/size 消息循环，阻塞主线程的消息泵，导致动画与视频冻结（GLFW 已知限制）。

- `SilkDesktopHost` 改为**主线程泵消息 + 专用渲染线程**，主线程被模态循环卡住时渲染照常出帧。
- 输入经**无锁消息队列**（单消费者）从主线程流向渲染线程，DOM 只被渲染线程触碰——以队列代替锁，根除跨线程 DOM 竞争。

## 测试

新增 14 项单测（`VideoElementTests` / `VideoSessionLifecycleTests`）覆盖标签构建、默认样式、replaced 纵横比、会话生命周期、跨线程失效；**全套 899 项测试通过**，`dotnet build miko.slnx` 通过。无头端到端自检：编码 320×240 片段经真实 FFmpeg 后端解码 156 帧、`Loaded` 尺寸正确、产出有效 `SKImage`、`Ended` 正常。

> 注：拖动/缩放期间「画面不冻结」的最终效果需在真实窗口交互下肉眼确认（无头环境无法自动化）。