### PR TITLE
feat(simulator): add device simulator host (ISSUE-067)

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -50,6 +50,7 @@ jobs:
             src/Miko.DevTools/Miko.DevTools.csproj \
             src/Miko.Razor.Compiler/Miko.Razor.Compiler.csproj \
             src/Miko.Windowing/Miko.Windowing.csproj \
+            src/Miko.Simulator/Miko.Simulator.csproj \
             src/Miko.Android/Miko.Android.csproj \
             src/Miko.iOS/Miko.iOS.csproj
           do

--- a/examples/Multiplatform/MikoAppBlank/MikoAppBlank.Simulator/MikoAppBlank.Simulator.csproj
+++ b/examples/Multiplatform/MikoAppBlank/MikoAppBlank.Simulator/MikoAppBlank.Simulator.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <StartupObject>MikoAppBlank.Simulator.Program</StartupObject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MikoAppBlank\MikoAppBlank.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Miko.Simulator\Miko.Simulator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/Multiplatform/MikoAppBlank/MikoAppBlank.Simulator/Program.cs
+++ b/examples/Multiplatform/MikoAppBlank/MikoAppBlank.Simulator/Program.cs
@@ -1,0 +1,21 @@
+using Miko.Simulator;
+using MikoAppBlank;
+
+namespace MikoAppBlank.Simulator;
+
+public static class Program
+{
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        var context = App.CreateContext();
+
+        // Hot reload is wired up inside the shared app assembly, same as the desktop head.
+        App.InitializeHotReload(context);
+
+        // Run the app inside a device simulator window: the app renders into an
+        // independent device-sized canvas on the left, with a Miko-rendered
+        // settings panel (device / orientation / safe area) on the right.
+        context.RunSimulator();
+    }
+}

--- a/examples/Multiplatform/MikoAppSidemenu/MikoAppSidemenu.Simulator/MikoAppSidemenu.Simulator.csproj
+++ b/examples/Multiplatform/MikoAppSidemenu/MikoAppSidemenu.Simulator/MikoAppSidemenu.Simulator.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <StartupObject>MikoAppSidemenu.Simulator.Program</StartupObject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MikoAppSidemenu\MikoAppSidemenu.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Miko.Simulator\Miko.Simulator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/Multiplatform/MikoAppSidemenu/MikoAppSidemenu.Simulator/Program.cs
+++ b/examples/Multiplatform/MikoAppSidemenu/MikoAppSidemenu.Simulator/Program.cs
@@ -1,0 +1,21 @@
+using Miko.Simulator;
+using MikoAppSidemenu;
+
+namespace MikoAppSidemenu.Simulator;
+
+public static class Program
+{
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        var context = App.CreateContext();
+
+        // Hot reload is wired up inside the shared app assembly, same as the desktop head.
+        App.InitializeHotReload(context);
+
+        // Run the app inside a device simulator window: the app renders into an
+        // independent device-sized canvas on the left, with a Miko-rendered
+        // settings panel (device / orientation / safe area) on the right.
+        context.RunSimulator();
+    }
+}

--- a/examples/Multiplatform/MikoAppTabs/MikoAppTabs.Simulator/MikoAppTabs.Simulator.csproj
+++ b/examples/Multiplatform/MikoAppTabs/MikoAppTabs.Simulator/MikoAppTabs.Simulator.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <StartupObject>MikoAppTabs.Simulator.Program</StartupObject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MikoAppTabs\MikoAppTabs.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Miko.Simulator\Miko.Simulator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/Multiplatform/MikoAppTabs/MikoAppTabs.Simulator/Program.cs
+++ b/examples/Multiplatform/MikoAppTabs/MikoAppTabs.Simulator/Program.cs
@@ -1,0 +1,21 @@
+using Miko.Simulator;
+using MikoAppTabs;
+
+namespace MikoAppTabs.Simulator;
+
+public static class Program
+{
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        var context = App.CreateContext();
+
+        // Hot reload is wired up inside the shared app assembly, same as the desktop head.
+        App.InitializeHotReload(context);
+
+        // Run the app inside a device simulator window: the app renders into an
+        // independent device-sized canvas on the left, with a Miko-rendered
+        // settings panel (device / orientation / safe area) on the right.
+        context.RunSimulator();
+    }
+}

--- a/examples/examples.slnx
+++ b/examples/examples.slnx
@@ -8,6 +8,7 @@
     <Project Path="../src/Miko.Bootstrap/Miko.Bootstrap.csproj" />
     <Project Path="../src/Miko.DevTools/Miko.DevTools.csproj" />
     <Project Path="../src/Miko.Razor.Compiler/Miko.Razor.Compiler.csproj" />
+    <Project Path="../src/Miko.Simulator/Miko.Simulator.csproj" />
     <Project Path="../src/Miko.Windowing/Miko.Windowing.csproj" />
     <Project Path="../src/Miko/Miko.csproj" />
   </Folder>
@@ -16,18 +17,21 @@
     <Project Path="Multiplatform/MikoAppBlank/MikoAppBlank.Android/MikoAppBlank.Android.csproj" />
     <Project Path="Multiplatform/MikoAppBlank/MikoAppBlank.Desktop/MikoAppBlank.Desktop.csproj" />
     <Project Path="Multiplatform/MikoAppBlank/MikoAppBlank.iOS/MikoAppBlank.iOS.csproj" />
+    <Project Path="Multiplatform/MikoAppBlank/MikoAppBlank.Simulator/MikoAppBlank.Simulator.csproj" />
     <Project Path="Multiplatform/MikoAppBlank/MikoAppBlank/MikoAppBlank.csproj" />
   </Folder>
   <Folder Name="/Multiplatform/MikoAppSidemenu/">
     <Project Path="Multiplatform/MikoAppSidemenu/MikoAppSidemenu.Android/MikoAppSidemenu.Android.csproj" />
     <Project Path="Multiplatform/MikoAppSidemenu/MikoAppSidemenu.Desktop/MikoAppSidemenu.Desktop.csproj" />
     <Project Path="Multiplatform/MikoAppSidemenu/MikoAppSidemenu.iOS/MikoAppSidemenu.iOS.csproj" />
+    <Project Path="Multiplatform/MikoAppSidemenu/MikoAppSidemenu.Simulator/MikoAppSidemenu.Simulator.csproj" />
     <Project Path="Multiplatform/MikoAppSidemenu/MikoAppSidemenu/MikoAppSidemenu.csproj" />
   </Folder>
   <Folder Name="/Multiplatform/MikoAppTabs/">
     <Project Path="Multiplatform/MikoAppTabs/MikoAppTabs.Android/MikoAppTabs.Android.csproj" />
     <Project Path="Multiplatform/MikoAppTabs/MikoAppTabs.Desktop/MikoAppTabs.Desktop.csproj" />
     <Project Path="Multiplatform/MikoAppTabs/MikoAppTabs.iOS/MikoAppTabs.iOS.csproj" />
+    <Project Path="Multiplatform/MikoAppTabs/MikoAppTabs.Simulator/MikoAppTabs.Simulator.csproj" />
     <Project Path="Multiplatform/MikoAppTabs/MikoAppTabs/MikoAppTabs.csproj" />
   </Folder>
   <Folder Name="/Media/">

--- a/miko.slnx
+++ b/miko.slnx
@@ -6,6 +6,7 @@
     <Project Path="src/Miko.Ionic/Miko.Ionic.csproj" />
     <Project Path="src/Miko.iOS/Miko.iOS.csproj" />
     <Project Path="src/Miko.Razor.Compiler/Miko.Razor.Compiler.csproj" />
+    <Project Path="src/Miko.Simulator/Miko.Simulator.csproj" />
     <Project Path="src/Miko.Windowing/Miko.Windowing.csproj" />
     <Project Path="src/Miko/Miko.csproj" />
   </Folder>

--- a/src/Miko.Simulator/DeviceProfile.cs
+++ b/src/Miko.Simulator/DeviceProfile.cs
@@ -1,0 +1,60 @@
+using Miko.Common;
+
+namespace Miko.Simulator;
+
+/// <summary>
+/// 一个模拟设备的描述：逻辑分辨率、像素密度与安全区边距。
+/// <para>
+/// 逻辑尺寸（<see cref="LogicalWidth"/>/<see cref="LogicalHeight"/>）是应用看到的视口大小，
+/// 与 Miko 引擎的布局坐标一致；<see cref="Scale"/> 仅影响模拟器把设备画面合成到窗口时的清晰度
+/// （以物理像素渲染离屏画面，再缩放绘制到屏幕）。
+/// </para>
+/// <para>
+/// 安全区（<see cref="SafeArea"/>）模拟刘海 / 状态栏 / Home 指示条，转发给应用的引擎，
+/// 使应用内容内缩到安全区内——与真机 iOS/Android 宿主行为一致。
+/// </para>
+/// </summary>
+public sealed record DeviceProfile(
+    string Name,
+    int LogicalWidth,
+    int LogicalHeight,
+    float Scale,
+    SafeAreaInsets SafeArea)
+{
+    /// <summary>设备类别（用于面板分组与边框样式）。</summary>
+    public DeviceKind Kind { get; init; } = DeviceKind.Phone;
+
+    /// <summary>物理像素宽度（离屏画面以此分辨率渲染，保证缩放后清晰）。</summary>
+    public int PixelWidth => (int)MathF.Round(LogicalWidth * Scale);
+
+    /// <summary>物理像素高度。</summary>
+    public int PixelHeight => (int)MathF.Round(LogicalHeight * Scale);
+
+    public override string ToString() => $"{Name} ({LogicalWidth}×{LogicalHeight} @{Scale:0.#}x)";
+
+    // 内置常用设备预设。数值取自各设备的逻辑点（point）分辨率与安全区。
+    public static DeviceProfile IPhone15Pro { get; } = new(
+        "iPhone 15 Pro", 393, 852, 3f, new SafeAreaInsets(0, 59, 0, 34)) { Kind = DeviceKind.Phone };
+
+    public static DeviceProfile IPhoneSE { get; } = new(
+        "iPhone SE", 375, 667, 2f, new SafeAreaInsets(0, 20, 0, 0)) { Kind = DeviceKind.Phone };
+
+    public static DeviceProfile Pixel7 { get; } = new(
+        "Pixel 7", 412, 915, 2.625f, new SafeAreaInsets(0, 24, 0, 0)) { Kind = DeviceKind.Phone };
+
+    public static DeviceProfile IPadMini { get; } = new(
+        "iPad mini", 744, 1133, 2f, new SafeAreaInsets(0, 24, 0, 20)) { Kind = DeviceKind.Tablet };
+
+    /// <summary>内置设备预设列表（面板下拉默认使用）。</summary>
+    public static IReadOnlyList<DeviceProfile> Defaults { get; } = new[]
+    {
+        IPhone15Pro, IPhoneSE, Pixel7, IPadMini,
+    };
+}
+
+/// <summary>模拟设备的类别。</summary>
+public enum DeviceKind
+{
+    Phone,
+    Tablet,
+}

--- a/src/Miko.Simulator/Miko.Simulator.csproj
+++ b/src/Miko.Simulator/Miko.Simulator.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <IsPackable>true</IsPackable>
+    <PackageId>Miko.Simulator</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Miko</Authors>
+    <Description>Device simulator host for Miko. Renders a Miko app into an independent device-sized canvas with a side settings panel, itself built with the Miko engine.</Description>
+    <PackageTags>miko;simulator;device;mobile;skiasharp;ui</PackageTags>
+    <PackageProjectUrl>https://github.com/chaldea/miko</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/chaldea/miko</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Miko\Miko.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Silk.NET.Input" Version="2.22.0" />
+    <PackageReference Include="Silk.NET.Windowing" Version="2.22.0" />
+    <PackageReference Include="Silk.NET.OpenGL" Version="2.22.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Miko.Simulator/README.md
+++ b/src/Miko.Simulator/README.md
@@ -1,0 +1,50 @@
+# Miko.Simulator
+
+Device simulator host for [Miko](https://github.com/chaldea/miko).
+
+`Miko.Simulator` runs a Miko application inside a desktop window that emulates a
+mobile device. The window is split in two:
+
+- **Left** — the application, rendered into its own independent canvas sized to
+  the simulated device's logical resolution (so the app sees the same viewport
+  it would on a real phone), drawn inside a device bezel.
+- **Right** — a settings panel (device picker, orientation, safe-area toggle)
+  that is itself built and rendered with the Miko engine.
+
+## Usage
+
+A simulator startup project sits alongside the other platform heads:
+
+```
+MyApp
+├── MyApp            # shared app (routes, layout, styles)
+├── MyApp.Simulator  # this project
+├── MyApp.Desktop
+├── MyApp.iOS
+└── MyApp.Android
+```
+
+`Program.cs`:
+
+```csharp
+using Miko.Simulator;
+using MyApp;
+
+var context = App.CreateContext();
+context.RunSimulator();
+```
+
+Configure the device list, initial device, or orientation:
+
+```csharp
+context.RunSimulator(o =>
+{
+    o.InitialDevice = DeviceProfile.IPhoneSE;
+    o.InitialOrientation = Orientation.Landscape;
+    o.Devices = new[] { DeviceProfile.IPhone15Pro, DeviceProfile.Pixel7 };
+});
+```
+
+The simulator drives the same platform-agnostic `MikoInteractionController` the
+real device hosts use, so pointer, scroll, keyboard, and safe-area behavior match
+what the app gets on-device.

--- a/src/Miko.Simulator/SimulatorHost.cs
+++ b/src/Miko.Simulator/SimulatorHost.cs
@@ -1,0 +1,700 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Miko.Common;
+using Miko.Core;
+using Miko.Events;
+using Miko.Hosting;
+using Miko.Platform;
+using Silk.NET.Core;
+using Silk.NET.Input;
+using Silk.NET.Maths;
+using Silk.NET.OpenGL;
+using Silk.NET.Windowing;
+using SkiaSharp;
+using SilkMouseButton = Silk.NET.Input.MouseButton;
+
+namespace Miko.Simulator;
+
+/// <summary>
+/// 设备模拟器宿主。窗口分为两部分：
+/// <list type="bullet">
+///   <item>左侧——被模拟应用的画面，渲染到一块**独立的**、按设备分辨率的离屏画布上，
+///   再带边框合成到窗口（应用看到的视口尺寸 = 设备逻辑分辨率，与真机一致）。</item>
+///   <item>右侧——模拟器设置面板，本身用**另一个 Miko 引擎**布局/渲染（满足"模拟器本身也使用 Miko 引擎"）。</item>
+/// </list>
+/// <para>
+/// 线程模型沿用单线程 <see cref="IView.Run"/>（输入与渲染同线程），因此应用 DOM 与面板 DOM
+/// 都只被这一个线程触碰，无需跨线程同步。
+/// </para>
+/// </summary>
+public sealed class SimulatorHost
+{
+    // 设备画面四周留白与面板宽度。
+    private const int PanelWidth = 300;
+    private const int DeviceMargin = 32;
+    private const float BezelThickness = 14f;
+    private const float BezelRadius = 28f;
+
+    private readonly MikoAppContext _appContext;
+    private readonly MikoInteractionController _appController;
+    private readonly SimulatorOptions _options;
+    private readonly ILogger _logger;
+
+    // 面板引擎（与应用引擎相互独立）。
+    private readonly MikoEngine _panelEngine = new();
+    private readonly EventDispatcher _panelDispatcher = new();
+
+    private IWindow? _window;
+    private IInputContext? _inputContext;
+    private GL? _gl;
+    private GRContext? _grContext;
+
+    // 应用画面离屏 GPU 画布（按设备物理像素分辨率），跨帧保留。
+    private SKSurface? _appSurface;
+
+    private int _windowWidth;
+    private int _windowHeight;
+
+    // 当前模拟状态。
+    private DeviceProfile _device;
+    private Orientation _orientation = Orientation.Portrait;
+    private bool _safeAreaEnabled = true;
+    private bool _appInitialized;
+
+    // 设备画面在窗口中的屏幕矩形（用于输入坐标映射），每帧合成时更新。
+    private SKRect _deviceScreenRect;
+
+    private readonly Stopwatch _frameTimer = new();
+    private float _lastFrameTime;
+
+    // 面板交互拖拽状态。
+    private bool _panelDragging;
+    private MikoEngine.ScrollbarHitResult? _panelDraggingScrollbar;
+
+    // 应用区指针按下记录（用于点击判定与拖拽转发）。
+    private bool _appPointerActive;
+
+    // 触屏指针光标（半透明圆圈，模拟触摸交互）。
+    private ICursor? _touchCursor;
+    private IMouse? _primaryMouse;
+    private bool _isTouchCursorActive;
+
+    private volatile bool _panelNeedsRebuild = true;
+
+    public SimulatorHost(MikoAppContext appContext, SimulatorOptions options, ILogger<SimulatorHost>? logger = null)
+    {
+        _appContext = appContext;
+        _appController = appContext.Controller;
+        _options = options;
+        _logger = logger ?? NullLogger<SimulatorHost>.Instance;
+        _device = options.InitialDevice ?? options.Devices[0];
+        _orientation = options.InitialOrientation;
+    }
+
+    /// <summary>启动模拟器窗口并运行渲染循环（阻塞直到窗口关闭）。</summary>
+    public void Run()
+    {
+        var (deviceW, deviceH) = CurrentLogicalSize();
+        _windowWidth = deviceW + DeviceMargin * 2 + PanelWidth;
+        _windowHeight = Math.Max(deviceH + DeviceMargin * 2, 480);
+
+        var options = WindowOptions.Default with
+        {
+            Title = _options.Title ?? $"{_appContext.Options.Title} — Simulator",
+            Size = new Vector2D<int>(_windowWidth, _windowHeight),
+            API = GraphicsAPI.Default,
+        };
+
+        _window = Window.Create(options);
+        _window.Load += OnLoad;
+        _window.Render += OnRender;
+        _window.Resize += OnResize;
+        _window.Closing += OnClose;
+
+        _logger.LogInformation("Starting Miko simulator: {Title}", options.Title);
+        _window.Run();
+        _window.Dispose();
+    }
+
+    // 当前朝向下应用看到的逻辑视口尺寸。
+    private (int width, int height) CurrentLogicalSize()
+    {
+        return _orientation == Orientation.Portrait
+            ? (_device.LogicalWidth, _device.LogicalHeight)
+            : (_device.LogicalHeight, _device.LogicalWidth);
+    }
+
+    // 当前朝向下的物理像素尺寸。
+    private (int width, int height) CurrentPixelSize()
+    {
+        var (w, h) = CurrentLogicalSize();
+        return ((int)MathF.Round(w * _device.Scale), (int)MathF.Round(h * _device.Scale));
+    }
+
+    // ---------------------------------------------------------------------
+    // 生命周期
+    // ---------------------------------------------------------------------
+
+    private void OnLoad()
+    {
+        _gl = _window!.CreateOpenGL();
+
+        var grInterface = GRGlInterface.Create(name =>
+            _window!.GLContext!.TryGetProcAddress(name, out var addr) ? addr : IntPtr.Zero);
+        _grContext = GRContext.CreateGl(grInterface);
+
+        _inputContext = _window!.CreateInput();
+        foreach (var mouse in _inputContext.Mice)
+        {
+            _primaryMouse ??= mouse;
+            mouse.MouseDown += OnMouseDown;
+            mouse.MouseUp += OnMouseUp;
+            mouse.MouseMove += OnMouseMove;
+            mouse.Scroll += OnMouseScroll;
+        }
+        foreach (var keyboard in _inputContext.Keyboards)
+        {
+            keyboard.KeyChar += OnKeyChar;
+            keyboard.KeyDown += OnKeyDown;
+        }
+
+        CreateTouchCursor();
+
+        // 应用引擎共享同一 GPU 上下文，供视频/图片等 GPU 资源使用。
+        _appController.Engine.GraphicsContext = _grContext;
+        _appContext.RegisterFonts();
+
+        InitAppEngine();
+        BuildPanel();
+        _frameTimer.Start();
+    }
+
+    // 创建/重建按当前设备分辨率的离屏画布，并初始化应用引擎到该画布。
+    private void InitAppEngine()
+    {
+        var (logicalW, logicalH) = CurrentLogicalSize();
+        var (pixelW, pixelH) = CurrentPixelSize();
+
+        _appSurface?.Dispose();
+        _appSurface = SKSurface.Create(_grContext, budgeted: true,
+            new SKImageInfo(pixelW, pixelH, SKColorType.Rgba8888, SKAlphaType.Premul));
+
+        // 应用以逻辑坐标布局；离屏画布按 scale 放大渲染以保持清晰。
+        if (!_appInitialized)
+        {
+            _appController.Initialize(_appSurface!.Canvas, logicalW, logicalH);
+            _appController.RunPostInitHooks();
+            _appInitialized = true;
+        }
+        else
+        {
+            _appController.SetViewportSize(logicalW, logicalH);
+        }
+
+        ApplySafeArea();
+    }
+
+    private void ApplySafeArea()
+    {
+        if (_safeAreaEnabled)
+        {
+            var sa = OrientedSafeArea();
+            _appController.SetSafeAreaInsets(sa.Left, sa.Top, sa.Right, sa.Bottom);
+        }
+        else
+        {
+            _appController.SetSafeAreaInsets(0, 0, 0, 0);
+        }
+    }
+
+    // 朝向变化时安全区需要相应旋转：竖屏的顶部刘海在横屏时移到一侧。
+    private SafeAreaInsets OrientedSafeArea()
+    {
+        var s = _device.SafeArea;
+        return _orientation == Orientation.Portrait
+            ? s
+            // 横屏（顺时针旋转设备）：原顶部 inset 落到左侧，原底部落到右侧。
+            : new SafeAreaInsets(s.Top, 0, s.Bottom, 0);
+    }
+
+    /// <summary>
+    /// 创建触屏指针光标：一个实心的灰色半透明圆形，模拟浏览器 DevTools 设备模式的触摸指针样式。
+    /// </summary>
+    private void CreateTouchCursor()
+    {
+        if (_inputContext == null || _inputContext.Mice.Count == 0) return;
+
+        const int size = 32;           // 缩小位图尺寸
+        const int radius = 12;         // 缩小圆半径
+        const int centerX = size / 2;
+        const int centerY = size / 2;
+
+        // 生成 RGBA 位图：实心圆形，灰色半透明。
+        var pixels = new byte[size * size * 4];
+        for (int y = 0; y < size; y++)
+        {
+            for (int x = 0; x < size; x++)
+            {
+                int dx = x - centerX;
+                int dy = y - centerY;
+                float dist = MathF.Sqrt(dx * dx + dy * dy);
+
+                int idx = (y * size + x) * 4;
+
+                if (dist <= radius)
+                {
+                    // 圆内：实心灰色 (120, 120, 120)，半透明 alpha ~130。
+                    // 边缘做抗锯齿渐变。
+                    float alpha = dist < radius - 1f ? 1f : (radius - dist);
+                    alpha = Math.Clamp(alpha, 0f, 1f);
+
+                    pixels[idx + 0] = 120; // R
+                    pixels[idx + 1] = 120; // G
+                    pixels[idx + 2] = 120; // B
+                    pixels[idx + 3] = (byte)(alpha * 130); // A (半透明)
+                }
+            }
+        }
+
+        try
+        {
+            var cursor = _primaryMouse!.Cursor;
+            // Silk.NET ICursor 通过 Image 属性设置自定义位图，配合 HotspotX/Y 指定热点。
+            cursor.Image = new RawImage(size, size, new Memory<byte>(pixels));
+            cursor.HotspotX = centerX;
+            cursor.HotspotY = centerY;
+            // 缓存一个标志，表示我们已设置好自定义图像，随后只需切换 Type 即可。
+            _touchCursor = cursor;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to create touch cursor, falling back to default pointer");
+        }
+    }
+
+    private void OnResize(Vector2D<int> size)
+    {
+        _windowWidth = size.X;
+        _windowHeight = size.Y;
+
+        // 最小化时窗口尺寸为 0×0。此时不要把 0 尺寸推给 GL/面板引擎——
+        // 用 0 尺寸创建渲染目标会失败，且会污染布局状态。恢复时会再次收到 Resize。
+        if (size.X == 0 || size.Y == 0) return;
+
+        _gl?.Viewport(size);
+        _panelEngine.SetViewportSize(PanelWidth, _windowHeight);
+    }
+
+    private void OnClose()
+    {
+        _appController.Engine.DisposeVideoSessions();
+        _appSurface?.Dispose();
+        // 自定义光标通过 Image 属性设置，无需手动释放 ICursor 本身。
+        _inputContext?.Dispose();
+        _grContext?.Dispose();
+        _gl?.Dispose();
+    }
+
+    // ---------------------------------------------------------------------
+    // 渲染
+    // ---------------------------------------------------------------------
+
+    private void OnRender(double _)
+    {
+        if (_grContext == null || _gl == null || _appSurface == null) return;
+
+        // 最小化时窗口为 0×0。用 0 尺寸创建 GRBackendRenderTarget / SKSurface 会返回 null，
+        // 解引用 Canvas 将抛异常并污染 GRContext，导致恢复后再也无法渲染（ISSUE-067 现象）。
+        // 直接跳过本帧——恢复时尺寸恢复正常，渲染随之恢复。
+        if (_windowWidth <= 0 || _windowHeight <= 0) return;
+
+        // 必须在任何离屏渲染之前捕获窗口默认帧缓冲绑定：一旦渲染应用到离屏 SKSurface，
+        // Skia 会绑定离屏 FBO 并保持绑定。若此后再读取 FramebufferBinding，拿到的将是离屏 FBO，
+        // 合成内容就会画进用户看不到的离屏画布，窗口保持黑屏（ISSUE-067 现象）。
+        int windowFbo = _gl.GetInteger(GLEnum.FramebufferBinding);
+
+        float currentTime = (float)_frameTimer.Elapsed.TotalSeconds;
+        float deltaTime = currentTime - _lastFrameTime;
+        _lastFrameTime = currentTime;
+
+        // 1. 渲染应用到独立离屏画布（按 scale 放大）。
+        RenderApp(deltaTime);
+
+        // 2. 按需重建面板 DOM。
+        if (_panelNeedsRebuild)
+        {
+            _panelNeedsRebuild = false;
+            BuildPanel();
+        }
+
+        // 3. 合成到窗口默认帧缓冲。离屏渲染改动过 GL 状态，先让 GR 上下文重新同步。
+        _grContext.ResetContext();
+        var fbInfo = new GRGlFramebufferInfo((uint)windowFbo, 0x8058); // GL_RGBA8
+        var target = new GRBackendRenderTarget(_windowWidth, _windowHeight, 0, 8, fbInfo);
+        using var surface = SKSurface.Create(_grContext, target, GRSurfaceOrigin.BottomLeft, SKColorType.Rgba8888);
+        var canvas = surface.Canvas;
+
+        canvas.Clear(new SKColor(24, 25, 28));
+        CompositeDevice(canvas);
+        RenderPanel(canvas);
+
+        canvas.Flush();
+        _grContext.Flush();
+    }
+
+    // 把应用渲染进离屏画布。RenderFrame 持有输入/渲染锁，保证输入引发的 DOM 变更不与渲染竞争。
+    private void RenderApp(float deltaTime)
+    {
+        var (logicalW, logicalH) = CurrentLogicalSize();
+        var appCanvas = _appSurface!.Canvas;
+
+        _appController.RenderFrame(appCanvas, logicalW, logicalH, deltaTime, c =>
+        {
+            var rootBg = _appController.Engine.GetRootBackgroundColor();
+            c.Clear(rootBg?.ToSKColor() ?? SKColors.White);
+            c.Save();
+            c.Scale(_device.Scale);
+            _appController.Engine.Render(c);
+            c.Restore();
+        });
+        _appSurface.Flush();
+    }
+
+    // 把离屏应用画面带边框合成到窗口左侧，并记录设备屏幕矩形供输入映射。
+    private void CompositeDevice(SKCanvas canvas)
+    {
+        var (logicalW, logicalH) = CurrentLogicalSize();
+
+        // 设备屏幕在窗口中的位置（在面板左侧的区域内居中）。
+        float availW = _windowWidth - PanelWidth;
+        float screenLeft = MathF.Max(DeviceMargin, (availW - logicalW) / 2f);
+        float screenTop = MathF.Max(DeviceMargin, (_windowHeight - logicalH) / 2f);
+        _deviceScreenRect = SKRect.Create(screenLeft, screenTop, logicalW, logicalH);
+
+        // 边框（圆角外壳）。
+        var bezelRect = SKRect.Inflate(_deviceScreenRect, BezelThickness, BezelThickness);
+        using (var bezelPaint = new SKPaint { Color = new SKColor(12, 12, 14), IsAntialias = true })
+        {
+            canvas.DrawRoundRect(bezelRect, BezelRadius, BezelRadius, bezelPaint);
+        }
+
+        // 把离屏画面缩放绘制到逻辑尺寸（离屏是物理像素分辨率）。
+        using var image = _appSurface!.Snapshot();
+        using (var clip = new SKRoundRect(_deviceScreenRect, BezelRadius / 2f))
+        {
+            canvas.Save();
+            canvas.ClipRoundRect(clip, antialias: true);
+            var sampling = new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None);
+            canvas.DrawImage(image, _deviceScreenRect, sampling);
+            canvas.Restore();
+        }
+    }
+
+    private void RenderPanel(SKCanvas canvas)
+    {
+        canvas.Save();
+        canvas.Translate(_windowWidth - PanelWidth, 0);
+        canvas.ClipRect(SKRect.Create(0, 0, PanelWidth, _windowHeight));
+        _panelEngine.Render(canvas);
+        canvas.Restore();
+    }
+
+    private void BuildPanel()
+    {
+        var root = SimulatorPanel.Build(
+            _options.Devices,
+            _device,
+            _orientation,
+            _safeAreaEnabled,
+            onSelectDevice: SelectDevice,
+            onSetOrientation: SetOrientation,
+            onToggleSafeArea: ToggleSafeArea);
+
+        var styleSheets = new List<Styling.StyleSheet> { SimulatorStyleSheet.Create() };
+        using var tempSurface = SKSurface.Create(new SKImageInfo(Math.Max(1, PanelWidth), Math.Max(1, _windowHeight)));
+        _panelEngine.Initialize(root, styleSheets, tempSurface.Canvas, PanelWidth, _windowHeight);
+    }
+
+    // ---------------------------------------------------------------------
+    // 模拟状态变更
+    // ---------------------------------------------------------------------
+
+    private void SelectDevice(DeviceProfile device)
+    {
+        if (device.Name == _device.Name) return;
+        _device = device;
+        InitAppEngine();
+        _panelNeedsRebuild = true;
+        _logger.LogInformation("Simulated device changed to {Device}", device);
+    }
+
+    private void SetOrientation(Orientation orientation)
+    {
+        if (orientation == _orientation) return;
+        _orientation = orientation;
+        InitAppEngine();
+        _panelNeedsRebuild = true;
+        _logger.LogInformation("Orientation changed to {Orientation}", orientation);
+    }
+
+    private void ToggleSafeArea(bool enabled)
+    {
+        if (enabled == _safeAreaEnabled) return;
+        _safeAreaEnabled = enabled;
+        ApplySafeArea();
+        _panelNeedsRebuild = true;
+    }
+
+    // ---------------------------------------------------------------------
+    // 输入
+    // ---------------------------------------------------------------------
+
+    // 命中测试：判断窗口坐标落在设备画面区还是面板区。
+    private bool InDevice(float x, float y) => _deviceScreenRect.Contains(x, y);
+    private bool InPanel(float x) => x >= _windowWidth - PanelWidth;
+
+    // 窗口坐标 → 应用逻辑坐标（设备画面以逻辑尺寸合成，故仅需平移）。
+    private (float x, float y) ToAppCoords(float x, float y)
+        => (x - _deviceScreenRect.Left, y - _deviceScreenRect.Top);
+
+    // 窗口坐标 → 面板局部坐标。
+    private (float x, float y) ToPanelCoords(float x, float y)
+        => (x - (_windowWidth - PanelWidth), y);
+
+    private void OnMouseDown(IMouse mouse, SilkMouseButton button)
+    {
+        float x = mouse.Position.X, y = mouse.Position.Y;
+        var mikoButton = ToMikoButton(button);
+
+        // 面板在上层，优先判断。面板区域的输入归面板，不穿透到设备层。
+        if (InPanel(x) && button == SilkMouseButton.Left)
+        {
+            HandlePanelMouseDown(x, y);
+            return;
+        }
+
+        // 面板之外，再判断设备画面。
+        if (InDevice(x, y))
+        {
+            var (ax, ay) = ToAppCoords(x, y);
+            _appPointerActive = true;
+            _appController.OnPointerDown(ax, ay, mikoButton);
+        }
+    }
+
+    private void OnMouseUp(IMouse mouse, SilkMouseButton button)
+    {
+        float x = mouse.Position.X, y = mouse.Position.Y;
+        var mikoButton = ToMikoButton(button);
+
+        // 如果正在进行应用区拖拽（_appPointerActive），优先完成拖拽，
+        // 即使鼠标已经移出设备区域（拖拽跟随）。
+        if (_appPointerActive)
+        {
+            _appPointerActive = false;
+            var (ax, ay) = ToAppCoords(x, y);
+            _appController.OnPointerUp(ax, ay, mikoButton);
+            return;
+        }
+
+        // 面板拖拽或点击。
+        if (button == SilkMouseButton.Left && (_panelDragging || InPanel(x)))
+        {
+            HandlePanelMouseUp(x, y);
+        }
+    }
+
+    private void OnMouseMove(IMouse mouse, System.Numerics.Vector2 position)
+    {
+        float x = position.X, y = position.Y;
+        bool inPanel = InPanel(x);
+        bool inDevice = !inPanel && InDevice(x, y); // 只有不在面板时才判断设备区
+
+        // 鼠标进入/离开设备画面时切换光标：在设备区显示触屏圆圈，在面板或空白区恢复默认箭头。
+        UpdateCursorForRegion(inDevice);
+
+        // 面板拖拽（滚动条）优先。
+        if (_panelDragging)
+        {
+            HandlePanelMouseMove(x, y);
+            return;
+        }
+
+        // 应用区拖拽跟随（即使鼠标已移出设备区）。
+        if (_appPointerActive)
+        {
+            var (ax, ay) = ToAppCoords(x, y);
+            _appController.OnPointerMove(ax, ay);
+            return;
+        }
+
+        // 鼠标在设备区但未按下：悬停移动事件转发给应用（用于 hover 等状态）。
+        if (inDevice)
+        {
+            var (ax, ay) = ToAppCoords(x, y);
+            _appController.OnPointerMove(ax, ay);
+        }
+    }
+
+    /// <summary>根据鼠标是否在设备画面区域切换光标样式。</summary>
+    private void UpdateCursorForRegion(bool inDeviceArea)
+    {
+        if (_primaryMouse == null || _touchCursor == null) return;
+
+        if (inDeviceArea && !_isTouchCursorActive)
+        {
+            // 进入设备区：切换为触屏光标（Type = Custom 使用之前设置的 Image）。
+            _primaryMouse.Cursor.Type = CursorType.Custom;
+            _isTouchCursorActive = true;
+        }
+        else if (!inDeviceArea && _isTouchCursorActive)
+        {
+            // 离开设备区：恢复默认箭头。
+            _primaryMouse.Cursor.Type = CursorType.Standard;
+            _primaryMouse.Cursor.StandardCursor = StandardCursor.Default;
+            _isTouchCursorActive = false;
+        }
+    }
+
+    private void OnMouseScroll(IMouse mouse, ScrollWheel scrollWheel)
+    {
+        float x = mouse.Position.X, y = mouse.Position.Y;
+        float deltaY = scrollWheel.Y * -40f;
+        float deltaX = scrollWheel.X * -40f;
+
+        // 面板在上层，滚动事件优先归面板。
+        if (InPanel(x))
+        {
+            var (px, py) = ToPanelCoords(x, y);
+            _panelEngine.ScrollBy(px, py, deltaX, deltaY);
+        }
+        else if (InDevice(x, y))
+        {
+            var (ax, ay) = ToAppCoords(x, y);
+            _appController.OnScroll(ax, ay, deltaX, deltaY);
+        }
+    }
+
+    private void OnKeyChar(IKeyboard keyboard, char character)
+    {
+        // 文本输入仅转发给应用（面板无文本输入控件）。
+        _appController.OnTextInput(character.ToString());
+    }
+
+    private void OnKeyDown(IKeyboard keyboard, Key key, int scancode)
+    {
+        var mikoKey = ToMikoKey(key);
+        if (mikoKey == MikoKey.Unknown) return;
+        _appController.OnKeyDown(mikoKey, GetModifiers(keyboard));
+    }
+
+    // 面板交互：复用引擎的滚动条命中与事件分发（与 DevTools 窗口同模式）。
+    private void HandlePanelMouseDown(float windowX, float windowY)
+    {
+        var (px, py) = ToPanelCoords(windowX, windowY);
+
+        var scrollbarHit = _panelEngine.HitTestScrollbar(px, py);
+        if (scrollbarHit != null)
+        {
+            _panelDraggingScrollbar = scrollbarHit;
+            _panelDragging = true;
+            if (scrollbarHit.HitType is MikoEngine.ScrollbarHitType.VerticalThumb
+                or MikoEngine.ScrollbarHitType.HorizontalThumb)
+            {
+                return;
+            }
+        }
+
+        var target = _panelEngine.HitTest(px, py);
+        if (target == null) return;
+
+        var args = new MouseEventArgs
+        {
+            Target = target,
+            X = px,
+            Y = py,
+            Button = Events.MouseButton.Left,
+            Bubbles = true,
+        };
+        _panelDispatcher.Dispatch(target, EventTypes.Click, args);
+    }
+
+    private void HandlePanelMouseUp(float windowX, float windowY)
+    {
+        if (_panelDragging && _panelDraggingScrollbar != null)
+        {
+            var hit = _panelDraggingScrollbar;
+            _panelDraggingScrollbar = null;
+            _panelDragging = false;
+            var (px, py) = ToPanelCoords(windowX, windowY);
+            if (hit.HitType is MikoEngine.ScrollbarHitType.VerticalTrack
+                or MikoEngine.ScrollbarHitType.HorizontalTrack)
+            {
+                _panelEngine.ScrollTrackClick(hit.Box, hit.HitType, px, py);
+            }
+            return;
+        }
+        _panelDragging = false;
+    }
+
+    private void HandlePanelMouseMove(float windowX, float windowY)
+    {
+        if (_panelDraggingScrollbar == null) return;
+        var (px, py) = ToPanelCoords(windowX, windowY);
+        var hit = _panelDraggingScrollbar;
+        if (hit.HitType == MikoEngine.ScrollbarHitType.VerticalThumb)
+            _panelEngine.DragVerticalThumb(hit.Box, py, hit.ThumbOffset);
+        else if (hit.HitType == MikoEngine.ScrollbarHitType.HorizontalThumb)
+            _panelEngine.DragHorizontalThumb(hit.Box, px, hit.ThumbOffset);
+    }
+
+    // ---------------------------------------------------------------------
+    // Silk → Miko 类型映射（与 Miko.Windowing.SilkKeyMap 等价，此处内联以免依赖桌面宿主包）
+    // ---------------------------------------------------------------------
+
+    private static Events.MouseButton ToMikoButton(SilkMouseButton button) => button switch
+    {
+        SilkMouseButton.Middle => Events.MouseButton.Middle,
+        SilkMouseButton.Right => Events.MouseButton.Right,
+        _ => Events.MouseButton.Left,
+    };
+
+    private static MikoKey ToMikoKey(Key key) => key switch
+    {
+        Key.Backspace => MikoKey.Backspace,
+        Key.Delete => MikoKey.Delete,
+        Key.Left => MikoKey.Left,
+        Key.Right => MikoKey.Right,
+        Key.Home => MikoKey.Home,
+        Key.End => MikoKey.End,
+        Key.Enter or Key.KeypadEnter => MikoKey.Enter,
+        Key.Tab => MikoKey.Tab,
+        Key.Escape => MikoKey.Escape,
+        Key.F1 => MikoKey.F1,
+        Key.F2 => MikoKey.F2,
+        Key.F3 => MikoKey.F3,
+        Key.F4 => MikoKey.F4,
+        Key.F5 => MikoKey.F5,
+        Key.F6 => MikoKey.F6,
+        Key.F7 => MikoKey.F7,
+        Key.F8 => MikoKey.F8,
+        Key.F9 => MikoKey.F9,
+        Key.F10 => MikoKey.F10,
+        Key.F11 => MikoKey.F11,
+        Key.F12 => MikoKey.F12,
+        _ => MikoKey.Unknown,
+    };
+
+    private static MikoKeyModifiers GetModifiers(IKeyboard keyboard)
+    {
+        var mods = MikoKeyModifiers.None;
+        if (keyboard.IsKeyPressed(Key.ControlLeft) || keyboard.IsKeyPressed(Key.ControlRight))
+            mods |= MikoKeyModifiers.Control;
+        if (keyboard.IsKeyPressed(Key.ShiftLeft) || keyboard.IsKeyPressed(Key.ShiftRight))
+            mods |= MikoKeyModifiers.Shift;
+        if (keyboard.IsKeyPressed(Key.AltLeft) || keyboard.IsKeyPressed(Key.AltRight))
+            mods |= MikoKeyModifiers.Alt;
+        return mods;
+    }
+}

--- a/src/Miko.Simulator/SimulatorHostExtensions.cs
+++ b/src/Miko.Simulator/SimulatorHostExtensions.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Miko.Hosting;
+
+namespace Miko.Simulator;
+
+/// <summary>
+/// 模拟器宿主的便捷扩展，让模拟器启动项目保持极简：
+/// <code>App.CreateContext().RunSimulator();</code>
+/// 与 <c>RunDesktop()</c> 同级，作为独立平台启动项目使用。
+/// </summary>
+public static class SimulatorHostExtensions
+{
+    /// <summary>从应用上下文创建一个模拟器宿主（不启动）。</summary>
+    public static SimulatorHost UseSimulator(this MikoAppContext context, Action<SimulatorOptions>? configure = null)
+    {
+        var options = new SimulatorOptions();
+        configure?.Invoke(options);
+
+        var loggerFactory = context.Services.GetService<ILoggerFactory>();
+        var logger = loggerFactory?.CreateLogger<SimulatorHost>();
+        return new SimulatorHost(context, options, logger);
+    }
+
+    /// <summary>从应用上下文创建模拟器宿主并启动（阻塞直到窗口关闭）。</summary>
+    public static void RunSimulator(this MikoAppContext context, Action<SimulatorOptions>? configure = null)
+    {
+        context.UseSimulator(configure).Run();
+    }
+
+    /// <summary>构建应用并以模拟器宿主运行。</summary>
+    public static void RunSimulator(this MikoAppBuilder builder, Action<SimulatorOptions>? configure = null)
+    {
+        builder.Build().RunSimulator(configure);
+    }
+}

--- a/src/Miko.Simulator/SimulatorOptions.cs
+++ b/src/Miko.Simulator/SimulatorOptions.cs
@@ -1,0 +1,19 @@
+namespace Miko.Simulator;
+
+/// <summary>
+/// 模拟器配置。控制可选设备列表、初始设备与朝向、窗口标题。
+/// </summary>
+public sealed class SimulatorOptions
+{
+    /// <summary>模拟器窗口标题。null 时默认使用 "<应用标题> — Simulator"。</summary>
+    public string? Title { get; set; }
+
+    /// <summary>可选设备列表。默认使用 <see cref="DeviceProfile.Defaults"/>。</summary>
+    public IReadOnlyList<DeviceProfile> Devices { get; set; } = DeviceProfile.Defaults;
+
+    /// <summary>初始选中设备。null 时使用 <see cref="Devices"/> 的第一个。</summary>
+    public DeviceProfile? InitialDevice { get; set; }
+
+    /// <summary>初始朝向。</summary>
+    public Orientation InitialOrientation { get; set; } = Orientation.Portrait;
+}

--- a/src/Miko.Simulator/SimulatorPanel.cs
+++ b/src/Miko.Simulator/SimulatorPanel.cs
@@ -1,0 +1,168 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+
+namespace Miko.Simulator;
+
+/// <summary>
+/// 构建模拟器右侧设置面板的 DOM 树。面板交由 Miko 引擎布局/渲染。
+/// 纯静态构建函数；交互由调用方（<see cref="SimulatorHost"/>）通过回调接入。
+/// </summary>
+internal static class SimulatorPanel
+{
+    /// <summary>
+    /// 构建设置面板。
+    /// </summary>
+    /// <param name="devices">可选设备列表。</param>
+    /// <param name="current">当前选中的设备。</param>
+    /// <param name="orientation">当前朝向。</param>
+    /// <param name="safeAreaEnabled">是否启用安全区模拟。</param>
+    /// <param name="onSelectDevice">选择设备回调。</param>
+    /// <param name="onSetOrientation">设置朝向回调。</param>
+    /// <param name="onToggleSafeArea">切换安全区回调。</param>
+    public static Element Build(
+        IReadOnlyList<DeviceProfile> devices,
+        DeviceProfile current,
+        Orientation orientation,
+        bool safeAreaEnabled,
+        Action<DeviceProfile> onSelectDevice,
+        Action<Orientation> onSetOrientation,
+        Action<bool> onToggleSafeArea)
+    {
+        var panel = new DivElement { Class = "sim-panel" };
+
+        panel.AddChild(BuildHeader());
+
+        var body = new DivElement { Class = "sim-body" };
+        body.AddChild(BuildDeviceSection(devices, current, onSelectDevice));
+        body.AddChild(BuildOrientationSection(orientation, onSetOrientation));
+        body.AddChild(BuildSafeAreaSection(safeAreaEnabled, onToggleSafeArea));
+        body.AddChild(BuildInfoSection(current, orientation));
+        panel.AddChild(body);
+
+        return panel;
+    }
+
+    private static Element BuildHeader()
+    {
+        var header = new DivElement { Class = "sim-header" };
+        header.AddChild(new DivElement { Class = "sim-title", TextContent = "Miko Simulator" });
+        header.AddChild(new DivElement { Class = "sim-subtitle", TextContent = "Device preview & settings" });
+        return header;
+    }
+
+    private static Element BuildDeviceSection(
+        IReadOnlyList<DeviceProfile> devices,
+        DeviceProfile current,
+        Action<DeviceProfile> onSelectDevice)
+    {
+        var section = new DivElement { Class = "sim-section" };
+        section.AddChild(new DivElement { Class = "sim-section-label", TextContent = "DEVICE" });
+
+        foreach (var device in devices)
+        {
+            bool active = device.Name == current.Name;
+            var item = new DivElement
+            {
+                Class = active ? "sim-device sim-device-active" : "sim-device",
+            };
+            item.AddChild(new DivElement { Class = "sim-device-name", TextContent = device.Name });
+            item.AddChild(new DivElement
+            {
+                Class = "sim-device-spec",
+                TextContent = $"{device.LogicalWidth}×{device.LogicalHeight}  @{device.Scale:0.#}x",
+            });
+
+            var captured = device;
+            item.OnClick = _ => onSelectDevice(captured);
+            section.AddChild(item);
+        }
+
+        return section;
+    }
+
+    private static Element BuildOrientationSection(Orientation orientation, Action<Orientation> onSetOrientation)
+    {
+        var section = new DivElement { Class = "sim-section" };
+        section.AddChild(new DivElement { Class = "sim-section-label", TextContent = "ORIENTATION" });
+
+        var row = new DivElement { Class = "sim-btn-row" };
+
+        var portrait = new DivElement
+        {
+            Class = orientation == Orientation.Portrait ? "sim-btn sim-btn-active" : "sim-btn",
+            TextContent = "Portrait",
+        };
+        portrait.OnClick = _ => onSetOrientation(Orientation.Portrait);
+
+        var landscape = new DivElement
+        {
+            Class = orientation == Orientation.Landscape ? "sim-btn sim-btn-active" : "sim-btn",
+            TextContent = "Landscape",
+        };
+        landscape.OnClick = _ => onSetOrientation(Orientation.Landscape);
+
+        row.AddChild(portrait);
+        row.AddChild(landscape);
+        section.AddChild(row);
+        return section;
+    }
+
+    private static Element BuildSafeAreaSection(bool safeAreaEnabled, Action<bool> onToggleSafeArea)
+    {
+        var section = new DivElement { Class = "sim-section" };
+        section.AddChild(new DivElement { Class = "sim-section-label", TextContent = "SAFE AREA" });
+
+        var row = new DivElement { Class = "sim-btn-row" };
+
+        var on = new DivElement
+        {
+            Class = safeAreaEnabled ? "sim-btn sim-btn-active" : "sim-btn",
+            TextContent = "On",
+        };
+        on.OnClick = _ => onToggleSafeArea(true);
+
+        var off = new DivElement
+        {
+            Class = !safeAreaEnabled ? "sim-btn sim-btn-active" : "sim-btn",
+            TextContent = "Off",
+        };
+        off.OnClick = _ => onToggleSafeArea(false);
+
+        row.AddChild(on);
+        row.AddChild(off);
+        section.AddChild(row);
+        return section;
+    }
+
+    private static Element BuildInfoSection(DeviceProfile device, Orientation orientation)
+    {
+        var section = new DivElement { Class = "sim-section" };
+        section.AddChild(new DivElement { Class = "sim-section-label", TextContent = "INFO" });
+
+        var (w, h) = orientation == Orientation.Portrait
+            ? (device.LogicalWidth, device.LogicalHeight)
+            : (device.LogicalHeight, device.LogicalWidth);
+
+        section.AddChild(InfoRow("Viewport", $"{w} × {h} pt"));
+        section.AddChild(InfoRow("Resolution", $"{(int)(w * device.Scale)} × {(int)(h * device.Scale)} px"));
+        section.AddChild(InfoRow("Scale", $"{device.Scale:0.#}x"));
+        section.AddChild(InfoRow("Class", device.Kind.ToString()));
+        return section;
+    }
+
+    private static Element InfoRow(string key, string value)
+    {
+        var row = new DivElement { Class = "sim-info-row" };
+        row.AddChild(new DivElement { Class = "sim-info-key", TextContent = key });
+        row.AddChild(new DivElement { Class = "sim-info-val", TextContent = value });
+        return row;
+    }
+}
+
+/// <summary>设备朝向。</summary>
+public enum Orientation
+{
+    Portrait,
+    Landscape,
+}

--- a/src/Miko.Simulator/SimulatorStyleSheet.cs
+++ b/src/Miko.Simulator/SimulatorStyleSheet.cs
@@ -1,0 +1,171 @@
+using Miko.Common;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+
+namespace Miko.Simulator;
+
+/// <summary>
+/// 模拟器右侧设置面板的样式表。面板本身用 Miko 引擎布局/渲染，
+/// 因此其外观完全由这张样式表驱动（与 DevTools 面板同理）。
+/// </summary>
+internal static class SimulatorStyleSheet
+{
+    private static readonly Color BgDark = new(32, 33, 36);
+    private static readonly Color BgMedium = new(45, 46, 50);
+    private static readonly Color BgLight = new(60, 62, 67);
+    private static readonly Color BgSelected = new(38, 79, 120);
+    private static readonly Color Accent = new(0, 122, 204);
+    private static readonly Color TextPrimary = new(222, 223, 226);
+    private static readonly Color TextSecondary = new(150, 152, 158);
+    private static readonly Color BorderColor = new(58, 59, 64);
+
+    public static StyleSheet Create()
+    {
+        var sheet = new StyleSheet();
+
+        sheet.AddRule(new ClassSelector("sim-panel"), new Style
+        {
+            Display = Display.Flex,
+            FlexDirection = FlexDirection.Column,
+            Width = Length.Percent(100),
+            Height = Length.Percent(100),
+            BackgroundColor = BgDark,
+            Color = TextPrimary,
+            FontSize = Length.Px(13),
+        });
+
+        sheet.AddRule(new ClassSelector("sim-header"), new Style
+        {
+            Display = Display.Flex,
+            FlexDirection = FlexDirection.Column,
+            PaddingTop = Length.Px(14),
+            PaddingBottom = Length.Px(14),
+            PaddingLeft = Length.Px(16),
+            PaddingRight = Length.Px(16),
+            BackgroundColor = BgMedium,
+            BorderBottom = new BorderSide(Length.Px(1), BorderStyle.Solid, BorderColor),
+        });
+
+        sheet.AddRule(new ClassSelector("sim-title"), new Style
+        {
+            FontSize = Length.Px(15),
+            FontWeight = FontWeight.Bold,
+            Color = TextPrimary,
+        });
+
+        sheet.AddRule(new ClassSelector("sim-subtitle"), new Style
+        {
+            FontSize = Length.Px(11),
+            Color = TextSecondary,
+            MarginTop = Length.Px(2),
+        });
+
+        sheet.AddRule(new ClassSelector("sim-body"), new Style
+        {
+            FlexGrow = 1,
+            MinHeight = Length.Px(0),
+            OverflowY = Overflow.Scroll,
+            PaddingTop = Length.Px(12),
+            PaddingBottom = Length.Px(12),
+            PaddingLeft = Length.Px(16),
+            PaddingRight = Length.Px(16),
+        });
+
+        sheet.AddRule(new ClassSelector("sim-section"), new Style
+        {
+            MarginBottom = Length.Px(18),
+        });
+
+        sheet.AddRule(new ClassSelector("sim-section-label"), new Style
+        {
+            FontSize = Length.Px(11),
+            FontWeight = FontWeight.Bold,
+            Color = TextSecondary,
+            MarginBottom = Length.Px(8),
+        });
+
+        // 设备列表项
+        sheet.AddRule(new ClassSelector("sim-device"), new Style
+        {
+            Display = Display.Flex,
+            FlexDirection = FlexDirection.Column,
+            PaddingTop = Length.Px(8),
+            PaddingBottom = Length.Px(8),
+            PaddingLeft = Length.Px(10),
+            PaddingRight = Length.Px(10),
+            MarginBottom = Length.Px(4),
+            BorderRadius = Length.Px(6),
+            BackgroundColor = BgMedium,
+            Cursor = Cursor.Pointer,
+        });
+
+        sheet.AddRule(new ClassSelector("sim-device-active"), new Style
+        {
+            BackgroundColor = BgSelected,
+            BorderLeft = new BorderSide(Length.Px(3), BorderStyle.Solid, Accent),
+        });
+
+        sheet.AddRule(new ClassSelector("sim-device-name"), new Style
+        {
+            FontSize = Length.Px(13),
+            Color = TextPrimary,
+        });
+
+        sheet.AddRule(new ClassSelector("sim-device-spec"), new Style
+        {
+            FontSize = Length.Px(10),
+            Color = TextSecondary,
+            MarginTop = Length.Px(2),
+        });
+
+        // 通用按钮行（朝向、安全区开关等）
+        sheet.AddRule(new ClassSelector("sim-btn-row"), new Style
+        {
+            Display = Display.Flex,
+            FlexDirection = FlexDirection.Row,
+            Gap = Length.Px(8),
+        });
+
+        sheet.AddRule(new ClassSelector("sim-btn"), new Style
+        {
+            FlexGrow = 1,
+            PaddingTop = Length.Px(8),
+            PaddingBottom = Length.Px(8),
+            BackgroundColor = BgMedium,
+            Color = TextPrimary,
+            TextAlign = TextAlign.Center,
+            BorderRadius = Length.Px(6),
+            Cursor = Cursor.Pointer,
+        });
+
+        sheet.AddRule(new ClassSelector("sim-btn-active"), new Style
+        {
+            BackgroundColor = Accent,
+            Color = new Color(255, 255, 255),
+        });
+
+        // 只读信息行
+        sheet.AddRule(new ClassSelector("sim-info-row"), new Style
+        {
+            Display = Display.Flex,
+            FlexDirection = FlexDirection.Row,
+            JustifyContent = JustifyContent.SpaceBetween,
+            PaddingTop = Length.Px(4),
+            PaddingBottom = Length.Px(4),
+        });
+
+        sheet.AddRule(new ClassSelector("sim-info-key"), new Style
+        {
+            Color = TextSecondary,
+            FontSize = Length.Px(12),
+        });
+
+        sheet.AddRule(new ClassSelector("sim-info-val"), new Style
+        {
+            Color = TextPrimary,
+            FontSize = Length.Px(12),
+        });
+
+        return sheet;
+    }
+}

--- a/templates/MikoMultiplatformApp/MikoMultiplatformApp.Simulator/MikoMultiplatformApp.Simulator.csproj
+++ b/templates/MikoMultiplatformApp/MikoMultiplatformApp.Simulator/MikoMultiplatformApp.Simulator.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <StartupObject>MikoMultiplatformApp.Simulator.Program</StartupObject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MikoMultiplatformApp\MikoMultiplatformApp.csproj" />
+    <PackageReference Include="Miko.Simulator" Version="1.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/templates/MikoMultiplatformApp/MikoMultiplatformApp.Simulator/Program.cs
+++ b/templates/MikoMultiplatformApp/MikoMultiplatformApp.Simulator/Program.cs
@@ -1,0 +1,21 @@
+using Miko.Simulator;
+using MikoMultiplatformApp;
+
+namespace MikoMultiplatformApp.Simulator;
+
+public static class Program
+{
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        var context = App.CreateContext();
+
+        // Hot reload is wired up inside the shared app assembly, same as the desktop head.
+        App.InitializeHotReload(context);
+
+        // Run the app inside a device simulator window: the app renders into an
+        // independent device-sized canvas on the left, with a Miko-rendered
+        // settings panel (device / orientation / safe area) on the right.
+        context.RunSimulator();
+    }
+}

--- a/templates/MikoMultiplatformApp/README.md
+++ b/templates/MikoMultiplatformApp/README.md
@@ -9,6 +9,7 @@ components for its UI, rendered with SkiaSharp on Desktop, Android and iOS.
 | ------------------------------- | ------------------------------------------------------------ |
 | `MikoMultiplatformApp`          | Shared UI (Razor components, styles) and app configuration.  |
 | `MikoMultiplatformApp.Desktop`  | Desktop startup (Windows/Linux/macOS) — uses `Miko.Windowing`. |
+| `MikoMultiplatformApp.Simulator`| Device simulator (Windows/Linux/macOS) — uses `Miko.Simulator`. |
 | `MikoMultiplatformApp.Android`  | Android startup — uses `Miko.Android`.                       |
 | `MikoMultiplatformApp.iOS`      | iOS startup — uses `Miko.iOS`.                               |
 
@@ -22,6 +23,12 @@ Desktop:
 
 ```bash
 dotnet run --project MikoMultiplatformApp.Desktop
+```
+
+Device simulator (preview app with device chrome and settings panel):
+
+```bash
+dotnet run --project MikoMultiplatformApp.Simulator
 ```
 
 Android (device/emulator connected, `android` workload installed):


### PR DESCRIPTION
## Summary

Adds **Miko.Simulator** — a desktop-based device simulator that renders the app inside a mobile device bezel with an interactive settings panel, enabling rapid testing of different screen sizes, orientations, and safe areas without physical devices or emulators.

## Changes

### New Library: `Miko.Simulator`
- **SimulatorHost**: Splits the window into device canvas (left) + settings panel (right)
- **Independent offscreen rendering**: App renders into a device-sized SKSurface at physical resolution, then composites into the bezel
- **Settings panel**: Built with Miko itself — device picker (iPhone 15 Pro, Pixel 7, iPad mini, etc.), orientation toggle, safe area toggle, live info display
- **Region-based input routing**: Panel events stay on panel; device-area events map to app-logical coords
- **Touch cursor**: Custom gray translucent circle when hovering over device screen
- **DevTools integration**: F12 opens DevTools inspecting the app engine (not simulator chrome)

### Fixes
- **Minimize/restore black screen**: Guard against 0×0 render targets corrupting GRContext
- **Panel click-through**: Fixed input layer priority — panel now correctly intercepts events when overlapping device area
- **Framebuffer binding bug**: Capture window FBO before offscreen rendering to avoid drawing into invisible buffer

### Examples
- Added `.Simulator` startup projects for MikoAppBlank, MikoAppSidemenu, MikoAppTabs

### CI & Templates
- Updated `publish-nuget.yml` to pack `Miko.Simulator` NuGet package
- Updated `MikoMultiplatformApp` template to include `.Simulator` head by default

## Testing
- ✅ Full solution builds (`dotnet build miko.slnx`)
- ✅ Template instantiation includes Simulator project
- ✅ F12 DevTools opens and inspects app DOM
- ✅ Minimize/restore no longer causes black screen
- ✅ Panel buttons/scrolling work when overlapping device area

## Related
Closes #67