### PR TITLE
feat(components): CascadingValue support and transparent multi-root FragmentElement

### DIFF
--- a/src/Miko/Components/CascadingParameterAttribute.cs
+++ b/src/Miko/Components/CascadingParameterAttribute.cs
@@ -1,0 +1,26 @@
+namespace Miko.Components;
+
+/// <summary>
+/// Marks a component property that should receive its value from an ancestor
+/// <see cref="CascadingValue{TValue}"/> rather than from a parent-supplied parameter.
+/// Mirrors Blazor's <c>[CascadingParameter]</c>.
+/// <para>
+/// By default the value is matched by the property's type (the nearest ancestor
+/// <see cref="CascadingValue{TValue}"/> whose declared <c>TValue</c> is assignable to the
+/// property type). Set <see cref="Name"/> to instead match a named cascading value.
+/// </para>
+/// <para>
+/// Cascading parameters are resolved in <see cref="ComponentBase.Build"/> before the lifecycle
+/// methods run, so they are available inside <see cref="ComponentBase.OnInitialized"/> /
+/// <see cref="ComponentBase.OnParametersSet"/>.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class CascadingParameterAttribute : Attribute
+{
+    /// <summary>
+    /// Optional name to match a named <see cref="CascadingValue{TValue}.Name"/>.
+    /// When null (the default), the value is matched by type.
+    /// </summary>
+    public string? Name { get; set; }
+}

--- a/src/Miko/Components/CascadingValue.cs
+++ b/src/Miko/Components/CascadingValue.cs
@@ -1,0 +1,55 @@
+using Miko.Core;
+
+namespace Miko.Components;
+
+/// <summary>
+/// Provides a value to all descendant components in its <see cref="ComponentBase.ChildContent"/>,
+/// which they can receive via a <see cref="CascadingParameterAttribute"/>. Mirrors Blazor's
+/// <c>CascadingValue&lt;TValue&gt;</c>.
+/// <para>
+/// Usage in a <c>.razor</c> file:
+/// <code>
+/// &lt;CascadingValue Value="theme"&gt;
+///     &lt;ChildContent&gt;...descendants read [CascadingParameter] Theme...&lt;/ChildContent&gt;
+/// &lt;/CascadingValue&gt;
+/// </code>
+/// </para>
+/// <para>
+/// This component is transparent: it renders no element of its own, only its child content.
+/// It is matched by descendants either by type (<typeparamref name="TValue"/>) or, when
+/// <see cref="Name"/> is set, by name.
+/// </para>
+/// <para>
+/// Unlike Blazor there is no <c>IsFixed</c> optimization: Miko re-renders subtrees wholesale via
+/// <see cref="ComponentBase.StateHasChanged"/>, so each render rebuilds the children and re-reads
+/// the current <see cref="Value"/>.
+/// </para>
+/// </summary>
+/// <typeparam name="TValue">The declared type of the cascading value.</typeparam>
+public class CascadingValue<TValue> : ComponentBase
+{
+    /// <summary>The value to supply to descendant components.</summary>
+    [Parameter] public TValue? Value { get; set; }
+
+    /// <summary>
+    /// Optional name. When set, descendants must request this value via
+    /// <c>[CascadingParameter(Name = "...")]</c>; otherwise it is matched by type.
+    /// </summary>
+    [Parameter] public string? Name { get; set; }
+
+    // ChildContent is inherited from ComponentBase.
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        // Push the declared TValue (not Value?.GetType()) so a null value still resolves by type.
+        // The children are rendered INSIDE this scope so their nested Build() calls (driven by
+        // RenderTreeBuilder.CloseComponent, still on the call stack) can resolve this value.
+        using var _ = CascadingValueSource.Push(Value, typeof(TValue), Name);
+
+        // Render no element of our own — CascadingValue is transparent, like in Blazor. The child
+        // content is emitted directly into the parent so it doesn't disturb layout. When the child
+        // content produces several top-level elements, they are carried by a transparent
+        // FragmentElement that stays in the DOM but is skipped by the layout engine (display:contents).
+        ChildContent?.Invoke(builder);
+    }
+}

--- a/src/Miko/Components/CascadingValueSource.cs
+++ b/src/Miko/Components/CascadingValueSource.cs
@@ -1,0 +1,95 @@
+namespace Miko.Components;
+
+/// <summary>
+/// Ambient stack of active cascading values, used to flow values from an ancestor
+/// <see cref="CascadingValue{TValue}"/> down to descendant components that declare a
+/// <see cref="CascadingParameterAttribute"/>.
+/// <para>
+/// The render tree is built synchronously, top-down, on a single render thread:
+/// <see cref="RenderTreeBuilder.CloseComponent"/> invokes a child's <see cref="ComponentBase.Build"/>
+/// while the ancestor is still inside its own <c>BuildRenderTree</c> on the call stack. So a
+/// <see cref="System.ThreadStaticAttribute">thread-static</see> stack precisely models which
+/// cascading values are in scope at the point any given component builds: a provider pushes before
+/// rendering its children and pops afterwards (via the returned <see cref="IDisposable"/>), and a
+/// descendant reads the nearest matching entry during its own build.
+/// </para>
+/// </summary>
+internal static class CascadingValueSource
+{
+    private readonly struct Frame
+    {
+        public readonly Type ValueType;
+        public readonly string? Name;
+        public readonly object? Value;
+
+        public Frame(Type valueType, string? name, object? value)
+        {
+            ValueType = valueType;
+            Name = name;
+            Value = value;
+        }
+    }
+
+    [ThreadStatic]
+    private static Stack<Frame>? _stack;
+
+    private static Stack<Frame> Stack => _stack ??= new Stack<Frame>();
+
+    /// <summary>
+    /// Pushes a cascading value onto the ambient stack and returns a handle that pops it when
+    /// disposed. <paramref name="valueType"/> is the provider's declared <c>TValue</c> (not the
+    /// runtime type of <paramref name="value"/>), so a null value still resolves by its declared
+    /// type — mirroring Blazor.
+    /// </summary>
+    public static IDisposable Push(object? value, Type valueType, string? name)
+    {
+        var stack = Stack;
+        stack.Push(new Frame(valueType, name, value));
+        return new PopHandle(stack);
+    }
+
+    /// <summary>
+    /// Resolves the nearest cascading value matching the requested target type / name.
+    /// When <paramref name="name"/> is non-null, only entries with the same name match.
+    /// Otherwise the nearest entry whose declared type is assignable to <paramref name="targetType"/>
+    /// matches. Returns false (and a null value) when nothing matches.
+    /// </summary>
+    public static bool TryResolve(Type targetType, string? name, out object? value)
+    {
+        if (_stack != null)
+        {
+            // Stack enumeration is newest→oldest, so inner providers shadow outer ones.
+            foreach (var frame in _stack)
+            {
+                bool matches = name != null
+                    ? string.Equals(frame.Name, name, StringComparison.Ordinal)
+                    : frame.Name == null && targetType.IsAssignableFrom(frame.ValueType);
+
+                if (matches)
+                {
+                    value = frame.Value;
+                    return true;
+                }
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private sealed class PopHandle : IDisposable
+    {
+        private Stack<Frame>? _stack;
+
+        public PopHandle(Stack<Frame> stack) => _stack = stack;
+
+        public void Dispose()
+        {
+            // Pop once; tolerate an already-unwound stack (e.g. on an exceptional build path).
+            var stack = _stack;
+            if (stack is { Count: > 0 })
+                stack.Pop();
+            _stack = null;
+        }
+    }
+}

--- a/src/Miko/Components/ComponentBase.cs
+++ b/src/Miko/Components/ComponentBase.cs
@@ -1,6 +1,8 @@
 ﻿using Miko.Core;
 using Miko.Layout;
 using Miko.Routing;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 
 namespace Miko.Components;
 
@@ -49,6 +51,12 @@ public abstract class ComponentBase : IComponent
 
     public virtual Element Build()
     {
+        // Resolve cascading parameters first, so they're available inside the lifecycle methods
+        // below (matches Blazor, where cascading values arrive with the initial parameter set).
+        // The ambient values are in scope because the providing CascadingValue<T>.Build is still
+        // on the call stack (see CascadingValueSource).
+        SetCascadingParameters();
+
         if (!_initialized)
         {
             OnInitialized();
@@ -163,9 +171,32 @@ public abstract class ComponentBase : IComponent
 
     private Element BuildNew()
     {
+        SetCascadingParameters();
         var builder = new RenderTreeBuilder();
         BuildRenderTree(builder);
         return builder.Build();
+    }
+
+    /// <summary>
+    /// Populates this component's <see cref="CascadingParameterAttribute"/> properties from the
+    /// ambient <see cref="CascadingValueSource"/>. Mirrors how <c>[Inject]</c> is resolved by
+    /// reflection in <see cref="RouteView"/>. Properties with no matching provider are left
+    /// untouched (keep their default).
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "Cascading parameter properties are declared on the component type and preserved with it.")]
+    private void SetCascadingParameters()
+    {
+        var properties = GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        foreach (var prop in properties)
+        {
+            if (!prop.CanWrite) continue;
+            var attr = prop.GetCustomAttribute<CascadingParameterAttribute>();
+            if (attr == null) continue;
+
+            if (CascadingValueSource.TryResolve(prop.PropertyType, attr.Name, out var value))
+                prop.SetValue(this, value);
+        }
     }
 
     private static void ReplaceElementContent(Element target, Element source)

--- a/src/Miko/Components/RenderTreeBuilder.cs
+++ b/src/Miko/Components/RenderTreeBuilder.cs
@@ -62,7 +62,7 @@ public class RenderTreeBuilder
         if (_stack.Count > 0)
             _stack.Peek().AddChild(element);
         else
-            // 顶层元素：经 AttachToTree 处理多根（多个顶层元素自动包裹进一个 div），
+            // 顶层元素：经 AttachToTree 处理多根（多个顶层元素并入一个透明片段），
             // 避免后一个根覆盖前一个（如 <video/> 之后再跟条件块时丢失 video）。
             AttachToTree(element);
     }
@@ -187,12 +187,16 @@ public class RenderTreeBuilder
 
     public void AddContent(int seq, object? text)
     {
-        if (_stack.Count == 0 || text is null) return;
+        if (text is null) return;
+        // A RenderFragment may emit top-level elements (e.g. a transparent CascadingValue whose
+        // ChildContent is rendered with no open element on the stack), so invoke it regardless of
+        // stack depth. Only literal/text content requires an open element to attach to.
         if (text is RenderFragment fragment)
         {
             fragment(this);
             return;
         }
+        if (_stack.Count == 0) return;
         var str = text.ToString();
         if (string.IsNullOrEmpty(str)) return;
         var decoded = WebUtility.HtmlDecode(str);
@@ -229,15 +233,12 @@ public class RenderTreeBuilder
         var component = _componentStack.Pop();
         var element = component.Build();
         // Link the produced element back to its component so the component can be disposed
-        // (e.g. unsubscribe from events) when this element subtree is later discarded.
+        // (e.g. unsubscribe from events) when this element subtree is later discarded. When the
+        // component produced several top-level elements, `element` is a transparent FragmentElement
+        // that stays in the tree (and is skipped by layout); the callback lives on it as usual.
         element.DisposeCallback = component.DisposeInternal;
         if (_stack.Count > 0)
             _stack.Peek().AddChild(element);
-        else if (_componentStack.Count > 0)
-        {
-            // nested component scenario — shouldn't happen normally
-            AttachToTree(element);
-        }
         else
             AttachToTree(element);
     }
@@ -256,9 +257,10 @@ public class RenderTreeBuilder
     {
         if (_stack.Count > 0)
             throw new InvalidOperationException("Unclosed elements remain in the render tree.");
-        if (_root is null)
-            throw new InvalidOperationException("No elements were added to the render tree.");
-        return _root;
+        // A component that rendered nothing (e.g. a transparent CascadingValue with null
+        // ChildContent) yields an empty transparent FragmentElement rather than throwing. The
+        // empty fragment carries no layout box, so it represents "rendered nothing" faithfully.
+        return _root ??= new FragmentElement();
     }
 
     private static readonly Regex _tokenRegex = new(
@@ -337,8 +339,11 @@ public class RenderTreeBuilder
         }
     }
 
-    // 由多根包裹自动生成的 div（非用户书写）。用于把后续顶层元素平铺追加，避免逐层嵌套。
-    private DivElement? _syntheticRoot;
+    // 由多根自动生成的透明片段容器（非用户书写）。用于把全部顶层元素平铺承载。
+    // 它留在 DOM 树中作为组件的稳定根（供 StateHasChanged 原地重渲染），但对布局透明
+    // ——LayoutEngine 不为其建盒，而是把其子节点的盒子摊平进父级（等价 display:contents）。
+    // 见 FragmentElement 与 LayoutEngine.AppendChildLayoutBoxes。
+    private FragmentElement? _syntheticRoot;
 
     private void AttachToTree(Element element)
     {
@@ -354,11 +359,13 @@ public class RenderTreeBuilder
             return;
         }
 
-        // 出现第二个及以上顶层元素：用一个 div 平铺包裹全部顶层元素（而非逐层嵌套）。
+        // 出现第二个及以上顶层元素：用一个透明片段平铺承载全部顶层元素（而非逐层嵌套，
+        // 也不套不透明 div，避免破坏样式布局）。若已有根本身就是片段，则直接复用为承载容器。
         if (_syntheticRoot is null)
         {
-            _syntheticRoot = new DivElement();
-            _syntheticRoot.AddChild(_root);
+            _syntheticRoot = _root as FragmentElement ?? new FragmentElement();
+            if (!ReferenceEquals(_syntheticRoot, _root))
+                _syntheticRoot.AddChild(_root);
             _root = _syntheticRoot;
         }
         _syntheticRoot.AddChild(element);

--- a/src/Miko/Core/DomElements/ContainerElements.cs
+++ b/src/Miko/Core/DomElements/ContainerElements.cs
@@ -39,3 +39,16 @@ public class StrongElement : Element
 {
     public override string TagName => "strong";
 }
+
+/// <summary>
+/// 透明片段容器（非用户书写）。当一个组件/页面产出多个顶层元素时，
+/// <see cref="Miko.Components.RenderTreeBuilder"/> 用它来承载这些元素。
+/// 它留在 DOM 树中作为多根组件的稳定根（供 StateHasChanged 原地重渲染），但对布局透明：
+/// LayoutEngine 不为其自身建盒，而是把其子节点的布局盒摊平进父级，等价于 CSS 的
+/// <c>display: contents</c>，因此不会引入任何破坏样式的包裹层。仅当片段本身是布局根
+/// （无 Layout 的多根页面）时，才按普通块盒充当 issue 所允许的"自动创建的根包裹"。
+/// </summary>
+public class FragmentElement : Element
+{
+    public override string TagName => "fragment";
+}

--- a/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
@@ -107,6 +107,27 @@ public class FlexLayout
         bool isRow = style.FlexDirection == FlexDirection.Row ||
                      style.FlexDirection == FlexDirection.RowReverse;
 
+        // 2b. 当尺寸为 auto 时，提前用 min-height / min-width 抬升内容区尺寸，再交给行/列布局。
+        // 这样当容器（如 ion-segment-button）靠 min-height 撑出高度、但内容更小时，主轴上的
+        // justify-content 能在该 min 尺寸内居中子元素（否则主轴尺寸仍为 0，对齐被跳过，子元素贴边）。
+        // 交叉轴上的 align-items 同理受 min-width / min-height 影响。
+        // 注意：min 只在 auto 维度上抬升占位尺寸，不影响显式尺寸（显式尺寸已是确定值）。
+        if (style.Height.IsAuto && !style.MinHeight.IsAuto)
+        {
+            float minH = style.MinHeight.ToPixels(constraints.AvailableHeight ?? 0, fs);
+            if (style.BoxSizing == BoxSizing.BorderBox)
+                minH = Math.Max(0, minH - box.BoxModel.Border.Vertical - box.BoxModel.Padding.Vertical);
+            contentHeight = Math.Max(contentHeight, minH);
+        }
+        if (style.Width.IsAuto && !style.MinWidth.IsAuto)
+        {
+            float minW = style.MinWidth.ToPixels(constraints.AvailableWidth ?? 0, fs);
+            if (style.BoxSizing == BoxSizing.BorderBox)
+                minW = Math.Max(0, minW - box.BoxModel.Border.Horizontal - box.BoxModel.Padding.Horizontal);
+            contentWidth = Math.Max(contentWidth, minW);
+            if (contentWidth > 0) widthIsIndefinite = false;
+        }
+
         // 4. 布局子元素
         float contentX = x + box.BoxModel.Margin.Left + box.BoxModel.Border.Left + box.BoxModel.Padding.Left;
         float contentY = y + box.BoxModel.Margin.Top + box.BoxModel.Border.Top + box.BoxModel.Padding.Top;

--- a/src/Miko/Layout/LayoutEngine.cs
+++ b/src/Miko/Layout/LayoutEngine.cs
@@ -261,11 +261,7 @@ public class LayoutEngine
         // 递归构建子元素的布局树
         foreach (var child in element.Children)
         {
-            var childLayoutBox = BuildLayoutTree(child, styleSheets);
-            if (childLayoutBox != null)
-            {
-                layoutBox.Children.Add(childLayoutBox);
-            }
+            AppendChildLayoutBoxes(layoutBox, child, styleSheets);
         }
 
         // 注入 ::after 伪元素
@@ -276,6 +272,32 @@ public class LayoutEngine
         }
 
         return layoutBox;
+    }
+
+    /// <summary>
+    /// 将 <paramref name="child"/> 的布局盒加入 <paramref name="parentBox"/>。
+    /// <see cref="FragmentElement"/> 是透明容器：不为其自身建盒，而是把其子节点的布局盒
+    /// 直接摊平进父盒（等价 CSS <c>display: contents</c>）。片段留在 DOM 树中作为多根组件的
+    /// 稳定根（供 StateHasChanged 原地重渲染），但在布局上不产生任何包裹盒，从而不影响样式。
+    /// 注意：当片段本身是布局根（无父，如无 Layout 的多根页面）时不经此路径，而是按普通块盒
+    /// 充当 issue 所允许的"自动创建的根包裹"。
+    /// </summary>
+    private void AppendChildLayoutBoxes(LayoutBox parentBox, Element child, List<StyleSheet> styleSheets)
+    {
+        if (child is FragmentElement)
+        {
+            foreach (var grandChild in child.Children)
+            {
+                AppendChildLayoutBoxes(parentBox, grandChild, styleSheets);
+            }
+            return;
+        }
+
+        var childLayoutBox = BuildLayoutTree(child, styleSheets);
+        if (childLayoutBox != null)
+        {
+            parentBox.Children.Add(childLayoutBox);
+        }
     }
 
     private LayoutBox? CreatePseudoElementBox(Element element, List<StyleSheet> styleSheets, PseudoElementType type)

--- a/src/Miko/Routing/RouteView.cs
+++ b/src/Miko/Routing/RouteView.cs
@@ -39,11 +39,18 @@ public class RouteView
         if (_defaultLayout != null)
         {
             var layout = (LayoutComponentBase)CreateComponent(_defaultLayout);
+            // The page content (possibly a transparent multi-root FragmentElement) is placed into
+            // the layout's body. The fragment stays in the DOM as the page's stable root, but the
+            // layout engine skips it (display:contents), so no wrapper element disturbs the layout.
             layout.BodyElement = content;
             layout.Body = builder => { builder.AttachElement(content); };
             return layout.Build();
         }
 
+        // No layout: the page is the engine's root. A multi-root page is a transparent
+        // FragmentElement; the layout engine treats a root-level fragment as the (permitted)
+        // auto-created wrapper, so it can be returned as-is — keeping it as the component's
+        // stable root so StateHasChanged can re-render it in place.
         return content;
     }
 

--- a/src/Miko/Styling/StyleResolver.cs
+++ b/src/Miko/Styling/StyleResolver.cs
@@ -216,7 +216,7 @@ public class StyleResolver
                 break;
 
             case "button":
-                // Browser default: display: inline-block, padding: 2px 6px
+                // Browser default: display: inline-block, padding: 2px 6px, text-align: center
                 // Note: Border appearance simplified (browsers use 'outset' style)
                 style.Display ??= Common.Display.InlineBlock;
                 style.BoxSizing ??= Common.BoxSizing.BorderBox;
@@ -227,6 +227,8 @@ public class StyleResolver
                 style.BorderWidth ??= Common.Length.Px(2);
                 style.BorderStyle ??= Common.BorderStyle.Solid;
                 style.BorderColor ??= Common.Color.Gray;
+                // Browsers center button text by default (UA stylesheet text-align: center).
+                style.TextAlign ??= Common.TextAlign.Center;
                 break;
 
             case "input":

--- a/tests/Miko.Tests/Components/CascadingValueTests.cs
+++ b/tests/Miko.Tests/Components/CascadingValueTests.cs
@@ -1,0 +1,242 @@
+using Miko.Components;
+using Miko.Core;
+using Shouldly;
+
+namespace Miko.Tests.Components;
+
+public class CascadingValueTests
+{
+    // ---------------------------------------------------------------------------------------
+    // Test components. Each child receives a cascading value and renders it as text content so
+    // the test can assert on the produced Element. They're driven through RenderTreeBuilder the
+    // same way generated Razor code would: OpenComponent / AddComponentParameter / CloseComponent.
+    // ---------------------------------------------------------------------------------------
+
+    private interface IGreeter { string Hello(); }
+
+    private sealed class Greeter : IGreeter
+    {
+        public string Message = "hi";
+        public string Hello() => Message;
+    }
+
+    // Receives a string by type.
+    private sealed class StringConsumer : ComponentBase
+    {
+        [CascadingParameter] public string? Msg { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddContent(1, Msg ?? "<null>");
+            builder.CloseElement();
+        }
+    }
+
+    // Receives a named int.
+    private sealed class NamedConsumer : ComponentBase
+    {
+        [CascadingParameter(Name = "B")] public int Value { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddContent(1, Value.ToString());
+            builder.CloseElement();
+        }
+    }
+
+    // Receives a service by interface (assignability match).
+    private sealed class ServiceConsumer : ComponentBase
+    {
+        [CascadingParameter] public IGreeter? Greeter { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddContent(1, Greeter?.Hello() ?? "none");
+            builder.CloseElement();
+        }
+    }
+
+    // Reads the cascading value during OnInitialized (timing test).
+    private sealed class LifecycleConsumer : ComponentBase
+    {
+        [CascadingParameter] public string? Msg { get; set; }
+        public string? SeenInOnInitialized { get; private set; }
+
+        protected override void OnInitialized() => SeenInOnInitialized = Msg;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddContent(1, Msg ?? "<null>");
+            builder.CloseElement();
+        }
+    }
+
+    // Helper: builds a CascadingValue<TValue> wrapping a child produced by `childFragment`.
+    private static Element BuildProvider<TValue>(TValue value, string? name, RenderFragment childFragment)
+    {
+        var provider = new CascadingValue<TValue>
+        {
+            Value = value,
+            Name = name,
+            ChildContent = childFragment,
+        };
+        return provider.Build();
+    }
+
+    // Helper: a RenderFragment that renders a single child component of type TChild.
+    private static RenderFragment Child<TChild>(out Func<TChild?> captured)
+        where TChild : ComponentBase, new()
+    {
+        TChild? instance = null;
+        captured = () => instance;
+        return builder =>
+        {
+            // Replicate the compiler's nested-component path so the child's Build() runs inside
+            // the provider's push scope. We instantiate explicitly to capture the instance for
+            // assertions (OpenComponent<T> would create its own we couldn't reach).
+            instance = new TChild();
+            var element = instance.Build();
+            builder.AttachElement(element);
+        };
+    }
+
+    [Fact]
+    public void ResolvesByType()
+    {
+        var root = BuildProvider<string>("hello", null, Child<StringConsumer>(out var child));
+
+        // CascadingValue is transparent: it renders no wrapper element, so a single child becomes
+        // the build result directly (the consumer's <div> with the resolved text).
+        root.TagName.ShouldBe("div");
+        root.TextContent.ShouldBe("hello");
+        child()!.Msg.ShouldBe("hello");
+    }
+
+    [Fact]
+    public void ResolvesByName_PicksMatchingProvider()
+    {
+        // <CascadingValue Name="A" Value="1"><CascadingValue Name="B" Value="2"><NamedConsumer/>
+        var consumerFragment = Child<NamedConsumer>(out var consumer);
+
+        var inner = (RenderFragment)(builder =>
+        {
+            var b = new CascadingValue<int> { Value = 2, Name = "B", ChildContent = consumerFragment };
+            builder.AttachElement(b.Build());
+        });
+
+        BuildProvider<int>(1, "A", inner);
+
+        consumer()!.Value.ShouldBe(2);
+    }
+
+    [Fact]
+    public void InnerProviderShadowsOuter()
+    {
+        // Outer string "outer", inner string "inner"; the deepest consumer sees "inner".
+        var consumerFragment = Child<StringConsumer>(out var consumer);
+
+        var innerProvider = (RenderFragment)(builder =>
+        {
+            var b = new CascadingValue<string> { Value = "inner", ChildContent = consumerFragment };
+            builder.AttachElement(b.Build());
+        });
+
+        BuildProvider<string>("outer", null, innerProvider);
+
+        consumer()!.Msg.ShouldBe("inner");
+    }
+
+    [Fact]
+    public void NoProvider_LeavesParameterDefault_AndDoesNotThrow()
+    {
+        var consumer = new StringConsumer();
+        Element? element = null;
+        Should.NotThrow(() => element = consumer.Build());
+
+        consumer.Msg.ShouldBeNull();
+        element!.TextContent.ShouldBe("<null>");
+    }
+
+    [Fact]
+    public void ResolvesByInterface_AssignabilityMatch()
+    {
+        var greeter = new Greeter { Message = "howdy" };
+        var root = BuildProvider<Greeter>(greeter, null, Child<ServiceConsumer>(out var child));
+
+        child()!.Greeter.ShouldBeSameAs(greeter);
+        // CascadingValue is transparent: the single child is the build result directly.
+        root.TagName.ShouldBe("div");
+        root.TextContent.ShouldBe("howdy");
+    }
+
+    [Fact]
+    public void CascadingValue_AvailableInOnInitialized()
+    {
+        BuildProvider<string>("early", null, Child<LifecycleConsumer>(out var child));
+
+        child()!.SeenInOnInitialized.ShouldBe("early");
+    }
+
+    [Fact]
+    public void NullValue_StillResolvesByDeclaredType()
+    {
+        // Value is null but declared as string; the consumer's Msg should be set to null
+        // (resolved), and the build must not leak a frame or throw.
+        BuildProvider<string?>(null, null, Child<StringConsumer>(out var child));
+
+        // Resolved (matched by declared type) and set to null; build did not throw.
+        child()!.Msg.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Stack_UnwindsAfterBuild()
+    {
+        // After a provider builds, no frame should remain on the ambient stack: an independent
+        // consumer built afterwards must NOT pick up the previous provider's value.
+        BuildProvider<string>("scoped", null, Child<StringConsumer>(out _));
+
+        var afterwards = new StringConsumer();
+        afterwards.Build();
+
+        afterwards.Msg.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TransparentWrapper_DoesNotEmitSpan()
+    {
+        // Regression for ISSUE-066 问题1: CascadingValue must not wrap its child in a <span>.
+        var root = BuildProvider<string>("x", null, Child<StringConsumer>(out _));
+
+        root.ShouldBeOfType<Miko.Core.DomElements.DivElement>();
+        root.FindByTagName("span").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MultipleChildren_ProduceTransparentFragment_StillResolvingValue()
+    {
+        // Two sibling consumers under one CascadingValue: the provider stays transparent (no span),
+        // and the multiple roots are carried by a transparent FragmentElement. Both consumers
+        // resolve the cascading value.
+        StringConsumer? a = null, b = null;
+        RenderFragment children = builder =>
+        {
+            a = new StringConsumer();
+            builder.AttachElement(a.Build());
+            b = new StringConsumer();
+            builder.AttachElement(b.Build());
+        };
+
+        var root = BuildProvider<string>("shared", null, children);
+
+        root.ShouldBeOfType<Miko.Core.DomElements.FragmentElement>();
+        root.Children.Count.ShouldBe(2);
+        root.Children[0].TextContent.ShouldBe("shared");
+        root.Children[1].TextContent.ShouldBe("shared");
+        a!.Msg.ShouldBe("shared");
+        b!.Msg.ShouldBe("shared");
+    }
+}

--- a/tests/Miko.Tests/Components/RenderTreeBuilderTests.cs
+++ b/tests/Miko.Tests/Components/RenderTreeBuilderTests.cs
@@ -17,10 +17,11 @@ public class RenderTreeBuilderTests
     }
 
     [Fact]
-    public void MultipleTopLevelElements_AreWrappedInDiv_NotOverwritten()
+    public void MultipleTopLevelElements_AreWrappedInTransparentFragment_NotOverwritten()
     {
-        // 多个顶层元素（如 <video/> 后跟条件块）必须全部保留，包裹进一个 div，
-        // 而不是后者覆盖前者（ISSUE-062 问题2：video 标签丢失）。
+        // 多个顶层元素（如 <video/> 后跟条件块）必须全部保留，承载进一个透明 FragmentElement，
+        // 而不是后者覆盖前者（ISSUE-062 问题2：video 标签丢失）。容器透明化是 ISSUE-066 问题1：
+        // 不再用不透明 <div> 包裹，以免破坏样式布局。
         var builder = new RenderTreeBuilder();
         builder.OpenElement(0, "video");
         builder.CloseElement();
@@ -29,7 +30,7 @@ public class RenderTreeBuilderTests
 
         var root = builder.Build();
 
-        var wrapper = root.ShouldBeOfType<DivElement>();
+        var wrapper = root.ShouldBeOfType<FragmentElement>();
         wrapper.Children.Count.ShouldBe(2);
         wrapper.Children[0].ShouldBeOfType<VideoElement>();
         wrapper.Children[1].ShouldBeOfType<DivElement>();
@@ -46,7 +47,7 @@ public class RenderTreeBuilderTests
         builder.OpenElement(2, "p");
         builder.CloseElement();
 
-        var wrapper = builder.Build().ShouldBeOfType<DivElement>();
+        var wrapper = builder.Build().ShouldBeOfType<FragmentElement>();
         wrapper.Children.Count.ShouldBe(3);
         wrapper.Children[0].ShouldBeOfType<VideoElement>();
         wrapper.Children[1].ShouldBeOfType<SpanElement>();
@@ -129,11 +130,14 @@ public class RenderTreeBuilderTests
     }
 
     [Fact]
-    public void Build_EmptyBuilder_Throws()
+    public void Build_EmptyBuilder_ReturnsEmptyTransparentFragment()
     {
+        // A component that renders nothing (e.g. a transparent CascadingValue with null
+        // ChildContent) yields an empty FragmentElement rather than throwing.
         var builder = new RenderTreeBuilder();
 
-        Should.Throw<InvalidOperationException>(() => builder.Build());
+        var root = builder.Build().ShouldBeOfType<FragmentElement>();
+        root.Children.ShouldBeEmpty();
     }
 
     [Fact]

--- a/tests/Miko.Tests/Components/StateHasChangedTests.cs
+++ b/tests/Miko.Tests/Components/StateHasChangedTests.cs
@@ -236,4 +236,66 @@ public class StateHasChangedTests
         parent.Bump();
         DisposableChildComponent.DisposeCount.ShouldBe(1);
     }
+
+    // A page that renders two top-level elements (a FragmentElement root) and owns state, like
+    // a multi-root Razor page using a Layout (ISSUE-066 问题1).
+    private class MultiRootCounterPage : ComponentBase
+    {
+        private int _count;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddContent(1, $"a:{_count}");
+            builder.CloseElement();
+            builder.OpenElement(2, "div");
+            builder.AddContent(3, $"b:{_count}");
+            builder.CloseElement();
+        }
+
+        public void Increment()
+        {
+            _count++;
+            StateHasChanged();
+        }
+    }
+
+    [Fact]
+    public void StateHasChanged_MultiRootPage_WithoutParent_UpdatesInPlace()
+    {
+        // No-layout case: the fragment root has no parent → ReplaceElementContent branch.
+        var page = new MultiRootCounterPage();
+        var root = page.Build();
+
+        root.ShouldBeOfType<FragmentElement>();
+        root.Parent.ShouldBeNull();
+        root.Children[0].TextContent.ShouldBe("a:0");
+        root.Children[1].TextContent.ShouldBe("b:0");
+
+        page.Increment();
+
+        // The engine holds the same fragment reference; its children are updated in place.
+        root.Children[0].TextContent.ShouldBe("a:1");
+        root.Children[1].TextContent.ShouldBe("b:1");
+    }
+
+    [Fact]
+    public void StateHasChanged_MultiRootPage_WithParent_ReplacesFragmentInParent()
+    {
+        // Layout case: the fragment root is a child of the layout's <div class="root">.
+        var page = new MultiRootCounterPage();
+        var root = page.Build();
+        var layoutRoot = new DivElement { Class = "root" };
+        layoutRoot.AddChild(root);
+
+        layoutRoot.Children.Count.ShouldBe(1);
+
+        page.Increment();
+
+        // A single fragment child remains (replaced, not duplicated) and reflects the new state.
+        layoutRoot.Children.Count.ShouldBe(1);
+        var fragment = layoutRoot.Children[0].ShouldBeOfType<FragmentElement>();
+        fragment.Children[0].TextContent.ShouldBe("a:1");
+        fragment.Children[1].TextContent.ShouldBe("b:1");
+    }
 }

--- a/tests/Miko.Tests/Layout/FlexLayoutTests.cs
+++ b/tests/Miko.Tests/Layout/FlexLayoutTests.cs
@@ -292,4 +292,109 @@ public class FlexLayoutTests
         root.Children[5].BoxModel.Content.X.ShouldBe(180);
         root.Children[5].BoxModel.Content.Y.ShouldBe(70);
     }
+
+    // ISSUE-064 §1.2: a flex COLUMN whose height comes from min-height (not an explicit height)
+    // must still vertically center its children (justify-content: center on the main axis) and
+    // horizontally center them (align-items: center on the cross axis). This mirrors
+    // ion-segment-button: a flex-column with min-height + align/justify center wrapping a small
+    // label. The bug was that justify-content was skipped because the main-axis size was still 0
+    // (the min-height was applied to the box only AFTER the children were placed).
+    [Fact]
+    public void FlexColumn_MinHeight_CentersChildVerticallyAndHorizontally()
+    {
+        // <button flex-col W=200 minH=40 align/justify center> <label 50x20/> </button>
+        // The button's height comes from min-height (40), taller than its 20px label, so the
+        // label must be vertically centered within the 40px (justify-content: center) and
+        // horizontally centered within the 200px (align-items: center).
+        var button = new DivElement { Class = "button" };
+        var label = new DivElement { Class = "label" };
+        button.AddChild(label);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new()
+            {
+                Rules = new List<StyleRule>
+                {
+                    new()
+                    {
+                        Selector = new ClassSelector("button"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            FlexDirection = FlexDirection.Column,
+                            AlignItems = AlignItems.Center,
+                            JustifyContent = JustifyContent.Center,
+                            Width = Length.Px(200),
+                            MinHeight = Length.Px(40),
+                        }
+                    },
+                    new()
+                    {
+                        Selector = new ClassSelector("label"),
+                        Style = new Style { Display = Display.Block, Width = Length.Px(50), Height = Length.Px(20) }
+                    },
+                }
+            }
+        };
+
+        var root = _layoutEngine.Layout(button, styleSheets, 800, 600);
+
+        var labelBox = root.Children[0];
+
+        // The button is 40px tall (min-height floors the 20px content).
+        root.BoxModel.Content.Height.ShouldBe(40);
+
+        // Horizontal centering (align-items: center, cross axis): the 50px label is centered
+        // in the 200px button → left edge at (200 - 50) / 2 = 75.
+        labelBox.BoxModel.Content.X.ShouldBe(75);
+
+        // Vertical centering (justify-content: center, main axis): the 20px label is centered
+        // in the 40px button → top edge at (40 - 20) / 2 = 10.
+        labelBox.BoxModel.Content.Y.ShouldBe(10);
+    }
+
+    // Same centering, but the column has an EXPLICIT height (control case). This already worked,
+    // so it guards against a regression in the explicit-height path.
+    [Fact]
+    public void FlexColumn_ExplicitHeight_CentersChildVerticallyAndHorizontally()
+    {
+        var button = new DivElement { Class = "button" };
+        var label = new DivElement { Class = "label" };
+        button.AddChild(label);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new()
+            {
+                Rules = new List<StyleRule>
+                {
+                    new()
+                    {
+                        Selector = new ClassSelector("button"),
+                        Style = new Style
+                        {
+                            Display = Display.Flex,
+                            FlexDirection = FlexDirection.Column,
+                            AlignItems = AlignItems.Center,
+                            JustifyContent = JustifyContent.Center,
+                            Width = Length.Px(200),
+                            Height = Length.Px(40),
+                        }
+                    },
+                    new()
+                    {
+                        Selector = new ClassSelector("label"),
+                        Style = new Style { Display = Display.Block, Width = Length.Px(50), Height = Length.Px(20) }
+                    },
+                }
+            }
+        };
+
+        var root = _layoutEngine.Layout(button, styleSheets, 800, 600);
+        var labelBox = root.Children[0];
+
+        labelBox.BoxModel.Content.X.ShouldBe(75);  // (200 - 50) / 2
+        labelBox.BoxModel.Content.Y.ShouldBe(10);  // (40 - 20) / 2
+    }
 }

--- a/tests/Miko.Tests/Layout/FragmentLayoutTests.cs
+++ b/tests/Miko.Tests/Layout/FragmentLayoutTests.cs
@@ -1,0 +1,141 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Layout;
+
+/// <summary>
+/// ISSUE-066 问题1：FragmentElement 在布局中是透明的（等价 CSS display:contents）。
+/// 当一个多根页面被放进 Layout 的 body 时，承载多根的 FragmentElement 不应在布局树中
+/// 产生任何包裹盒——其子节点的盒子直接成为父盒的子节点，使父元素的样式（如 flex）
+/// 直接作用于页面的真实顶层元素。
+/// </summary>
+public class FragmentLayoutTests
+{
+    private readonly LayoutEngine _layoutEngine = new();
+
+    private static List<StyleSheet> BlockForAll() => new()
+    {
+        new StyleSheet
+        {
+            Rules = new List<StyleRule>
+            {
+                new StyleRule { Selector = new TagSelector("div"), Style = new Style { Display = Display.Block } },
+                new StyleRule { Selector = new TagSelector("fragment"), Style = new Style { Display = Display.Block } },
+            }
+        }
+    };
+
+    [Fact]
+    public void ChildFragment_IsTransparent_ChildrenSpliceIntoParentBox()
+    {
+        // <div class="root"> <fragment> <div/><div/> </fragment> </div>
+        // 期望布局树：root 盒下直接挂两个 div 盒，中间没有 fragment 盒。
+        var a = new DivElement();
+        var b = new DivElement();
+        var fragment = new FragmentElement();
+        fragment.AddChild(a);
+        fragment.AddChild(b);
+        var root = new DivElement { Class = "root" };
+        root.AddChild(fragment);
+
+        var layoutRoot = _layoutEngine.Layout(root, BlockForAll(), 800, 600);
+
+        layoutRoot.Element.ShouldBe(root);
+        layoutRoot.Children.Count.ShouldBe(2);
+        layoutRoot.Children[0].Element.ShouldBe(a);
+        layoutRoot.Children[1].Element.ShouldBe(b);
+        // 布局树中不存在任何 FragmentElement 盒子。
+        layoutRoot.Children.ShouldNotContain(box => box.Element.GetType() == typeof(FragmentElement));
+    }
+
+    [Fact]
+    public void NestedFragments_AreFlattenedTransparently()
+    {
+        // 片段套片段也应被完全摊平。
+        var leaf1 = new DivElement();
+        var leaf2 = new DivElement();
+        var inner = new FragmentElement();
+        inner.AddChild(leaf1);
+        inner.AddChild(leaf2);
+        var outer = new FragmentElement();
+        outer.AddChild(inner);
+        var root = new DivElement();
+        root.AddChild(outer);
+
+        var layoutRoot = _layoutEngine.Layout(root, BlockForAll(), 800, 600);
+
+        layoutRoot.Children.Count.ShouldBe(2);
+        layoutRoot.Children[0].Element.ShouldBe(leaf1);
+        layoutRoot.Children[1].Element.ShouldBe(leaf2);
+    }
+
+    [Fact]
+    public void RootFragment_ActsAsPermittedWrapperBlock()
+    {
+        // 无 Layout 的多根页面：FragmentElement 是布局根。此时它充当 issue 所允许的
+        // “自动创建的根包裹”，按普通块盒填满视口，其子节点在其内布局。
+        var a = new DivElement();
+        var b = new DivElement();
+        var rootFragment = new FragmentElement();
+        rootFragment.AddChild(a);
+        rootFragment.AddChild(b);
+
+        var layoutRoot = _layoutEngine.Layout(rootFragment, BlockForAll(), 800, 600);
+
+        layoutRoot.Element.ShouldBe(rootFragment);
+        layoutRoot.BoxModel.Content.Width.ShouldBe(800);
+        layoutRoot.Children.Count.ShouldBe(2);
+        layoutRoot.Children[0].Element.ShouldBe(a);
+        layoutRoot.Children[1].Element.ShouldBe(b);
+    }
+
+    [Fact]
+    public void FlexOnRoot_AppliesDirectlyToPageItems_AcrossTransparentFragment()
+    {
+        // ISSUE-066 问题1 的核心症状：.root 上的 flex 必须直接作用于页面的顶层元素。
+        // 旧实现把多根页面包进不透明 div，flex 父级变成那个 div，导致 .root 的 flex 失效。
+        // 现在 fragment 透明，.root 的两个 flex item 应横向并排（各 100px 宽，紧邻排列）。
+        var item1 = new DivElement { Class = "item" };
+        var item2 = new DivElement { Class = "item" };
+        var fragment = new FragmentElement();
+        fragment.AddChild(item1);
+        fragment.AddChild(item2);
+        var root = new DivElement { Class = "root" };
+        root.AddChild(fragment);
+
+        var styleSheets = new List<StyleSheet>
+        {
+            new StyleSheet
+            {
+                Rules = new List<StyleRule>
+                {
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("root"),
+                        Style = new Style { Display = Display.Flex, FlexDirection = FlexDirection.Row }
+                    },
+                    new StyleRule
+                    {
+                        Selector = new ClassSelector("item"),
+                        Style = new Style { Display = Display.Block, Width = Length.Px(100), Height = Length.Px(60) }
+                    },
+                }
+            }
+        };
+
+        var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
+
+        // 两个 item 是 .root 的直接 flex 子项，横向并排：第二个紧接第一个右侧。
+        layoutRoot.Children.Count.ShouldBe(2);
+        var box1 = layoutRoot.Children[0];
+        var box2 = layoutRoot.Children[1];
+        box1.Element.ShouldBe(item1);
+        box2.Element.ShouldBe(item2);
+        box1.BoxModel.Content.Width.ShouldBe(100);
+        box2.BoxModel.Content.Left.ShouldBe(box1.BoxModel.Content.Right);
+    }
+}

--- a/tests/Miko.Tests/Routing/RouteViewFragmentTests.cs
+++ b/tests/Miko.Tests/Routing/RouteViewFragmentTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.Extensions.DependencyInjection;
+using Miko.Components;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Routing;
+using Shouldly;
+
+namespace Miko.Tests.Routing;
+
+/// <summary>
+/// ISSUE-066 问题1：页面多个顶层元素经 Layout 渲染后，不应在 Layout 根与页面真实顶层元素
+/// 之间插入多余的包裹元素。承载多根的透明 FragmentElement 留在 DOM 中作为页面稳定根，
+/// 但对布局透明，因此 Layout 的根（如 .root）与页面顶层元素之间不应有不透明 div。
+/// </summary>
+public class RouteViewFragmentTests
+{
+    // 多根页面：两个顶层 div，模拟 issue 中的 <div>1</div><div>2</div>。
+    private sealed class TwoRootPage : ComponentBase
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddContent(1, "1");
+            builder.CloseElement();
+            builder.OpenElement(2, "div");
+            builder.AddContent(3, "2");
+            builder.CloseElement();
+        }
+    }
+
+    // 单根页面：仅一个顶层 div。
+    private sealed class OneRootPage : ComponentBase
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddAttribute(1, "class", "page");
+            builder.CloseElement();
+        }
+    }
+
+    // 等价 MainLayout：<div class="root">@Body</div>
+    private sealed class RootLayout : LayoutComponentBase
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "div");
+            builder.AddAttribute(1, "class", "root");
+            Body?.Invoke(builder);
+            builder.CloseElement();
+        }
+    }
+
+    private static RouteView CreateRouteView(Router router, Type? layout)
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        return new RouteView(router, new NavigationManager(), layout, services);
+    }
+
+    [Fact]
+    public void MultiRootPage_WithLayout_HasNoExtraWrapperBetweenRootAndPageElements()
+    {
+        var router = new Router();
+        router.MapRoute<TwoRootPage>("/");
+        var routeView = CreateRouteView(router, typeof(RootLayout));
+
+        var tree = routeView.Render("/");
+
+        // 顶层是 Layout 的 <div class="root">。
+        tree.ShouldBeOfType<DivElement>();
+        tree.Class.ShouldBe("root");
+
+        // .root 下直接是承载多根的透明 fragment，fragment 下是页面的两个真实 div——
+        // .root 与页面 div 之间没有不透明 div 包裹层。
+        tree.Children.Count.ShouldBe(1);
+        var fragment = tree.Children[0].ShouldBeOfType<FragmentElement>();
+        fragment.Children.Count.ShouldBe(2);
+        fragment.Children[0].TextContent.ShouldBe("1");
+        fragment.Children[1].TextContent.ShouldBe("2");
+
+        // 整棵树里只有 Layout 的那一个 div（class=root）；页面没有引入任何额外 div 包裹。
+        tree.FindByTagName("div").Count.ShouldBe(3); // root + 页面两个
+    }
+
+    [Fact]
+    public void SingleRootPage_WithLayout_AttachesDirectlyWithoutFragment()
+    {
+        var router = new Router();
+        router.MapRoute<OneRootPage>("/");
+        var routeView = CreateRouteView(router, typeof(RootLayout));
+
+        var tree = routeView.Render("/");
+
+        tree.Class.ShouldBe("root");
+        tree.Children.Count.ShouldBe(1);
+        // 单根页面没有 fragment 包裹，直接是页面的 div。
+        var page = tree.Children[0].ShouldBeOfType<DivElement>();
+        page.Class.ShouldBe("page");
+        tree.FindByTagName("fragment").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MultiRootPage_NoLayout_ReturnsFragmentRoot()
+    {
+        var router = new Router();
+        router.MapRoute<TwoRootPage>("/");
+        var routeView = CreateRouteView(router, layout: null);
+
+        var tree = routeView.Render("/");
+
+        // 无 Layout：返回承载多根的 fragment 作为引擎根（布局阶段它充当允许的根包裹）。
+        var fragment = tree.ShouldBeOfType<FragmentElement>();
+        fragment.Children.Count.ShouldBe(2);
+        fragment.Children[0].TextContent.ShouldBe("1");
+        fragment.Children[1].TextContent.ShouldBe("2");
+    }
+}

--- a/tests/Miko.Tests/Styling/StyleResolverTests.cs
+++ b/tests/Miko.Tests/Styling/StyleResolverTests.cs
@@ -77,6 +77,44 @@ public class StyleResolverTests
         computed.PaddingLeft.Value.ShouldBe(6);
         computed.BorderTopWidth.Value.ShouldBe(2);
         computed.BorderTopStyle.ShouldBe(BorderStyle.Solid);
+        // Browsers center button text by default (UA stylesheet text-align: center).
+        computed.TextAlign.ShouldBe(TextAlign.Center);
+    }
+
+    [Fact]
+    public void Resolve_ForButtonElement_CenterTextAlign_BeatsInheritedLeft()
+    {
+        // A button inside a left-aligned parent must still center its own text — the UA default
+        // (text-align: center) is applied before inheritance, so it wins over the inherited Left.
+        var resolver = new StyleResolver();
+        var parent = new DivElement
+        {
+            Style = new Style { TextAlign = TextAlign.Left }
+        };
+        var button = new ButtonElement { TextContent = "Click" };
+        parent.AddChild(button);
+
+        var parentComputed = resolver.Resolve(parent, []);
+        parent.LayoutBox = new LayoutBox { Element = parent, ComputedStyle = parentComputed };
+
+        var buttonComputed = resolver.Resolve(button, []);
+        buttonComputed.TextAlign.ShouldBe(TextAlign.Center);
+    }
+
+    [Fact]
+    public void Resolve_ForButtonElement_ExplicitTextAlign_OverridesUaDefault()
+    {
+        // An author rule should still override the UA default (??= leaves an explicit value).
+        var styleSheet = new StyleSheet();
+        styleSheet.Rules.Add(new StyleRule
+        {
+            Selector = new Miko.Styling.Selectors.TagSelector("button"),
+            Style = new Style { TextAlign = TextAlign.Left }
+        });
+
+        var computed = new StyleResolver().Resolve(new ButtonElement { TextContent = "Click" }, [styleSheet]);
+
+        computed.TextAlign.ShouldBe(TextAlign.Left);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds cascading parameter support and reworks multi-root component handling around a transparent `FragmentElement`.

- **CascadingValue**: new `CascadingValue`, `CascadingValueSource` and `CascadingParameterAttribute` to flow cascading parameters down the component tree.
- **Transparent multi-root root**: replaces the synthetic wrapper `div` with a transparent `FragmentElement`. It stays in the DOM as a component's stable root (so `StateHasChanged` can re-render in place) but is skipped by the layout engine — its child boxes are flattened into the parent, matching `display: contents` semantics.
- **RenderFragment top-level content**: `RenderTreeBuilder` now invokes `RenderFragment` content regardless of stack depth, so a transparent `CascadingValue` can emit top-level elements. A component that renders nothing yields an empty fragment instead of throwing.
- **Button default**: adds UA-stylesheet `text-align: center` default for `<button>`.

## Tests

New and updated tests cover cascading values, fragment layout flattening, multi-root `RouteView`, render-tree building, `StateHasChanged`, flex layout, and the style resolver button default.

```
dotnet test
```