### PR TITLE
Add Ionic component ports

### DIFF
--- a/src/Miko.Ionic/Components/Badge/BadgeStyles.cs
+++ b/src/Miko.Ionic/Components/Badge/BadgeStyles.cs
@@ -1,0 +1,54 @@
+using Miko.Common;
+using Miko.Styling;
+
+namespace Miko.Ionic.Components;
+
+/// <summary>Styles for <c>ion-badge</c>.</summary>
+internal static class BadgeStyles
+{
+    internal static CssObject GenStyle(string mode, IonicTheme t)
+    {
+        var css = new CssObject
+        {
+            [$".ion-badge.{mode}"] = new()
+            {
+                Display = Display.InlineBlock,
+                MinWidth = Length.Px(t.BadgeMinWidth),
+                PaddingTop = Length.Px(t.BadgePaddingTop),
+                PaddingRight = Length.Px(t.BadgePaddingEnd),
+                PaddingBottom = Length.Px(t.BadgePaddingBottom),
+                PaddingLeft = Length.Px(t.BadgePaddingStart),
+                BackgroundColor = t.BadgeBackground,
+                Color = t.BadgeColor,
+                FontSize = Length.Px(t.BadgeFontSize),
+                FontWeight = FontWeight.Bold,
+                LineHeight = Length.Number(1),
+                TextAlign = TextAlign.Center,
+                WhiteSpace = WhiteSpace.Nowrap,
+                VerticalAlign = VerticalAlign.Baseline,
+                BorderRadius = new BorderRadius(Length.Px(t.BadgeBorderRadius)),
+            },
+        };
+
+        AddColor(css, mode, "primary", t.Primary, Color.White);
+        AddColor(css, mode, "secondary", t.Secondary, Color.White);
+        AddColor(css, mode, "tertiary", t.Tertiary, Color.White);
+        AddColor(css, mode, "success", t.Success, Color.Black);
+        AddColor(css, mode, "warning", t.Warning, Color.Black);
+        AddColor(css, mode, "danger", t.Danger, Color.White);
+        AddColor(css, mode, "light", t.Light, Color.Black);
+        AddColor(css, mode, "medium", t.Medium, Color.White);
+        AddColor(css, mode, "dark", t.Dark, Color.White);
+
+        return css;
+    }
+
+    private static void AddColor(CssObject css, string mode, string name, Color background, Color color)
+    {
+        css[$".ion-badge.{mode}.ion-color-{name}"] = new()
+        {
+            BackgroundColor = background,
+            Color = color,
+        };
+    }
+}

--- a/src/Miko.Ionic/Components/Badge/IonBadge.razor
+++ b/src/Miko.Ionic/Components/Badge/IonBadge.razor
@@ -1,0 +1,20 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<span class="@_cssClass">
+    @ChildContent
+</span>
+
+@code {
+    /// <summary>Named palette color (Ionic <c>color</c>): <c>"primary"</c>, <c>"danger"</c>, ... .</summary>
+    [Parameter] public string? Color { get; set; }
+
+    private string _cssClass = "md ion-badge";
+
+    protected override void OnParametersSet()
+    {
+        var cls = $"{Mode} ion-badge";
+        if (!string.IsNullOrWhiteSpace(Color))
+            cls += $" ion-color ion-color-{Color.ToLowerInvariant()}";
+        _cssClass = cls;
+    }
+}

--- a/src/Miko.Ionic/Components/Card/CardStyles.cs
+++ b/src/Miko.Ionic/Components/Card/CardStyles.cs
@@ -1,0 +1,114 @@
+using Miko.Common;
+using Miko.Styling;
+
+namespace Miko.Ionic.Components;
+
+/// <summary>Styles for <c>ion-card</c>, <c>ion-card-header</c>, and <c>ion-card-content</c>.</summary>
+internal static class CardStyles
+{
+    internal static CssObject GenStyle(string mode, IonicTheme t)
+    {
+        var css = new CssObject
+        {
+            [$".ion-card.{mode}"] = new()
+            {
+                Display = Display.Block,
+                Position = Position.Relative,
+                MarginTop = Length.Px(t.CardMarginTop),
+                MarginRight = Length.Px(t.CardMarginEnd),
+                MarginBottom = Length.Px(t.CardMarginBottom),
+                MarginLeft = Length.Px(t.CardMarginStart),
+                BackgroundColor = t.CardBackground,
+                Color = t.CardColor,
+                FontSize = Length.Px(t.CardFontSize),
+                LineHeight = t.CardLineHeight,
+                BorderRadius = new BorderRadius(Length.Px(t.CardBorderRadius)),
+                BoxShadow = t.CardBoxShadow.Count > 0 ? t.CardBoxShadow : null,
+                Overflow = Overflow.Hidden,
+            },
+
+            [$".ion-card.{mode}.card-disabled"] = new()
+            {
+                Opacity = 0.3f,
+                Cursor = Cursor.Default,
+                PointerEvents = PointerEvents.None,
+            },
+
+            [$".ion-card.{mode} .card-native"] = new()
+            {
+                Display = Display.Block,
+                Width = Length.Percent(100),
+                MinHeight = Length.Px(0),
+                PaddingTop = Length.Px(0),
+                PaddingRight = Length.Px(0),
+                PaddingBottom = Length.Px(0),
+                PaddingLeft = Length.Px(0),
+                MarginTop = Length.Px(0),
+                MarginRight = Length.Px(0),
+                MarginBottom = Length.Px(0),
+                MarginLeft = Length.Px(0),
+                BackgroundColor = t.CardBackground,
+                Color = t.CardColor,
+                BorderWidth = Length.Px(0),
+                TextDecoration = TextDecoration.None,
+                Cursor = Cursor.Pointer,
+            },
+
+            [$".ion-card-header.{mode}"] = new()
+            {
+                Display = Display.Flex,
+                Position = Position.Relative,
+                FlexDirection = mode == "ios" ? FlexDirection.ColumnReverse : FlexDirection.Column,
+                PaddingTop = Length.Px(t.CardHeaderPaddingTop),
+                PaddingRight = Length.Px(t.CardHeaderPaddingEnd),
+                PaddingBottom = Length.Px(t.CardHeaderPaddingBottom),
+                PaddingLeft = Length.Px(t.CardHeaderPaddingStart),
+                BackgroundColor = Color.Transparent,
+                Color = t.CardColor,
+            },
+
+            [$".ion-card-content.{mode}"] = new()
+            {
+                Display = Display.Block,
+                Position = Position.Relative,
+                PaddingTop = Length.Px(t.CardContentPaddingTop),
+                PaddingRight = Length.Px(t.CardContentPaddingEnd),
+                PaddingBottom = Length.Px(t.CardContentPaddingBottom),
+                PaddingLeft = Length.Px(t.CardContentPaddingStart),
+                FontSize = Length.Px(t.CardContentFontSize),
+                LineHeight = t.CardContentLineHeight,
+            },
+
+            [$".ion-card-header.{mode} + .ion-card-content.{mode}"] = new()
+            {
+                PaddingTop = Length.Px(0),
+            },
+        };
+
+        AddColor(css, mode, "primary", t.Primary, Color.White);
+        AddColor(css, mode, "secondary", t.Secondary, Color.White);
+        AddColor(css, mode, "tertiary", t.Tertiary, Color.White);
+        AddColor(css, mode, "success", t.Success, Color.Black);
+        AddColor(css, mode, "warning", t.Warning, Color.Black);
+        AddColor(css, mode, "danger", t.Danger, Color.White);
+        AddColor(css, mode, "light", t.Light, Color.Black);
+        AddColor(css, mode, "medium", t.Medium, Color.White);
+        AddColor(css, mode, "dark", t.Dark, Color.White);
+
+        return css;
+    }
+
+    private static void AddColor(CssObject css, string mode, string name, Color background, Color color)
+    {
+        css[$".ion-card.{mode}.ion-color-{name}"] = new()
+        {
+            BackgroundColor = background,
+            Color = color,
+        };
+        css[$".ion-card-header.{mode}.ion-color-{name}"] = new()
+        {
+            BackgroundColor = background,
+            Color = color,
+        };
+    }
+}

--- a/src/Miko.Ionic/Components/Card/IonCard.razor
+++ b/src/Miko.Ionic/Components/Card/IonCard.razor
@@ -1,0 +1,80 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+@if (IsClickable)
+{
+    <div class="@_cssClass">
+        @if (string.IsNullOrEmpty(Href))
+        {
+            <button class="card-native" @onclick="HandleClick">
+                @ChildContent
+            </button>
+        }
+        else
+        {
+            <a class="card-native" href="@Href" target="@Target" rel="@Rel" @onclick="HandleClick">
+                @ChildContent
+            </a>
+        }
+    </div>
+}
+else
+{
+    <div class="@_cssClass">
+        @ChildContent
+    </div>
+}
+
+@code {
+    /// <summary>Named palette color (Ionic <c>color</c>): <c>"primary"</c>, <c>"danger"</c>, ... .</summary>
+    [Parameter] public string? Color { get; set; }
+
+    /// <summary>When true, renders a clickable card surface.</summary>
+    [Parameter] public bool Button { get; set; }
+
+    /// <summary>Link target. When set, the native card surface is an anchor.</summary>
+    [Parameter] public string? Href { get; set; }
+
+    /// <summary>Anchor target, used only when <see cref="Href"/> is set.</summary>
+    [Parameter] public string? Target { get; set; }
+
+    /// <summary>Anchor rel, used only when <see cref="Href"/> is set.</summary>
+    [Parameter] public string? Rel { get; set; }
+
+    /// <summary>When true, the card is dimmed and non-interactive.</summary>
+    [Parameter] public bool Disabled { get; set; }
+
+    /// <summary>Raised when the clickable card surface is tapped.</summary>
+    [Parameter] public EventCallback OnClick { get; set; }
+
+    private string _cssClass = "md ion-card";
+
+    private bool IsClickable => Button || !string.IsNullOrEmpty(Href);
+
+    protected override void OnParametersSet()
+    {
+        var cls = $"{Mode} ion-card";
+        if (Disabled) cls += " card-disabled";
+        if (IsClickable) cls += " ion-activatable";
+        if (!string.IsNullOrWhiteSpace(Color))
+            cls += $" ion-color ion-color-{Color.ToLowerInvariant()}";
+        _cssClass = cls;
+    }
+
+    public override Element Build()
+    {
+        var root = base.Build();
+        if (Disabled)
+            root.SetState(ElementState.Disabled);
+
+        if (root.FindByClass("card-native").FirstOrDefault() is { } native && Disabled)
+            native.SetState(ElementState.Disabled);
+
+        return root;
+    }
+
+    private async Task HandleClick(MouseEventArgs _)
+    {
+        if (Disabled) return;
+        await OnClick.InvokeAsync();
+    }
+}

--- a/src/Miko.Ionic/Components/Card/IonCardContent.razor
+++ b/src/Miko.Ionic/Components/Card/IonCardContent.razor
@@ -1,0 +1,14 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<div class="@_cssClass">
+    @ChildContent
+</div>
+
+@code {
+    private string _cssClass = "md ion-card-content card-content-md";
+
+    protected override void OnParametersSet()
+    {
+        _cssClass = $"{Mode} ion-card-content card-content-{Mode}";
+    }
+}

--- a/src/Miko.Ionic/Components/Card/IonCardHeader.razor
+++ b/src/Miko.Ionic/Components/Card/IonCardHeader.razor
@@ -1,0 +1,24 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<div class="@_cssClass">
+    @ChildContent
+</div>
+
+@code {
+    /// <summary>Named palette color (Ionic <c>color</c>): <c>"primary"</c>, <c>"danger"</c>, ... .</summary>
+    [Parameter] public string? Color { get; set; }
+
+    /// <summary>When true, stamps the iOS translucent header marker class.</summary>
+    [Parameter] public bool Translucent { get; set; }
+
+    private string _cssClass = "md ion-card-header ion-inherit-color";
+
+    protected override void OnParametersSet()
+    {
+        var cls = $"{Mode} ion-card-header ion-inherit-color";
+        if (Translucent) cls += " card-header-translucent";
+        if (!string.IsNullOrWhiteSpace(Color))
+            cls += $" ion-color ion-color-{Color.ToLowerInvariant()}";
+        _cssClass = cls;
+    }
+}

--- a/src/Miko.Ionic/Components/Chip/ChipStyles.cs
+++ b/src/Miko.Ionic/Components/Chip/ChipStyles.cs
@@ -1,0 +1,94 @@
+using Miko.Common;
+using Miko.Styling;
+
+namespace Miko.Ionic.Components;
+
+/// <summary>Styles for <c>ion-chip</c>.</summary>
+internal static class ChipStyles
+{
+    internal static CssObject GenStyle(string mode, IonicTheme t)
+    {
+        var css = new CssObject
+        {
+            [$".ion-chip.{mode}"] = new()
+            {
+                Display = Display.InlineBlock,
+                Position = Position.Relative,
+                MinHeight = Length.Px(32),
+                PaddingTop = Length.Px(6),
+                PaddingRight = Length.Px(12),
+                PaddingBottom = Length.Px(6),
+                PaddingLeft = Length.Px(12),
+                MarginTop = Length.Px(4),
+                MarginRight = Length.Px(4),
+                MarginBottom = Length.Px(4),
+                MarginLeft = Length.Px(4),
+                BackgroundColor = t.ChipBackground,
+                Color = t.ChipColor,
+                FontSize = Length.Px(t.ChipFontSize),
+                BorderRadius = new BorderRadius(Length.Px(16)),
+                Cursor = Cursor.Pointer,
+                VerticalAlign = VerticalAlign.Middle,
+                BoxSizing = BoxSizing.BorderBox,
+                Overflow = Overflow.Hidden,
+            },
+
+            [$".ion-chip.{mode}.chip-disabled"] = new()
+            {
+                Opacity = 0.4f,
+                Cursor = Cursor.Default,
+                PointerEvents = PointerEvents.None,
+            },
+
+            [$".ion-chip.{mode}.chip-outline"] = new()
+            {
+                BackgroundColor = Color.Transparent,
+                BorderWidth = Length.Px(1),
+                BorderStyle = BorderStyle.Solid,
+                BorderColor = t.ChipBorderColor,
+            },
+
+            [$".ion-chip.{mode} .ion-icon"] = new()
+            {
+                Width = Length.Px(18),
+                Height = Length.Px(18),
+                MarginRight = Length.Px(8),
+            },
+
+            [$".ion-chip.{mode} .ion-avatar"] = new()
+            {
+                Width = Length.Px(24),
+                Height = Length.Px(24),
+                MarginRight = Length.Px(8),
+                FlexShrink = 0,
+            },
+        };
+
+        AddColor(css, mode, "primary", t.Primary);
+        AddColor(css, mode, "secondary", t.Secondary);
+        AddColor(css, mode, "tertiary", t.Tertiary);
+        AddColor(css, mode, "success", t.Success);
+        AddColor(css, mode, "warning", t.Warning);
+        AddColor(css, mode, "danger", t.Danger);
+        AddColor(css, mode, "light", t.Light);
+        AddColor(css, mode, "medium", t.Medium);
+        AddColor(css, mode, "dark", t.Dark);
+
+        return css;
+    }
+
+    private static void AddColor(CssObject css, string mode, string name, Color color)
+    {
+        css[$".ion-chip.{mode}.ion-color-{name}"] = new()
+        {
+            BackgroundColor = new Color(color.R, color.G, color.B, 20),
+            Color = color,
+        };
+        css[$".ion-chip.{mode}.chip-outline.ion-color-{name}"] = new()
+        {
+            BackgroundColor = Color.Transparent,
+            BorderColor = new Color(color.R, color.G, color.B, 82),
+            Color = color,
+        };
+    }
+}

--- a/src/Miko.Ionic/Components/Chip/IonChip.razor
+++ b/src/Miko.Ionic/Components/Chip/IonChip.razor
@@ -1,0 +1,28 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<div class="@_cssClass">
+    @ChildContent
+</div>
+
+@code {
+    /// <summary>Named palette color (Ionic <c>color</c>): <c>"primary"</c>, <c>"danger"</c>, ... .</summary>
+    [Parameter] public string? Color { get; set; }
+
+    /// <summary>When true, renders the outline chip variant.</summary>
+    [Parameter] public bool Outline { get; set; }
+
+    /// <summary>When true, the chip is dimmed and non-interactive.</summary>
+    [Parameter] public bool Disabled { get; set; }
+
+    private string _cssClass = "md ion-chip ion-activatable";
+
+    protected override void OnParametersSet()
+    {
+        var cls = $"{Mode} ion-chip ion-activatable";
+        if (Outline) cls += " chip-outline";
+        if (Disabled) cls += " chip-disabled";
+        if (!string.IsNullOrWhiteSpace(Color))
+            cls += $" ion-color ion-color-{Color.ToLowerInvariant()}";
+        _cssClass = cls;
+    }
+}

--- a/src/Miko.Ionic/Components/Grid/GridStyles.cs
+++ b/src/Miko.Ionic/Components/Grid/GridStyles.cs
@@ -1,0 +1,59 @@
+using Miko.Common;
+using Miko.Styling;
+
+namespace Miko.Ionic.Components;
+
+/// <summary>Styles for <c>ion-grid</c>, <c>ion-row</c>, and <c>ion-col</c>.</summary>
+internal static class GridStyles
+{
+    internal static CssObject GenStyle(string mode, IonicTheme t)
+    {
+        return new CssObject
+        {
+            [$".ion-grid.{mode}"] = new()
+            {
+                Display = Display.Block,
+                FlexGrow = 1,
+                FlexShrink = 1,
+                FlexBasis = Length.Percent(0),
+                Width = Length.Percent(100),
+                PaddingTop = Length.Px(t.GridPadding),
+                PaddingRight = Length.Px(t.GridPadding),
+                PaddingBottom = Length.Px(t.GridPadding),
+                PaddingLeft = Length.Px(t.GridPadding),
+                MarginLeft = Length.Auto,
+                MarginRight = Length.Auto,
+                BoxSizing = BoxSizing.BorderBox,
+            },
+
+            [$".ion-grid.{mode}.grid-fixed"] = new()
+            {
+                MaxWidth = Length.Px(t.GridFixedWidth),
+            },
+
+            [$".ion-row.{mode}"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Row,
+                FlexWrap = FlexWrap.Wrap,
+                Width = Length.Percent(100),
+            },
+
+            [$".ion-col.{mode}"] = new()
+            {
+                Position = Position.Relative,
+                FlexGrow = 1,
+                FlexShrink = 1,
+                FlexBasis = Length.Percent(0),
+                Width = Length.Percent(100),
+                MaxWidth = Length.Percent(100),
+                MinHeight = Length.Px(1),
+                PaddingTop = Length.Px(t.GridColumnPadding),
+                PaddingRight = Length.Px(t.GridColumnPadding),
+                PaddingBottom = Length.Px(t.GridColumnPadding),
+                PaddingLeft = Length.Px(t.GridColumnPadding),
+                BoxSizing = BoxSizing.BorderBox,
+            },
+        };
+    }
+}

--- a/src/Miko.Ionic/Components/Grid/IonCol.razor
+++ b/src/Miko.Ionic/Components/Grid/IonCol.razor
@@ -1,0 +1,83 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<div class="@_cssClass" Style="@_inlineStyle">
+    @ChildContent
+</div>
+
+@code {
+    /// <summary>Column size from 1 to 12, or <c>"auto"</c>.</summary>
+    [Parameter] public string? Size { get; set; }
+
+    /// <summary>Column offset from 1 to 11 columns.</summary>
+    [Parameter] public string? Offset { get; set; }
+
+    /// <summary>Column push from 1 to 11 columns.</summary>
+    [Parameter] public string? Push { get; set; }
+
+    /// <summary>Column pull from 1 to 11 columns.</summary>
+    [Parameter] public string? Pull { get; set; }
+
+    private string _cssClass = "md ion-col";
+    private Style? _inlineStyle;
+
+    protected override void OnParametersSet()
+    {
+        _cssClass = $"{Mode} ion-col";
+        _inlineStyle = BuildColumnStyle();
+    }
+
+    private Style? BuildColumnStyle()
+    {
+        Style? style = null;
+
+        if (!string.IsNullOrWhiteSpace(Size))
+        {
+            style ??= new Style();
+            if (string.Equals(Size, "auto", StringComparison.OrdinalIgnoreCase))
+            {
+                style.FlexGrow = 0;
+                style.FlexShrink = 0;
+                style.FlexBasis = Length.Auto;
+                style.Width = Length.Auto;
+                style.MaxWidth = Length.Percent(100);
+            }
+            else if (TryColumnPercent(Size, out var sizePercent))
+            {
+                style.FlexGrow = 0;
+                style.FlexShrink = 0;
+                style.FlexBasis = Length.Percent(sizePercent);
+                style.Width = Length.Percent(sizePercent);
+                style.MaxWidth = Length.Percent(sizePercent);
+            }
+        }
+
+        if (TryColumnPercent(Offset, out var offsetPercent))
+        {
+            style ??= new Style();
+            style.MarginLeft = Length.Percent(offsetPercent);
+        }
+
+        if (TryColumnPercent(Push, out var pushPercent))
+        {
+            style ??= new Style();
+            style.Left = Length.Percent(pushPercent);
+        }
+
+        if (TryColumnPercent(Pull, out var pullPercent))
+        {
+            style ??= new Style();
+            style.Right = Length.Percent(pullPercent);
+        }
+
+        return style;
+    }
+
+    private static bool TryColumnPercent(string? value, out float percent)
+    {
+        percent = 0;
+        if (!float.TryParse(value, out var columns)) return false;
+        if (columns <= 0 || columns > 12) return false;
+        percent = columns / 12f * 100f;
+        return true;
+    }
+}

--- a/src/Miko.Ionic/Components/Grid/IonGrid.razor
+++ b/src/Miko.Ionic/Components/Grid/IonGrid.razor
@@ -1,0 +1,17 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<div class="@_cssClass">
+    @ChildContent
+</div>
+
+@code {
+    /// <summary>When true, constrains the grid to Ionic's fixed grid width.</summary>
+    [Parameter] public bool Fixed { get; set; }
+
+    private string _cssClass = "md ion-grid";
+
+    protected override void OnParametersSet()
+    {
+        _cssClass = Fixed ? $"{Mode} ion-grid grid-fixed" : $"{Mode} ion-grid";
+    }
+}

--- a/src/Miko.Ionic/Components/Grid/IonRow.razor
+++ b/src/Miko.Ionic/Components/Grid/IonRow.razor
@@ -1,0 +1,14 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<div class="@_cssClass">
+    @ChildContent
+</div>
+
+@code {
+    private string _cssClass = "md ion-row";
+
+    protected override void OnParametersSet()
+    {
+        _cssClass = $"{Mode} ion-row";
+    }
+}

--- a/src/Miko.Ionic/Components/InfiniteScroll/InfiniteScrollStyles.cs
+++ b/src/Miko.Ionic/Components/InfiniteScroll/InfiniteScrollStyles.cs
@@ -1,0 +1,60 @@
+using Miko.Common;
+using Miko.Styling;
+
+namespace Miko.Ionic.Components;
+
+/// <summary>Styles for <c>ion-infinite-scroll</c> and <c>ion-infinite-scroll-content</c>.</summary>
+internal static class InfiniteScrollStyles
+{
+    internal static CssObject GenStyle(string mode, IonicTheme t)
+    {
+        return new CssObject
+        {
+            [$".ion-infinite-scroll.{mode}"] = new()
+            {
+                Display = Display.None,
+                Width = Length.Percent(100),
+            },
+
+            [$".ion-infinite-scroll.{mode}.infinite-scroll-enabled"] = new()
+            {
+                Display = Display.Block,
+            },
+
+            [$".ion-infinite-scroll-content.{mode}"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                JustifyContent = JustifyContent.Center,
+                MinHeight = Length.Px(t.InfiniteScrollContentMinHeight),
+                TextAlign = TextAlign.Center,
+                UserSelect = UserSelect.None,
+            },
+
+            [$".ion-infinite-scroll-content.{mode} .infinite-loading"] = new()
+            {
+                Display = Display.None,
+                Width = Length.Percent(100),
+                MarginBottom = Length.Px(32),
+            },
+
+            [$".ion-infinite-scroll.{mode}.infinite-scroll-loading .infinite-loading"] = new()
+            {
+                Display = Display.Block,
+            },
+
+            [$".ion-infinite-scroll-content.{mode} .infinite-loading-text"] = new()
+            {
+                MarginTop = Length.Px(4),
+                MarginRight = Length.Px(32),
+                MarginLeft = Length.Px(32),
+            },
+
+            [$".ion-infinite-scroll-content.{mode} .infinite-loading-spinner-icon"] = new()
+            {
+                Width = Length.Px(24),
+                Height = Length.Px(24),
+            },
+        };
+    }
+}

--- a/src/Miko.Ionic/Components/InfiniteScroll/IonInfiniteScroll.razor
+++ b/src/Miko.Ionic/Components/InfiniteScroll/IonInfiniteScroll.razor
@@ -1,0 +1,102 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<div class="@_cssClass" @onscroll="HandleScroll">
+    @ChildContent
+</div>
+
+@code {
+    /// <summary>Threshold distance from the edge. Supports pixels (<c>"100px"</c>) or percent (<c>"15%"</c>).</summary>
+    [Parameter] public string Threshold { get; set; } = "15%";
+
+    /// <summary>When true, the infinite scroll is hidden and does not emit events.</summary>
+    [Parameter] public bool Disabled { get; set; }
+
+    /// <summary>Position of the infinite scroll marker: <c>"bottom"</c> (default) or <c>"top"</c>.</summary>
+    [Parameter] public string Position { get; set; } = "bottom";
+
+    /// <summary>Declarative loading state. Use <see cref="Complete"/> to reset it from code.</summary>
+    [Parameter] public bool Loading { get; set; }
+
+    /// <summary>Raised when the scroll event crosses the threshold. The event carries no payload, matching Ionic's ionInfinite.</summary>
+    [Parameter] public EventCallback OnInfinite { get; set; }
+
+    private string _cssClass = "md ion-infinite-scroll infinite-scroll-enabled";
+    private bool _isLoading;
+    private bool _didFire;
+
+    protected override void OnParametersSet()
+    {
+        if (Disabled)
+        {
+            _isLoading = false;
+            _didFire = false;
+        }
+        else if (Loading)
+        {
+            _isLoading = true;
+        }
+
+        var cls = $"{Mode} ion-infinite-scroll";
+        if (!Disabled) cls += " infinite-scroll-enabled";
+        if (_isLoading) cls += " infinite-scroll-loading";
+        if (string.Equals(Position, "top", StringComparison.OrdinalIgnoreCase))
+            cls += " infinite-scroll-top";
+        _cssClass = cls;
+    }
+
+    /// <summary>Marks the infinite scroll work as complete and allows the next threshold crossing to fire.</summary>
+    public Task Complete()
+    {
+        _isLoading = false;
+        _didFire = false;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    private async Task HandleScroll(ScrollEventArgs args)
+    {
+        if (Disabled || _isLoading || _didFire) return;
+        if (!CrossedThreshold(args)) return;
+
+        _isLoading = true;
+        _didFire = true;
+        await OnInfinite.InvokeAsync();
+    }
+
+    private bool CrossedThreshold(ScrollEventArgs args)
+    {
+        if (!TryParseThreshold(Threshold, out var amount, out var isPercent))
+            return true;
+
+        var delta = string.Equals(Position, "top", StringComparison.OrdinalIgnoreCase)
+            ? -args.DeltaY
+            : args.DeltaY;
+
+        if (delta <= 0) return false;
+
+        // Miko's scroll event currently exposes deltas and scrollTop, not viewport/content height.
+        // Pixel thresholds are compared to the delta; percent thresholds are treated as "any
+        // forward scroll" because the denominator is not available at this layer.
+        return isPercent || delta >= amount;
+    }
+
+    private static bool TryParseThreshold(string? threshold, out float amount, out bool isPercent)
+    {
+        amount = 0;
+        isPercent = false;
+
+        if (string.IsNullOrWhiteSpace(threshold)) return false;
+
+        var text = threshold.Trim();
+        if (text.EndsWith("%", StringComparison.Ordinal))
+        {
+            isPercent = true;
+            return float.TryParse(text[..^1], out amount);
+        }
+
+        if (text.EndsWith("px", StringComparison.OrdinalIgnoreCase))
+            text = text[..^2];
+
+        return float.TryParse(text, out amount);
+    }
+}

--- a/src/Miko.Ionic/Components/InfiniteScroll/IonInfiniteScrollContent.razor
+++ b/src/Miko.Ionic/Components/InfiniteScroll/IonInfiniteScrollContent.razor
@@ -1,0 +1,31 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<div class="@_cssClass">
+    <div class="infinite-loading">
+        @if (!string.IsNullOrEmpty(LoadingSpinner))
+        {
+            <div class="infinite-loading-spinner">
+                <IonSpinner Name="@LoadingSpinner" Class="infinite-loading-spinner-icon" />
+            </div>
+        }
+        @if (LoadingText is not null)
+        {
+            <div class="infinite-loading-text">@LoadingText</div>
+        }
+    </div>
+</div>
+
+@code {
+    /// <summary>Spinner name to show while loading.</summary>
+    [Parameter] public string? LoadingSpinner { get; set; }
+
+    /// <summary>Optional text to display while loading.</summary>
+    [Parameter] public string? LoadingText { get; set; }
+
+    private string _cssClass = "md ion-infinite-scroll-content infinite-scroll-content-md";
+
+    protected override void OnParametersSet()
+    {
+        _cssClass = $"{Mode} ion-infinite-scroll-content infinite-scroll-content-{Mode}";
+    }
+}

--- a/src/Miko.Ionic/Components/Refresher/IonRefresher.razor
+++ b/src/Miko.Ionic/Components/Refresher/IonRefresher.razor
@@ -1,0 +1,84 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<div class="@_cssClass">
+    @ChildContent
+</div>
+
+@code {
+    /// <summary>Minimum pull distance before a refresh becomes ready.</summary>
+    [Parameter] public int PullMin { get; set; } = 60;
+
+    /// <summary>Maximum pull distance before refresh starts automatically. Kept for API parity.</summary>
+    [Parameter] public int? PullMax { get; set; }
+
+    /// <summary>When true, the refresher is hidden and non-interactive.</summary>
+    [Parameter] public bool Disabled { get; set; }
+
+    /// <summary>Current refresher state. Supported values: inactive, pulling, ready, refreshing, cancelling, completing.</summary>
+    [Parameter] public string State { get; set; } = "inactive";
+
+    /// <summary>Raised when refresh starts. Call <see cref="Complete"/> when the async work is done.</summary>
+    [Parameter] public EventCallback OnRefresh { get; set; }
+
+    private string _cssClass = "md ion-refresher refresher-md";
+    private float _progress;
+    private string _state = "inactive";
+
+    protected override void OnParametersSet()
+    {
+        _state = NormalizeState(State);
+        BuildClass();
+    }
+
+    /// <summary>Programmatically enters refreshing state and emits <see cref="OnRefresh"/>.</summary>
+    public async Task BeginRefresh()
+    {
+        if (Disabled || _state == "refreshing") return;
+        _state = "refreshing";
+        _progress = 1f;
+        BuildClass();
+        await OnRefresh.InvokeAsync();
+    }
+
+    /// <summary>Completes the refresh and returns the refresher to inactive state.</summary>
+    public Task Complete()
+    {
+        _state = "inactive";
+        _progress = 0;
+        BuildClass();
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Cancels a pull gesture and returns the refresher to inactive state.</summary>
+    public Task Cancel()
+    {
+        _state = "inactive";
+        _progress = 0;
+        BuildClass();
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Returns the current pull progress.</summary>
+    public Task<float> GetProgress() => Task.FromResult(_progress);
+
+    private void BuildClass()
+    {
+        var cls = $"{Mode} ion-refresher refresher-{Mode}";
+        if (!Disabled && _state != "inactive") cls += " refresher-active";
+        if (Disabled) cls += " refresher-disabled";
+        if (_state != "inactive") cls += $" refresher-{_state}";
+        _cssClass = cls;
+    }
+
+    private static string NormalizeState(string? state) => state?.ToLowerInvariant() switch
+    {
+        "pulling" => "pulling",
+        "ready" => "ready",
+        "refreshing" => "refreshing",
+        "cancelling" => "cancelling",
+        "completing" => "completing",
+        _ => "inactive",
+    };
+}

--- a/src/Miko.Ionic/Components/Refresher/IonRefresherContent.razor
+++ b/src/Miko.Ionic/Components/Refresher/IonRefresherContent.razor
@@ -1,0 +1,51 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<div class="@_cssClass">
+    <div class="refresher-pulling">
+        @if (!string.IsNullOrEmpty(PullingIcon))
+        {
+            <div class="refresher-pulling-icon">
+                <IonIcon Icon="@PullingIcon" />
+            </div>
+        }
+        @if (PullingText is not null)
+        {
+            <div class="refresher-pulling-text">@PullingText</div>
+        }
+    </div>
+    <div class="refresher-refreshing">
+        @if (!string.IsNullOrEmpty(RefreshingSpinner))
+        {
+            <div class="refresher-refreshing-icon">
+                <IonSpinner Name="@RefreshingSpinner" />
+            </div>
+        }
+        @if (RefreshingText is not null)
+        {
+            <div class="refresher-refreshing-text">@RefreshingText</div>
+        }
+    </div>
+</div>
+
+@code {
+    /// <summary>Icon to show while pulling. Defaults to arrow-down (md) / refresh (ios).</summary>
+    [Parameter] public string? PullingIcon { get; set; }
+
+    /// <summary>Text to show while pulling.</summary>
+    [Parameter] public string? PullingText { get; set; }
+
+    /// <summary>Spinner name to show while refreshing.</summary>
+    [Parameter] public string? RefreshingSpinner { get; set; }
+
+    /// <summary>Text to show while refreshing.</summary>
+    [Parameter] public string? RefreshingText { get; set; }
+
+    private string _cssClass = "md ion-refresher-content";
+
+    protected override void OnParametersSet()
+    {
+        _cssClass = $"{Mode} ion-refresher-content";
+        PullingIcon ??= Mode == "ios" ? Ionicons.Refresh : Ionicons.ArrowDown;
+        RefreshingSpinner ??= Mode == "ios" ? "lines" : "circular";
+    }
+}

--- a/src/Miko.Ionic/Components/Refresher/RefresherStyles.cs
+++ b/src/Miko.Ionic/Components/Refresher/RefresherStyles.cs
@@ -1,0 +1,100 @@
+using Miko.Common;
+using Miko.Styling;
+
+namespace Miko.Ionic.Components;
+
+/// <summary>Styles for <c>ion-refresher</c> and <c>ion-refresher-content</c>.</summary>
+internal static class RefresherStyles
+{
+    internal static CssObject GenStyle(string mode, IonicTheme t)
+    {
+        return new CssObject
+        {
+            [$".ion-refresher.{mode}"] = new()
+            {
+                Display = Display.None,
+                Position = Position.Absolute,
+                Top = Length.Px(0),
+                Left = Length.Px(0),
+                Width = Length.Percent(100),
+                Height = Length.Px(t.RefresherHeight),
+                PointerEvents = PointerEvents.None,
+                ZIndex = 10,
+            },
+
+            [$".ion-refresher.{mode}.refresher-active"] = new()
+            {
+                Display = Display.Block,
+            },
+
+            [$".ion-refresher-content.{mode}"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                JustifyContent = JustifyContent.Center,
+                Height = Length.Percent(100),
+            },
+
+            [$".ion-refresher-content.{mode} .refresher-pulling"] = new()
+            {
+                Display = Display.None,
+                Width = Length.Percent(100),
+            },
+
+            [$".ion-refresher-content.{mode} .refresher-refreshing"] = new()
+            {
+                Display = Display.None,
+                Width = Length.Percent(100),
+            },
+
+            [$".ion-refresher.{mode}.refresher-pulling .refresher-pulling"] = new()
+            {
+                Display = Display.Block,
+            },
+
+            [$".ion-refresher.{mode}.refresher-ready .refresher-pulling"] = new()
+            {
+                Display = Display.Block,
+            },
+
+            [$".ion-refresher.{mode}.refresher-refreshing .refresher-refreshing"] = new()
+            {
+                Display = Display.Block,
+            },
+
+            [$".ion-refresher.{mode}.refresher-cancelling .refresher-pulling"] = new()
+            {
+                Display = Display.Block,
+            },
+
+            [$".ion-refresher.{mode}.refresher-completing .refresher-refreshing"] = new()
+            {
+                Display = Display.Block,
+            },
+
+            [$".ion-refresher-content.{mode} .refresher-pulling-icon"] = new()
+            {
+                FontSize = Length.Px(t.RefresherIconFontSize),
+                TextAlign = TextAlign.Center,
+            },
+
+            [$".ion-refresher-content.{mode} .refresher-refreshing-icon"] = new()
+            {
+                FontSize = Length.Px(t.RefresherIconFontSize),
+                TextAlign = TextAlign.Center,
+            },
+
+            [$".ion-refresher-content.{mode} .refresher-pulling-text"] = new()
+            {
+                FontSize = Length.Px(t.RefresherTextFontSize),
+                TextAlign = TextAlign.Center,
+            },
+
+            [$".ion-refresher-content.{mode} .refresher-refreshing-text"] = new()
+            {
+                FontSize = Length.Px(t.RefresherTextFontSize),
+                TextAlign = TextAlign.Center,
+            },
+        };
+    }
+}

--- a/src/Miko.Ionic/Components/Select/IonSelect.razor
+++ b/src/Miko.Ionic/Components/Select/IonSelect.razor
@@ -1,0 +1,185 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<div class="@_cssClass">
+    <label class="select-wrapper">
+        @if (HasLabel)
+        {
+            <div class="label-text-wrapper">
+                <div class="label-text">@Label</div>
+            </div>
+        }
+        <div class="select-wrapper-inner">
+            @StartSlot
+            <div class="native-wrapper">
+                <select class="select-native" @onchange="HandleChange">
+                    @ChildContent
+                </select>
+                <div class="@_textClass">@DisplayText</div>
+            </div>
+            @EndSlot
+            <IonIcon Icon="@_toggleIcon" Class="select-icon" />
+        </div>
+        @if (Mode == "md" && Fill != "outline")
+        {
+            <div class="select-highlight"></div>
+        }
+    </label>
+    @if (HasBottomContent)
+    {
+        <div class="select-bottom">
+            @if (!string.IsNullOrEmpty(HelperText))
+            {
+                <div class="helper-text">@HelperText</div>
+            }
+            @if (!string.IsNullOrEmpty(ErrorText))
+            {
+                <div class="error-text">@ErrorText</div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    /// <summary>Named palette color (Ionic <c>color</c>): <c>"primary"</c>, <c>"danger"</c>, ... .</summary>
+    [Parameter] public string? Color { get; set; }
+
+    /// <summary>The selected value.</summary>
+    [Parameter] public string? Value { get; set; }
+
+    /// <summary>Raised when the selected value changes.</summary>
+    [Parameter] public EventCallback<string?> ValueChanged { get; set; }
+
+    /// <summary>Raised when the selected value changes.</summary>
+    [Parameter] public EventCallback<ChangeEventArgs> OnChange { get; set; }
+
+    /// <summary>Placeholder text shown when no value is selected.</summary>
+    [Parameter] public string? Placeholder { get; set; }
+
+    /// <summary>Visible label text associated with the select.</summary>
+    [Parameter] public string? Label { get; set; }
+
+    /// <summary>Label placement marker: start, end, floating, stacked, or fixed.</summary>
+    [Parameter] public string LabelPlacement { get; set; } = "start";
+
+    /// <summary>Content shown at the start side of the select.</summary>
+    [Parameter] public RenderFragment? StartSlot { get; set; }
+
+    /// <summary>Content shown at the end side of the select.</summary>
+    [Parameter] public RenderFragment? EndSlot { get; set; }
+
+    /// <summary>Helper text displayed below the control.</summary>
+    [Parameter] public string? HelperText { get; set; }
+
+    /// <summary>Error text displayed below the control.</summary>
+    [Parameter] public string? ErrorText { get; set; }
+
+    /// <summary>When true, the user cannot interact with the select.</summary>
+    [Parameter] public bool Disabled { get; set; }
+
+    /// <summary>When true, the select can accept multiple values. The native renderer stores a single selected index today.</summary>
+    [Parameter] public bool Multiple { get; set; }
+
+    /// <summary>Form field name marker.</summary>
+    [Parameter] public string? Name { get; set; }
+
+    /// <summary>Fill marker: solid or outline.</summary>
+    [Parameter] public string? Fill { get; set; }
+
+    /// <summary>Shape marker. Use <c>"round"</c> for round corners.</summary>
+    [Parameter] public string? Shape { get; set; }
+
+    /// <summary>Justify marker: start, end, or space-between.</summary>
+    [Parameter] public string? Justify { get; set; }
+
+    /// <summary>Toggle icon when closed. Defaults to chevron-expand on iOS and caret-down-sharp on md.</summary>
+    [Parameter] public string? ToggleIcon { get; set; }
+
+    /// <summary>Optional selected text override.</summary>
+    [Parameter] public string? SelectedText { get; set; }
+
+    private string _cssClass = "md ion-select ion-focusable select-ltr select-label-placement-start";
+    private string _textClass = "select-text select-placeholder";
+    private string _toggleIcon = Ionicons.CaretDownSharp;
+    private string? _displayText;
+
+    private bool HasLabel => !string.IsNullOrEmpty(Label);
+    private bool HasBottomContent => !string.IsNullOrEmpty(HelperText) || !string.IsNullOrEmpty(ErrorText);
+    private bool HasValue => !string.IsNullOrEmpty(Value);
+    private string DisplayText =>
+        !string.IsNullOrEmpty(SelectedText) ? SelectedText :
+        !string.IsNullOrEmpty(_displayText) ? _displayText :
+        Placeholder ?? string.Empty;
+
+    protected override void OnParametersSet()
+    {
+        var labelPlacement = NormalizeToken(LabelPlacement, "start");
+        var cls = $"{Mode} ion-select ion-focusable select-ltr select-label-placement-{labelPlacement}";
+        if (Disabled) cls += " select-disabled";
+        if (HasValue || !string.IsNullOrEmpty(SelectedText)) cls += " has-value";
+        if (!string.IsNullOrEmpty(Placeholder)) cls += " has-placeholder";
+        if (!string.IsNullOrEmpty(Fill)) cls += $" select-fill-{Fill.ToLowerInvariant()}";
+        if (!string.IsNullOrEmpty(Shape)) cls += $" select-shape-{Shape.ToLowerInvariant()}";
+        if (!string.IsNullOrEmpty(Justify)) cls += $" select-justify-{Justify.ToLowerInvariant()}";
+        if (!string.IsNullOrWhiteSpace(Color))
+            cls += $" ion-color ion-color-{Color.ToLowerInvariant()}";
+        _cssClass = cls;
+
+        _textClass = HasValue || !string.IsNullOrEmpty(SelectedText)
+            ? "select-text"
+            : "select-text select-placeholder";
+
+        _toggleIcon = ToggleIcon ?? (Mode == "ios" ? Ionicons.ChevronExpand : Ionicons.CaretDownSharp);
+    }
+
+    public override Element Build()
+    {
+        var root = base.Build();
+        var select = root.FindByClass("select-native").FirstOrDefault() as SelectElement;
+        if (select is null) return root;
+
+        select.Multiple = Multiple;
+        if (Disabled) select.SetState(ElementState.Disabled);
+
+        if (Value is not null)
+            select.Value = Value;
+        else
+            select.SelectedIndex = -1;
+
+        _displayText = ResolveDisplayText(select);
+        if (!root.HasClass("has-value") && !string.IsNullOrEmpty(_displayText))
+            root.Class += " has-value";
+
+        if (root.FindByClass("select-text").FirstOrDefault() is { } text)
+        {
+            var display = DisplayText;
+            text.TextContent = display;
+            text.Class = string.IsNullOrEmpty(display) || (string.IsNullOrEmpty(_displayText) && !string.IsNullOrEmpty(Placeholder))
+                ? "select-text select-placeholder"
+                : "select-text";
+        }
+
+        return root;
+    }
+
+    private async Task HandleChange(ChangeEventArgs args)
+    {
+        var next = (args.Target as SelectElement)?.Value ?? args.NewValue;
+        if (Value != next)
+        {
+            Value = next;
+            await ValueChanged.InvokeAsync(next);
+        }
+
+        await OnChange.InvokeAsync(args);
+    }
+
+    private string ResolveDisplayText(SelectElement select)
+    {
+        if (!string.IsNullOrEmpty(SelectedText)) return SelectedText;
+        var option = select.GetSelectedOption();
+        return option?.TextContent ?? string.Empty;
+    }
+
+    private static string NormalizeToken(string? value, string fallback)
+        => string.IsNullOrWhiteSpace(value) ? fallback : value.ToLowerInvariant();
+}

--- a/src/Miko.Ionic/Components/Select/IonSelectOption.razor
+++ b/src/Miko.Ionic/Components/Select/IonSelectOption.razor
@@ -1,0 +1,37 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<option class="@_cssClass">
+    @ChildContent
+</option>
+
+@code {
+    /// <summary>Option value. If null, the option text is used by the native select element.</summary>
+    [Parameter] public string? Value { get; set; }
+
+    /// <summary>When true, the option cannot be selected.</summary>
+    [Parameter] public bool Disabled { get; set; }
+
+    /// <summary>When true, the option is selected when no parent value overrides it.</summary>
+    [Parameter] public bool Selected { get; set; }
+
+    private string _cssClass = "md ion-select-option";
+
+    protected override void OnParametersSet()
+    {
+        _cssClass = Disabled
+            ? $"{Mode} ion-select-option select-option-disabled"
+            : $"{Mode} ion-select-option";
+    }
+
+    public override Element Build()
+    {
+        var root = base.Build();
+        if (root is OptionElement option)
+        {
+            option.Value = Value;
+            option.Selected = Selected;
+            if (Disabled) option.SetState(ElementState.Disabled);
+        }
+        return root;
+    }
+}

--- a/src/Miko.Ionic/Components/Select/SelectStyles.cs
+++ b/src/Miko.Ionic/Components/Select/SelectStyles.cs
@@ -1,0 +1,201 @@
+using Miko.Common;
+using Miko.Styling;
+
+namespace Miko.Ionic.Components;
+
+/// <summary>Styles for <c>ion-select</c> and <c>ion-select-option</c>.</summary>
+internal static class SelectStyles
+{
+    internal static CssObject GenStyle(string mode, IonicTheme t)
+    {
+        var css = new CssObject
+        {
+            [$".ion-select.{mode}"] = new()
+            {
+                Display = Display.Block,
+                Position = Position.Relative,
+                Width = Length.Percent(100),
+                MinHeight = Length.Px(t.SelectMinHeight),
+                Color = t.SelectTextColor,
+                FontSize = Length.Px(t.SelectFontSize),
+            },
+
+            [$".ion-select.{mode}.select-disabled"] = new()
+            {
+                Opacity = 0.4f,
+                PointerEvents = PointerEvents.None,
+            },
+
+            [$".ion-select.{mode} .select-wrapper"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                Width = Length.Percent(100),
+                MinHeight = Length.Px(t.SelectMinHeight),
+                Cursor = Cursor.Pointer,
+            },
+
+            [$".ion-select.{mode} .select-wrapper-inner"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Row,
+                AlignItems = AlignItems.Center,
+                Width = Length.Percent(100),
+                MinHeight = Length.Px(t.SelectMinHeight),
+                PaddingTop = Length.Px(t.SelectPaddingTop),
+                PaddingRight = Length.Px(t.SelectPaddingEnd),
+                PaddingBottom = Length.Px(t.SelectPaddingBottom),
+                PaddingLeft = Length.Px(t.SelectPaddingStart),
+                BoxSizing = BoxSizing.BorderBox,
+            },
+
+            [$".ion-select.{mode} .label-text-wrapper"] = new()
+            {
+                Display = Display.Block,
+                Color = t.SelectLabelColor,
+                FontSize = Length.Px(12),
+                MarginBottom = Length.Px(2),
+            },
+
+            [$".ion-select.{mode} .native-wrapper"] = new()
+            {
+                Display = Display.Flex,
+                FlexGrow = 1,
+                FlexShrink = 1,
+                FlexBasis = Length.Percent(0),
+                Position = Position.Relative,
+                AlignItems = AlignItems.Center,
+                MinWidth = Length.Px(0),
+            },
+
+            [$".ion-select.{mode} .select-native"] = new()
+            {
+                Width = Length.Percent(100),
+                MinHeight = Length.Px(t.SelectMinHeight),
+                BackgroundColor = t.SelectBackground,
+                Color = t.SelectTextColor,
+                BorderWidth = Length.Px(0),
+                Opacity = 0f,
+                Position = Position.Absolute,
+                Left = Length.Px(0),
+                Right = Length.Px(0),
+                Top = Length.Px(0),
+                Bottom = Length.Px(0),
+                Cursor = Cursor.Pointer,
+                ZIndex = 1,
+            },
+
+            [$".ion-select.{mode} .select-text"] = new()
+            {
+                Color = t.SelectTextColor,
+                WhiteSpace = WhiteSpace.Nowrap,
+                Overflow = Overflow.Hidden,
+            },
+
+            [$".ion-select.{mode} .select-placeholder"] = new()
+            {
+                Color = t.SelectPlaceholderColor,
+            },
+
+            [$".ion-select.{mode} .select-icon"] = new()
+            {
+                Width = Length.Px(20),
+                Height = Length.Px(20),
+                MarginLeft = Length.Px(8),
+                FlexShrink = 0,
+            },
+
+            [$".ion-select.{mode} .select-highlight"] = new()
+            {
+                Height = Length.Px(2),
+                BackgroundColor = t.SelectHighlightColor,
+                Width = Length.Percent(100),
+            },
+
+            [$".ion-select.{mode}.select-fill-solid .select-wrapper-inner"] = new()
+            {
+                BackgroundColor = mode == "md" ? new Color(0, 0, 0, 10) : t.SelectBackground,
+                BorderRadius = new BorderRadius(Length.Px(t.SelectBorderRadius)),
+                PaddingLeft = Length.Px(12),
+                PaddingRight = Length.Px(12),
+            },
+
+            [$".ion-select.{mode}.select-fill-outline .select-wrapper-inner"] = new()
+            {
+                BorderWidth = Length.Px(1),
+                BorderStyle = BorderStyle.Solid,
+                BorderColor = t.SelectBorderColor,
+                BorderRadius = new BorderRadius(Length.Px(t.SelectBorderRadius)),
+                PaddingLeft = Length.Px(12),
+                PaddingRight = Length.Px(12),
+            },
+
+            [$".ion-select.{mode}.select-shape-round .select-wrapper-inner"] = new()
+            {
+                BorderRadius = new BorderRadius(Length.Px(t.SelectRoundBorderRadius)),
+            },
+
+            [$".ion-select.{mode} .select-bottom"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                PaddingTop = Length.Px(4),
+                FontSize = Length.Px(12),
+            },
+
+            [$".ion-select.{mode} .helper-text"] = new()
+            {
+                Color = t.SelectHelperColor,
+            },
+
+            [$".ion-select.{mode} .error-text"] = new()
+            {
+                Color = t.SelectErrorColor,
+            },
+
+            [$".ion-select-option.{mode}"] = new()
+            {
+                Display = Display.Block,
+                PaddingTop = Length.Px(8),
+                PaddingRight = Length.Px(12),
+                PaddingBottom = Length.Px(8),
+                PaddingLeft = Length.Px(12),
+                Color = t.SelectTextColor,
+            },
+
+            [$".ion-select-option.{mode}.select-option-disabled"] = new()
+            {
+                Opacity = 0.4f,
+                PointerEvents = PointerEvents.None,
+            },
+        };
+
+        AddColor(css, mode, "primary", t.Primary);
+        AddColor(css, mode, "secondary", t.Secondary);
+        AddColor(css, mode, "tertiary", t.Tertiary);
+        AddColor(css, mode, "success", t.Success);
+        AddColor(css, mode, "warning", t.Warning);
+        AddColor(css, mode, "danger", t.Danger);
+        AddColor(css, mode, "light", t.Light);
+        AddColor(css, mode, "medium", t.Medium);
+        AddColor(css, mode, "dark", t.Dark);
+
+        return css;
+    }
+
+    private static void AddColor(CssObject css, string mode, string name, Color color)
+    {
+        css[$".ion-select.{mode}.ion-color-{name}"] = new()
+        {
+            Color = color,
+        };
+        css[$".ion-select.{mode}.ion-color-{name} .select-highlight"] = new()
+        {
+            BackgroundColor = color,
+        };
+        css[$".ion-select.{mode}.ion-color-{name} .select-icon"] = new()
+        {
+            Color = color,
+        };
+    }
+}

--- a/src/Miko.Ionic/Components/Spinner/IonSpinner.razor
+++ b/src/Miko.Ionic/Components/Spinner/IonSpinner.razor
@@ -1,0 +1,140 @@
+@namespace Miko.Ionic.Components
+@inherits IonicComponentBase
+<div class="@_cssClass" Style="@_hostStyle">
+    @for (var i = 0; i < _segmentCount; i++)
+    {
+        <div class="@SegmentClass(i)" Style="@SegmentStyle(i)"></div>
+    }
+</div>
+
+@code {
+    private static readonly HashSet<string> ValidNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "bubbles",
+        "circles",
+        "circular",
+        "crescent",
+        "dots",
+        "lines",
+        "lines-small",
+        "lines-sharp",
+        "lines-sharp-small",
+    };
+
+    /// <summary>Named palette color (Ionic <c>color</c>): <c>"primary"</c>, <c>"danger"</c>, ... .</summary>
+    [Parameter] public string? Color { get; set; }
+
+    /// <summary>Animation duration in milliseconds. Defaults to Ionic's per-spinner timing.</summary>
+    [Parameter] public int? Duration { get; set; }
+
+    /// <summary>
+    /// Spinner preset name: <c>bubbles</c>, <c>circles</c>, <c>circular</c>, <c>crescent</c>,
+    /// <c>dots</c>, <c>lines</c>, <c>lines-small</c>, <c>lines-sharp</c>, or
+    /// <c>lines-sharp-small</c>.
+    /// </summary>
+    [Parameter] public string? Name { get; set; }
+
+    /// <summary>When true, stamps Ionic's paused state and pauses the generated animation style.</summary>
+    [Parameter] public bool Paused { get; set; }
+
+    /// <summary>Additional CSS classes to apply to the spinner root element.</summary>
+    [Parameter] public string? Class { get; set; }
+
+    private string _cssClass = "md ion-spinner spinner-circular";
+    private string _spinnerName = "circular";
+    private int _segmentCount = 1;
+    private Style? _hostStyle;
+
+    protected override void OnParametersSet()
+    {
+        _spinnerName = NormalizeName(Name);
+        _segmentCount = SegmentCount(_spinnerName);
+
+        var cls = $"{Mode} ion-spinner spinner-{_spinnerName}";
+        if (Paused) cls += " spinner-paused";
+        if (!string.IsNullOrWhiteSpace(Color)) cls += $" ion-color ion-color-{Color.ToLowerInvariant()}";
+        if (!string.IsNullOrWhiteSpace(Class)) cls += $" {Class}";
+        _cssClass = cls;
+
+        _hostStyle = BuildHostStyle();
+    }
+
+    private string NormalizeName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return Mode == "ios" ? "lines" : "circular";
+
+        var normalized = name.Trim().ToLowerInvariant();
+        return ValidNames.Contains(normalized) ? normalized : "lines";
+    }
+
+    private static int SegmentCount(string name) => name switch
+    {
+        "bubbles" => 9,
+        "circles" => 8,
+        "dots" => 3,
+        "lines-sharp" or "lines-sharp-small" => 12,
+        "lines" or "lines-small" => 8,
+        _ => 1,
+    };
+
+    private static bool IsLineSpinner(string name) =>
+        name is "lines" or "lines-small" or "lines-sharp" or "lines-sharp-small";
+
+    private string SegmentClass(int index)
+    {
+        var type = IsLineSpinner(_spinnerName) ? "spinner-line" : "spinner-circle";
+        return $"{type} {type}-{index + 1}";
+    }
+
+    private Style? BuildHostStyle()
+    {
+        var seconds = (Duration ?? DefaultDuration(_spinnerName)) / 1000f;
+        if (seconds <= 0) return null;
+
+        return new Style
+        {
+            Animations = new List<KeyframeAnimation>
+            {
+                new("ion-spinner-rotate", seconds,
+                    new Keyframe(0f, new Style { Transform = Transform.FromRotate(0) }),
+                    new Keyframe(1f, new Style { Transform = Transform.FromRotate(360) }))
+                {
+                    Infinite = true,
+                    TimingFunction = TimingFunction.Linear,
+                    PlayState = Paused ? AnimationPlayState.Paused : AnimationPlayState.Running,
+                },
+            },
+        };
+    }
+
+    private Style SegmentStyle(int index)
+    {
+        if (_spinnerName == "dots")
+        {
+            return new Style
+            {
+                Opacity = MathF.Max(0.4f, 1f - index * 0.2f),
+            };
+        }
+
+        var angle = 360f / _segmentCount * index;
+        return new Style
+        {
+            Transform = Transform.FromRotate(angle),
+            Opacity = MathF.Max(0.25f, 1f - index * 0.07f),
+        };
+    }
+
+    private static int DefaultDuration(string name) => name switch
+    {
+        "bubbles" => 1000,
+        "circles" => 1000,
+        "circular" => 1400,
+        "crescent" => 750,
+        "dots" => 750,
+        "lines" or "lines-small" => 1000,
+        "lines-sharp" or "lines-sharp-small" => 1200,
+        _ => 1000,
+    };
+}

--- a/src/Miko.Ionic/Components/Spinner/SpinnerStyles.cs
+++ b/src/Miko.Ionic/Components/Spinner/SpinnerStyles.cs
@@ -1,0 +1,193 @@
+using Miko.Animation;
+using Miko.Common;
+using Miko.Styling;
+
+namespace Miko.Ionic.Components;
+
+/// <summary>Styles for <c>ion-spinner</c>.</summary>
+internal static class SpinnerStyles
+{
+    internal static CssObject GenStyle(string mode, IonicTheme t)
+    {
+        var css = new CssObject
+        {
+            [$".ion-spinner.{mode}"] = new()
+            {
+                Display = Display.InlineBlock,
+                Position = Position.Relative,
+                Width = Length.Px(t.SpinnerSize),
+                Height = Length.Px(t.SpinnerSize),
+                Color = t.SpinnerColor,
+                VerticalAlign = VerticalAlign.Middle,
+                BoxSizing = BoxSizing.BorderBox,
+            },
+
+            [$".ion-spinner.{mode}.spinner-paused"] = new()
+            {
+                Opacity = 0.6f,
+            },
+
+            [$".ion-spinner.{mode}.spinner-lines-small"] = new()
+            {
+                Width = Length.Px(t.SpinnerSmallSize),
+                Height = Length.Px(t.SpinnerSmallSize),
+            },
+
+            [$".ion-spinner.{mode}.spinner-lines-sharp-small"] = new()
+            {
+                Width = Length.Px(t.SpinnerSmallSize),
+                Height = Length.Px(t.SpinnerSmallSize),
+            },
+
+            [$".ion-spinner.{mode} .spinner-line"] = new()
+            {
+                Position = Position.Absolute,
+                Top = Length.Px(2),
+                Left = Length.Percent(50),
+                Width = Length.Px(2),
+                Height = Length.Px(9),
+                MarginLeft = Length.Px(-1),
+                BackgroundColor = t.SpinnerColor,
+                BorderRadius = new BorderRadius(Length.Px(1)),
+                TransformOrigin = new TransformOrigin(Length.Percent(50), Length.Px(12)),
+            },
+
+            [$".ion-spinner.{mode}.spinner-lines-small .spinner-line"] = new()
+            {
+                Height = Length.Px(6),
+                TransformOrigin = new TransformOrigin(Length.Percent(50), Length.Px(8)),
+            },
+
+            [$".ion-spinner.{mode}.spinner-lines-sharp .spinner-line"] = new()
+            {
+                Width = Length.Px(2),
+                Height = Length.Px(8),
+                BorderRadius = BorderRadius.None,
+                TransformOrigin = new TransformOrigin(Length.Percent(50), Length.Px(12)),
+            },
+
+            [$".ion-spinner.{mode}.spinner-lines-sharp-small .spinner-line"] = new()
+            {
+                Width = Length.Px(2),
+                Height = Length.Px(6),
+                BorderRadius = BorderRadius.None,
+                TransformOrigin = new TransformOrigin(Length.Percent(50), Length.Px(8)),
+            },
+
+            [$".ion-spinner.{mode} .spinner-circle"] = new()
+            {
+                Position = Position.Absolute,
+                Top = Length.Percent(50),
+                Left = Length.Percent(50),
+                Width = Length.Px(6),
+                Height = Length.Px(6),
+                MarginTop = Length.Px(-3),
+                MarginLeft = Length.Px(-3),
+                BackgroundColor = t.SpinnerColor,
+                BorderRadius = BorderRadius.Circle,
+                TransformOrigin = new TransformOrigin(Length.Percent(50), Length.Px(11)),
+            },
+
+            [$".ion-spinner.{mode}.spinner-circular .spinner-circle"] = new()
+            {
+                Top = Length.Px(2),
+                Left = Length.Px(2),
+                Width = Length.Px(t.SpinnerSize - 4),
+                Height = Length.Px(t.SpinnerSize - 4),
+                MarginTop = Length.Px(0),
+                MarginLeft = Length.Px(0),
+                BackgroundColor = Color.Transparent,
+                BorderWidth = Length.Px(3),
+                BorderStyle = BorderStyle.Solid,
+                BorderColor = t.SpinnerTrackColor,
+                BorderTopColor = t.SpinnerColor,
+                BorderRadius = BorderRadius.Circle,
+            },
+
+            [$".ion-spinner.{mode}.spinner-crescent .spinner-circle"] = new()
+            {
+                Top = Length.Px(2),
+                Left = Length.Px(2),
+                Width = Length.Px(t.SpinnerSize - 4),
+                Height = Length.Px(t.SpinnerSize - 4),
+                MarginTop = Length.Px(0),
+                MarginLeft = Length.Px(0),
+                BackgroundColor = Color.Transparent,
+                BorderWidth = Length.Px(3),
+                BorderStyle = BorderStyle.Solid,
+                BorderColor = Color.Transparent,
+                BorderTopColor = t.SpinnerColor,
+                BorderRightColor = t.SpinnerColor,
+                BorderRadius = BorderRadius.Circle,
+            },
+
+            [$".ion-spinner.{mode}.spinner-dots .spinner-circle"] = new()
+            {
+                Position = Position.Relative,
+                Top = Length.Px(0),
+                Left = Length.Px(0),
+                Display = Display.InlineBlock,
+                Width = Length.Px(6),
+                Height = Length.Px(6),
+                MarginTop = Length.Px(11),
+                MarginRight = Length.Px(2),
+                MarginBottom = Length.Px(0),
+                MarginLeft = Length.Px(2),
+                Transform = Transform.None,
+            },
+
+            [$".ion-spinner.{mode}.spinner-bubbles .spinner-circle"] = new()
+            {
+                Width = Length.Px(5),
+                Height = Length.Px(5),
+                MarginTop = Length.Px(-2.5f),
+                MarginLeft = Length.Px(-2.5f),
+                TransformOrigin = new TransformOrigin(Length.Percent(50), Length.Px(11)),
+            },
+        };
+
+        AddColor(css, mode, "primary", t.Primary);
+        AddColor(css, mode, "secondary", t.Secondary);
+        AddColor(css, mode, "tertiary", t.Tertiary);
+        AddColor(css, mode, "success", t.Success);
+        AddColor(css, mode, "warning", t.Warning);
+        AddColor(css, mode, "danger", t.Danger);
+        AddColor(css, mode, "light", t.Light);
+        AddColor(css, mode, "medium", t.Medium);
+        AddColor(css, mode, "dark", t.Dark);
+
+        return css;
+    }
+
+    private static void AddColor(CssObject css, string mode, string name, Color color)
+    {
+        css[$".ion-spinner.{mode}.ion-color-{name}"] = new()
+        {
+            Color = color,
+        };
+
+        css[$".ion-spinner.{mode}.ion-color-{name} .spinner-line"] = new()
+        {
+            BackgroundColor = color,
+        };
+
+        css[$".ion-spinner.{mode}.ion-color-{name} .spinner-circle"] = new()
+        {
+            BackgroundColor = color,
+        };
+
+        css[$".ion-spinner.{mode}.ion-color-{name}.spinner-circular .spinner-circle"] = new()
+        {
+            BackgroundColor = Color.Transparent,
+            BorderColor = new Color(color.R, color.G, color.B, 51),
+            BorderTopColor = color,
+        };
+
+        css[$".ion-spinner.{mode}.ion-color-{name}.spinner-crescent .spinner-circle"] = new()
+        {
+            BackgroundColor = Color.Transparent,
+            BorderTopColor = color,
+            BorderRightColor = color,
+        };
+    }
+}

--- a/src/Miko.Ionic/IonicStyleSheetFactory.cs
+++ b/src/Miko.Ionic/IonicStyleSheetFactory.cs
@@ -66,5 +66,13 @@ public static class IonicStyleSheetFactory
         sheet.Add(FooterStyles.GenStyle(mode, t));
         sheet.Add(SlidesStyles.GenStyle(mode, t));
         sheet.Add(AvatarStyles.GenStyle(mode, t));
+        sheet.Add(SpinnerStyles.GenStyle(mode, t));
+        sheet.Add(BadgeStyles.GenStyle(mode, t));
+        sheet.Add(ChipStyles.GenStyle(mode, t));
+        sheet.Add(CardStyles.GenStyle(mode, t));
+        sheet.Add(GridStyles.GenStyle(mode, t));
+        sheet.Add(InfiniteScrollStyles.GenStyle(mode, t));
+        sheet.Add(RefresherStyles.GenStyle(mode, t));
+        sheet.Add(SelectStyles.GenStyle(mode, t));
     }
 }

--- a/src/Miko.Ionic/IonicTheme.cs
+++ b/src/Miko.Ionic/IonicTheme.cs
@@ -230,6 +230,74 @@ public class IonicTheme
     /// <summary>Avatar host width/height (md 64px, ios 48px).</summary>
     public float AvatarSize { get; set; } = 64f;
 
+    // Spinner / badge / chip / card / grid / refresher / infinite-scroll / select.
+    public Color SpinnerColor { get; set; }
+    public Color SpinnerTrackColor { get; set; }
+    public float SpinnerSize { get; set; } = 28f;
+    public float SpinnerSmallSize { get; set; } = 16f;
+
+    public Color BadgeBackground { get; set; }
+    public Color BadgeColor { get; set; }
+    public float BadgeBorderRadius { get; set; } = 4f;
+    public float BadgeFontSize { get; set; } = 13f;
+    public float BadgePaddingTop { get; set; } = 3f;
+    public float BadgePaddingEnd { get; set; } = 4f;
+    public float BadgePaddingBottom { get; set; } = 4f;
+    public float BadgePaddingStart { get; set; } = 4f;
+    public float BadgeMinWidth { get; set; } = 10f;
+
+    public Color ChipBackground { get; set; }
+    public Color ChipColor { get; set; }
+    public Color ChipBorderColor { get; set; }
+    public float ChipFontSize { get; set; } = 14f;
+
+    public Color CardBackground { get; set; }
+    public Color CardColor { get; set; }
+    public float CardMarginTop { get; set; } = 10f;
+    public float CardMarginEnd { get; set; } = 10f;
+    public float CardMarginBottom { get; set; } = 10f;
+    public float CardMarginStart { get; set; } = 10f;
+    public float CardBorderRadius { get; set; } = 4f;
+    public float CardFontSize { get; set; } = 14f;
+    public Length CardLineHeight { get; set; } = Length.Number(1.5f);
+    public List<BoxShadow> CardBoxShadow { get; set; } = new();
+    public float CardHeaderPaddingTop { get; set; } = 16f;
+    public float CardHeaderPaddingEnd { get; set; } = 16f;
+    public float CardHeaderPaddingBottom { get; set; } = 16f;
+    public float CardHeaderPaddingStart { get; set; } = 16f;
+    public float CardContentPaddingTop { get; set; } = 13f;
+    public float CardContentPaddingEnd { get; set; } = 16f;
+    public float CardContentPaddingBottom { get; set; } = 13f;
+    public float CardContentPaddingStart { get; set; } = 16f;
+    public float CardContentFontSize { get; set; } = 14f;
+    public Length CardContentLineHeight { get; set; } = Length.Number(1.5f);
+
+    public float GridPadding { get; set; } = 5f;
+    public float GridColumnPadding { get; set; } = 5f;
+    public float GridFixedWidth { get; set; } = 1140f;
+
+    public float InfiniteScrollContentMinHeight { get; set; } = 84f;
+    public float RefresherHeight { get; set; } = 60f;
+    public float RefresherIconFontSize { get; set; } = 30f;
+    public float RefresherTextFontSize { get; set; } = 16f;
+
+    public Color SelectTextColor { get; set; }
+    public Color SelectPlaceholderColor { get; set; }
+    public Color SelectLabelColor { get; set; }
+    public Color SelectBackground { get; set; }
+    public Color SelectBorderColor { get; set; }
+    public Color SelectHighlightColor { get; set; }
+    public Color SelectHelperColor { get; set; }
+    public Color SelectErrorColor { get; set; }
+    public float SelectFontSize { get; set; } = 16f;
+    public float SelectMinHeight { get; set; } = 48f;
+    public float SelectPaddingTop { get; set; } = 8f;
+    public float SelectPaddingEnd { get; set; } = 0f;
+    public float SelectPaddingBottom { get; set; } = 8f;
+    public float SelectPaddingStart { get; set; } = 0f;
+    public float SelectBorderRadius { get; set; } = 4f;
+    public float SelectRoundBorderRadius { get; set; } = 999f;
+
     // Brand palette shared by both modes (ionic.theme.default.scss).
     private static void ApplyBrandColors(IonicTheme t)
     {
@@ -425,6 +493,75 @@ public class IonicTheme
         // Avatar (avatar.md.vars.scss): 64px square.
         t.AvatarSize = 64f;
 
+        t.SpinnerColor = t.Primary;
+        t.SpinnerTrackColor = new Color(t.Primary.R, t.Primary.G, t.Primary.B, 51);
+        t.SpinnerSize = 28f;
+        t.SpinnerSmallSize = 16f;
+
+        t.BadgeBackground = t.Primary;
+        t.BadgeColor = Color.FromHex("ffffff");
+        t.BadgeBorderRadius = 4f;
+        t.BadgeFontSize = 13f;
+        t.BadgePaddingTop = 3f;
+        t.BadgePaddingEnd = 4f;
+        t.BadgePaddingBottom = 4f;
+        t.BadgePaddingStart = 4f;
+
+        t.ChipBackground = new Color(0, 0, 0, 31);
+        t.ChipColor = new Color(0, 0, 0, 222);
+        t.ChipBorderColor = new Color(0, 0, 0, 82);
+        t.ChipFontSize = 14f;
+
+        t.CardBackground = Color.FromHex("ffffff");
+        t.CardColor = Color.FromHex("000000");
+        t.CardMarginTop = 10f;
+        t.CardMarginEnd = 10f;
+        t.CardMarginBottom = 10f;
+        t.CardMarginStart = 10f;
+        t.CardBorderRadius = 4f;
+        t.CardFontSize = 14f;
+        t.CardLineHeight = Length.Number(1.5f);
+        t.CardBoxShadow = new List<BoxShadow>
+        {
+            new BoxShadow(0, 3, 1, -2, new Color(0, 0, 0, 51)),
+            new BoxShadow(0, 2, 2, 0, new Color(0, 0, 0, 36)),
+            new BoxShadow(0, 1, 5, 0, new Color(0, 0, 0, 31)),
+        };
+        t.CardHeaderPaddingTop = 16f;
+        t.CardHeaderPaddingEnd = 16f;
+        t.CardHeaderPaddingBottom = 16f;
+        t.CardHeaderPaddingStart = 16f;
+        t.CardContentPaddingTop = 13f;
+        t.CardContentPaddingEnd = 16f;
+        t.CardContentPaddingBottom = 13f;
+        t.CardContentPaddingStart = 16f;
+        t.CardContentFontSize = 14f;
+        t.CardContentLineHeight = Length.Number(1.5f);
+
+        t.GridPadding = 5f;
+        t.GridColumnPadding = 5f;
+        t.GridFixedWidth = 1140f;
+
+        t.InfiniteScrollContentMinHeight = 84f;
+        t.RefresherHeight = 60f;
+        t.RefresherIconFontSize = 30f;
+        t.RefresherTextFontSize = 16f;
+
+        t.SelectTextColor = Color.FromHex("000000");
+        t.SelectPlaceholderColor = Color.FromHex("666666");
+        t.SelectLabelColor = Color.FromHex("666666");
+        t.SelectBackground = Color.Transparent;
+        t.SelectBorderColor = new Color(0, 0, 0, 61);
+        t.SelectHighlightColor = t.Primary;
+        t.SelectHelperColor = Color.FromHex("666666");
+        t.SelectErrorColor = t.Danger;
+        t.SelectFontSize = 16f;
+        t.SelectMinHeight = 48f;
+        t.SelectPaddingTop = 8f;
+        t.SelectPaddingBottom = 8f;
+        t.SelectBorderRadius = 4f;
+        t.SelectRoundBorderRadius = 999f;
+
         return t;
     }
 
@@ -585,6 +722,73 @@ public class IonicTheme
 
         // Avatar (avatar.ios.vars.scss): 48px square.
         t.AvatarSize = 48f;
+
+        t.SpinnerColor = t.Primary;
+        t.SpinnerTrackColor = new Color(t.Primary.R, t.Primary.G, t.Primary.B, 51);
+        t.SpinnerSize = 28f;
+        t.SpinnerSmallSize = 16f;
+
+        t.BadgeBackground = t.Primary;
+        t.BadgeColor = Color.FromHex("ffffff");
+        t.BadgeBorderRadius = 10f;
+        t.BadgeFontSize = 13f;
+        t.BadgePaddingTop = 3f;
+        t.BadgePaddingEnd = 8f;
+        t.BadgePaddingBottom = 3f;
+        t.BadgePaddingStart = 8f;
+
+        t.ChipBackground = new Color(0, 0, 0, 31);
+        t.ChipColor = new Color(0, 0, 0, 222);
+        t.ChipBorderColor = new Color(0, 0, 0, 82);
+        t.ChipFontSize = 14f;
+
+        t.CardBackground = Color.FromHex("ffffff");
+        t.CardColor = Color.FromHex("000000");
+        t.CardMarginTop = 24f;
+        t.CardMarginEnd = 16f;
+        t.CardMarginBottom = 24f;
+        t.CardMarginStart = 16f;
+        t.CardBorderRadius = 8f;
+        t.CardFontSize = 14f;
+        t.CardLineHeight = Length.Number(1.4f);
+        t.CardBoxShadow = new List<BoxShadow>
+        {
+            new BoxShadow(0, 4, 16, 0, new Color(0, 0, 0, 31)),
+        };
+        t.CardHeaderPaddingTop = 20f;
+        t.CardHeaderPaddingEnd = 20f;
+        t.CardHeaderPaddingBottom = 16f;
+        t.CardHeaderPaddingStart = 20f;
+        t.CardContentPaddingTop = 20f;
+        t.CardContentPaddingEnd = 20f;
+        t.CardContentPaddingBottom = 20f;
+        t.CardContentPaddingStart = 20f;
+        t.CardContentFontSize = 16f;
+        t.CardContentLineHeight = Length.Number(1.4f);
+
+        t.GridPadding = 5f;
+        t.GridColumnPadding = 5f;
+        t.GridFixedWidth = 1140f;
+
+        t.InfiniteScrollContentMinHeight = 84f;
+        t.RefresherHeight = 60f;
+        t.RefresherIconFontSize = 30f;
+        t.RefresherTextFontSize = 16f;
+
+        t.SelectTextColor = Color.FromHex("000000");
+        t.SelectPlaceholderColor = Color.FromHex("666666");
+        t.SelectLabelColor = Color.FromHex("666666");
+        t.SelectBackground = Color.Transparent;
+        t.SelectBorderColor = new Color(0, 0, 0, 51);
+        t.SelectHighlightColor = t.Primary;
+        t.SelectHelperColor = Color.FromHex("666666");
+        t.SelectErrorColor = t.Danger;
+        t.SelectFontSize = 17f;
+        t.SelectMinHeight = 44f;
+        t.SelectPaddingTop = 8f;
+        t.SelectPaddingBottom = 8f;
+        t.SelectBorderRadius = 10f;
+        t.SelectRoundBorderRadius = 999f;
 
         return t;
     }

--- a/tests/Miko.Ionic.Tests/Components/IonBadgeTests.cs
+++ b/tests/Miko.Ionic.Tests/Components/IonBadgeTests.cs
@@ -1,0 +1,83 @@
+using Miko.Common;
+using Miko.Components;
+using Miko.Ionic.Components;
+using Shouldly;
+
+namespace Miko.Ionic.Tests.Components;
+
+public class IonBadgeTests : IonicComponentTestBase
+{
+    private static RenderFragment Text(string value) => builder => builder.AddContent(0, value);
+
+    [Fact]
+    public void IonBadge_RendersDefaultDom()
+    {
+        var cut = Context.Render<IonBadge>(p => p.AddChildContent(Text("7")));
+
+        cut.Root.TagName.ShouldBe("span");
+        cut.Root.Class.ShouldBe("md ion-badge");
+        cut.GetTextContent().ShouldBe("7");
+    }
+
+    [Fact]
+    public void IonBadge_UsesIosClass_OnIosPlatform()
+    {
+        UsePlatform(Miko.Platform.HostPlatform.Ios);
+
+        var cut = Context.Render<IonBadge>(p => p.AddChildContent(Text("1")));
+
+        cut.Root.Class.ShouldBe("ios ion-badge");
+    }
+
+    [Fact]
+    public void IonBadge_StampsColorClass()
+    {
+        var cut = Context.Render<IonBadge>(p =>
+        {
+            p.Add(nameof(IonBadge.Color), "danger");
+            p.AddChildContent(Text("!"));
+        });
+
+        cut.Root.Class.ShouldBe("md ion-badge ion-color ion-color-danger");
+    }
+
+    [Fact]
+    public void IonBadge_DefaultStyle_UsesPrimaryFill()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonBadge>(p => p.AddChildContent(Text("3")));
+        var style = cut.GetComputedStyle(cut.Root)!;
+
+        style.Display.ShouldBe(Display.InlineBlock);
+        style.BackgroundColor.ShouldBe(Color.FromHex("0054e9"));
+        style.Color.ShouldBe(Color.White);
+        style.BorderTopLeftRadius.Value.ShouldBe(4f);
+    }
+
+    [Fact]
+    public void IonBadge_IosStyle_UsesRounderRadius()
+    {
+        UsePlatform(Miko.Platform.HostPlatform.Ios);
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonBadge>(p => p.AddChildContent(Text("3")));
+        var style = cut.GetComputedStyle(cut.Root)!;
+
+        style.BorderTopLeftRadius.Value.ShouldBe(10f);
+    }
+
+    [Fact]
+    public void IonBadge_DangerColor_UsesDangerFill()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonBadge>(p =>
+        {
+            p.Add(nameof(IonBadge.Color), "danger");
+            p.AddChildContent(Text("!"));
+        });
+
+        cut.GetComputedStyle(cut.Root)!.BackgroundColor.ShouldBe(Color.FromHex("c5000f"));
+    }
+}

--- a/tests/Miko.Ionic.Tests/Components/IonCardTests.cs
+++ b/tests/Miko.Ionic.Tests/Components/IonCardTests.cs
@@ -1,0 +1,150 @@
+using Miko.Common;
+using Miko.Components;
+using Miko.Core.DomElements;
+using Miko.Events;
+using Miko.Ionic.Components;
+using Shouldly;
+
+namespace Miko.Ionic.Tests.Components;
+
+public class IonCardTests : IonicComponentTestBase
+{
+    private static readonly RenderFragment Body = builder => builder.AddContent(0, "Card body");
+    private static RenderFragment Text(string value) => builder => builder.AddContent(0, value);
+
+    [Fact]
+    public void IonCard_RendersPlainCardDom()
+    {
+        var cut = Context.Render<IonCard>(p => p.Add(nameof(IonCard.ChildContent), Body));
+
+        cut.Root.TagName.ShouldBe("div");
+        cut.Root.Class.ShouldBe("md ion-card");
+        cut.GetTextContent().ShouldContain("Card body");
+    }
+
+    [Fact]
+    public void IonCard_RendersButtonNative_WhenButton()
+    {
+        var cut = Context.Render<IonCard>(p =>
+        {
+            p.Add(nameof(IonCard.Button), true);
+            p.Add(nameof(IonCard.ChildContent), Body);
+        });
+
+        cut.Root.Class.ShouldContain("ion-activatable");
+        cut.Root.Children[0].TagName.ShouldBe("button");
+        cut.Root.Children[0].Class.ShouldBe("card-native");
+    }
+
+    [Fact]
+    public void IonCard_RendersAnchorNative_WhenHref()
+    {
+        var cut = Context.Render<IonCard>(p =>
+        {
+            p.Add(nameof(IonCard.Href), "/details");
+            p.Add(nameof(IonCard.Target), "_blank");
+            p.Add(nameof(IonCard.ChildContent), Body);
+        });
+
+        var anchor = cut.Root.Children[0].ShouldBeOfType<AnchorElement>();
+        anchor.Class.ShouldBe("card-native");
+        anchor.Href.ShouldBe("/details");
+        anchor.Target.ShouldBe("_blank");
+    }
+
+    [Fact]
+    public void IonCard_InvokesOnClick_WhenClickable()
+    {
+        var clicked = false;
+        var cut = Context.Render<IonCard>(p =>
+        {
+            p.Add(nameof(IonCard.Button), true);
+            p.Add(nameof(IonCard.OnClick), EventCallback.Factory.Create(this, () => clicked = true));
+        });
+
+        cut.Root.Children[0].OnClick!.Invoke(new MouseEventArgs { Target = cut.Root.Children[0] });
+
+        clicked.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IonCard_DoesNotInvokeOnClick_WhenDisabled()
+    {
+        var clicked = false;
+        var cut = Context.Render<IonCard>(p =>
+        {
+            p.Add(nameof(IonCard.Button), true);
+            p.Add(nameof(IonCard.Disabled), true);
+            p.Add(nameof(IonCard.OnClick), EventCallback.Factory.Create(this, () => clicked = true));
+        });
+
+        cut.Root.Children[0].OnClick!.Invoke(new MouseEventArgs { Target = cut.Root.Children[0] });
+
+        clicked.ShouldBeFalse();
+        cut.Root.Class.ShouldContain("card-disabled");
+    }
+
+    [Fact]
+    public void IonCard_DefaultStyle_UsesMdCardSurface()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonCard>();
+        var style = cut.GetComputedStyle(cut.Root)!;
+
+        style.MarginTop.ShouldBe(Length.Px(10));
+        style.BorderTopLeftRadius.Value.ShouldBe(4f);
+        style.BoxShadow.ShouldNotBeNull();
+        style.BoxShadow!.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void IonCard_IosStyle_UsesLargerMarginAndRadius()
+    {
+        UsePlatform(Miko.Platform.HostPlatform.Ios);
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonCard>();
+        var style = cut.GetComputedStyle(cut.Root)!;
+
+        style.MarginTop.ShouldBe(Length.Px(24));
+        style.BorderTopLeftRadius.Value.ShouldBe(8f);
+    }
+
+    [Fact]
+    public void IonCardHeader_RendersAndStyles()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonCardHeader>(p => p.AddChildContent(Text("Header")));
+
+        cut.Root.Class.ShouldBe("md ion-card-header ion-inherit-color");
+        cut.GetComputedStyle(cut.Root)!.PaddingTop.ShouldBe(Length.Px(16));
+    }
+
+    [Fact]
+    public void IonCardHeader_StampsTranslucentAndColor()
+    {
+        var cut = Context.Render<IonCardHeader>(p =>
+        {
+            p.Add(nameof(IonCardHeader.Translucent), true);
+            p.Add(nameof(IonCardHeader.Color), "primary");
+        });
+
+        cut.Root.Class.ShouldContain("card-header-translucent");
+        cut.Root.Class.ShouldContain("ion-color-primary");
+    }
+
+    [Fact]
+    public void IonCardContent_RendersModeSpecificClassAndPadding()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonCardContent>(p => p.AddChildContent(Text("Content")));
+        var style = cut.GetComputedStyle(cut.Root)!;
+
+        cut.Root.Class.ShouldBe("md ion-card-content card-content-md");
+        style.PaddingTop.ShouldBe(Length.Px(13));
+        style.PaddingLeft.ShouldBe(Length.Px(16));
+    }
+}

--- a/tests/Miko.Ionic.Tests/Components/IonChipTests.cs
+++ b/tests/Miko.Ionic.Tests/Components/IonChipTests.cs
@@ -1,0 +1,82 @@
+using Miko.Common;
+using Miko.Components;
+using Miko.Ionic.Components;
+using Shouldly;
+
+namespace Miko.Ionic.Tests.Components;
+
+public class IonChipTests : IonicComponentTestBase
+{
+    private static readonly RenderFragment Label = builder => builder.AddContent(0, "Active");
+
+    [Fact]
+    public void IonChip_RendersDefaultDom()
+    {
+        var cut = Context.Render<IonChip>(p => p.Add(nameof(IonChip.ChildContent), Label));
+
+        cut.Root.TagName.ShouldBe("div");
+        cut.Root.Class.ShouldBe("md ion-chip ion-activatable");
+        cut.GetTextContent().ShouldContain("Active");
+    }
+
+    [Fact]
+    public void IonChip_UsesIosClass_OnIosPlatform()
+    {
+        UsePlatform(Miko.Platform.HostPlatform.Ios);
+
+        var cut = Context.Render<IonChip>();
+
+        cut.Root.Class.ShouldStartWith("ios ion-chip");
+    }
+
+    [Fact]
+    public void IonChip_StampsStateAndColorClasses()
+    {
+        var cut = Context.Render<IonChip>(p =>
+        {
+            p.Add(nameof(IonChip.Outline), true);
+            p.Add(nameof(IonChip.Disabled), true);
+            p.Add(nameof(IonChip.Color), "success");
+        });
+
+        cut.Root.Class.ShouldContain("chip-outline");
+        cut.Root.Class.ShouldContain("chip-disabled");
+        cut.Root.Class.ShouldContain("ion-color-success");
+    }
+
+    [Fact]
+    public void IonChip_DefaultStyle_IsInlinePill()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonChip>();
+        var style = cut.GetComputedStyle(cut.Root)!;
+
+        style.Display.ShouldBe(Display.InlineBlock);
+        style.MinHeight.ShouldBe(Length.Px(32));
+        style.BorderTopLeftRadius.Value.ShouldBe(16f);
+    }
+
+    [Fact]
+    public void IonChip_OutlineStyle_UsesBorderAndTransparentFill()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonChip>(p => p.Add(nameof(IonChip.Outline), true));
+        var style = cut.GetComputedStyle(cut.Root)!;
+
+        style.BackgroundColor.ShouldBe(Color.Transparent);
+        style.BorderTopWidth.ShouldBe(Length.Px(1));
+        style.BorderTopStyle.ShouldBe(BorderStyle.Solid);
+    }
+
+    [Fact]
+    public void IonChip_DisabledStyle_IsDimmed()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonChip>(p => p.Add(nameof(IonChip.Disabled), true));
+
+        cut.GetComputedStyle(cut.Root)!.Opacity.ShouldBe(0.4f);
+    }
+}

--- a/tests/Miko.Ionic.Tests/Components/IonGridTests.cs
+++ b/tests/Miko.Ionic.Tests/Components/IonGridTests.cs
@@ -1,0 +1,98 @@
+using Miko.Common;
+using Miko.Components;
+using Miko.Ionic.Components;
+using Shouldly;
+
+namespace Miko.Ionic.Tests.Components;
+
+public class IonGridTests : IonicComponentTestBase
+{
+    private static RenderFragment Text(string value) => builder => builder.AddContent(0, value);
+
+    [Fact]
+    public void IonGrid_RendersDomAndChildRows()
+    {
+        var cut = Context.Render<IonGrid>(p => p.AddChildContent(builder =>
+        {
+            builder.OpenComponent<IonRow>(0);
+            builder.CloseComponent();
+        }));
+
+        cut.Root.TagName.ShouldBe("div");
+        cut.Root.Class.ShouldBe("md ion-grid");
+        cut.FindByClass("ion-row").ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void IonGrid_StampsFixedClass()
+    {
+        var cut = Context.Render<IonGrid>(p => p.Add(nameof(IonGrid.Fixed), true));
+
+        cut.Root.Class.ShouldBe("md ion-grid grid-fixed");
+    }
+
+    [Fact]
+    public void IonRow_RendersFlexRowClass()
+    {
+        var cut = Context.Render<IonRow>();
+
+        cut.Root.TagName.ShouldBe("div");
+        cut.Root.Class.ShouldBe("md ion-row");
+    }
+
+    [Fact]
+    public void IonCol_RendersDefaultClass()
+    {
+        var cut = Context.Render<IonCol>(p => p.AddChildContent(Text("A")));
+
+        cut.Root.TagName.ShouldBe("div");
+        cut.Root.Class.ShouldBe("md ion-col");
+        cut.GetTextContent().ShouldBe("A");
+    }
+
+    [Fact]
+    public void IonCol_SizeAppliesInlineFlexBasis()
+    {
+        var cut = Context.Render<IonCol>(p => p.Add(nameof(IonCol.Size), "6"));
+
+        cut.Root.Style.ShouldNotBeNull();
+        cut.Root.Style!.FlexGrow.ShouldBe(0f);
+        cut.Root.Style.FlexBasis.ShouldBe(Length.Percent(50));
+        cut.Root.Style.Width.ShouldBe(Length.Percent(50));
+        cut.Root.Style.MaxWidth.ShouldBe(Length.Percent(50));
+    }
+
+    [Fact]
+    public void IonCol_OffsetPushPullApplyInlinePosition()
+    {
+        var cut = Context.Render<IonCol>(p =>
+        {
+            p.Add(nameof(IonCol.Offset), "3");
+            p.Add(nameof(IonCol.Push), "2");
+            p.Add(nameof(IonCol.Pull), "1");
+        });
+
+        cut.Root.Style!.MarginLeft.ShouldBe(Length.Percent(25));
+        cut.Root.Style.Left.ShouldBe(Length.Percent(16.666668f));
+        cut.Root.Style.Right.ShouldBe(Length.Percent(8.333334f));
+    }
+
+    [Fact]
+    public void GridStyles_ApplyLayoutRules()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var grid = Context.Render<IonGrid>(p => p.Add(nameof(IonGrid.Fixed), true));
+        var gridStyle = grid.GetComputedStyle(grid.Root)!;
+
+        gridStyle.Display.ShouldBe(Display.Block);
+        gridStyle.PaddingTop.ShouldBe(Length.Px(5));
+        gridStyle.MaxWidth.ShouldBe(Length.Px(1140));
+
+        var row = Context.Render<IonRow>();
+        row.GetComputedStyle(row.Root)!.FlexWrap.ShouldBe(FlexWrap.Wrap);
+
+        var col = Context.Render<IonCol>();
+        col.GetComputedStyle(col.Root)!.FlexGrow.ShouldBe(1f);
+    }
+}

--- a/tests/Miko.Ionic.Tests/Components/IonInfiniteScrollTests.cs
+++ b/tests/Miko.Ionic.Tests/Components/IonInfiniteScrollTests.cs
@@ -1,0 +1,108 @@
+using Miko.Common;
+using Miko.Components;
+using Miko.Events;
+using Miko.Ionic.Components;
+using Shouldly;
+
+namespace Miko.Ionic.Tests.Components;
+
+public class IonInfiniteScrollTests : IonicComponentTestBase
+{
+    [Fact]
+    public void IonInfiniteScroll_RendersEnabledDom()
+    {
+        var cut = Context.Render<IonInfiniteScroll>();
+
+        cut.Root.TagName.ShouldBe("div");
+        cut.Root.Class.ShouldBe("md ion-infinite-scroll infinite-scroll-enabled");
+    }
+
+    [Fact]
+    public void IonInfiniteScroll_DisabledOmitsEnabledClass()
+    {
+        var cut = Context.Render<IonInfiniteScroll>(p => p.Add(nameof(IonInfiniteScroll.Disabled), true));
+
+        cut.Root.Class.ShouldBe("md ion-infinite-scroll");
+    }
+
+    [Fact]
+    public void IonInfiniteScroll_LoadingStampsClass()
+    {
+        var cut = Context.Render<IonInfiniteScroll>(p => p.Add(nameof(IonInfiniteScroll.Loading), true));
+
+        cut.Root.Class.ShouldContain("infinite-scroll-loading");
+    }
+
+    [Fact]
+    public void IonInfiniteScroll_TopPositionStampsClass()
+    {
+        var cut = Context.Render<IonInfiniteScroll>(p => p.Add(nameof(IonInfiniteScroll.Position), "top"));
+
+        cut.Root.Class.ShouldContain("infinite-scroll-top");
+    }
+
+    [Fact]
+    public void IonInfiniteScroll_InvokesOnInfinite_WhenThresholdCrossed()
+    {
+        var invoked = false;
+        var cut = Context.Render<IonInfiniteScroll>(p =>
+        {
+            p.Add(nameof(IonInfiniteScroll.Threshold), "10px");
+            p.Add(nameof(IonInfiniteScroll.OnInfinite), EventCallback.Factory.Create(this, () => invoked = true));
+        });
+
+        cut.Root.OnScroll!.Invoke(new ScrollEventArgs { Target = cut.Root, DeltaY = 12, ScrollTop = 12 });
+
+        invoked.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IonInfiniteScroll_DoesNotInvoke_WhenDisabled()
+    {
+        var invoked = false;
+        var cut = Context.Render<IonInfiniteScroll>(p =>
+        {
+            p.Add(nameof(IonInfiniteScroll.Disabled), true);
+            p.Add(nameof(IonInfiniteScroll.OnInfinite), EventCallback.Factory.Create(this, () => invoked = true));
+        });
+
+        cut.Root.OnScroll!.Invoke(new ScrollEventArgs { Target = cut.Root, DeltaY = 100, ScrollTop = 100 });
+
+        invoked.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IonInfiniteScrollContent_RendersLoadingDom()
+    {
+        var cut = Context.Render<IonInfiniteScrollContent>(p =>
+        {
+            p.Add(nameof(IonInfiniteScrollContent.LoadingSpinner), "crescent");
+            p.Add(nameof(IonInfiniteScrollContent.LoadingText), "Loading more");
+        });
+
+        cut.Root.Class.ShouldBe("md ion-infinite-scroll-content infinite-scroll-content-md");
+        cut.FindByClass("infinite-loading").ShouldHaveSingleItem();
+        cut.FindByClass("infinite-loading-spinner").ShouldHaveSingleItem();
+        cut.GetTextContent().ShouldContain("Loading more");
+    }
+
+    [Fact]
+    public void InfiniteScrollStyles_LoadingStateShowsLoading()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonInfiniteScroll>(p =>
+        {
+            p.Add(nameof(IonInfiniteScroll.Loading), true);
+            p.AddChildContent(builder =>
+            {
+                builder.OpenComponent<IonInfiniteScrollContent>(0);
+                builder.AddComponentParameter(1, nameof(IonInfiniteScrollContent.LoadingText), "Loading");
+                builder.CloseComponent();
+            });
+        });
+
+        var loading = cut.FindByClass("infinite-loading").Single();
+        cut.GetComputedStyle(loading)!.Display.ShouldBe(Display.Block);
+    }
+}

--- a/tests/Miko.Ionic.Tests/Components/IonRefresherTests.cs
+++ b/tests/Miko.Ionic.Tests/Components/IonRefresherTests.cs
@@ -1,0 +1,114 @@
+using Miko.Common;
+using Miko.Components;
+using Miko.Ionic.Components;
+using Shouldly;
+
+namespace Miko.Ionic.Tests.Components;
+
+public class IonRefresherTests : IonicComponentTestBase
+{
+    [Fact]
+    public void IonRefresher_RendersInactiveDom()
+    {
+        var cut = Context.Render<IonRefresher>();
+
+        cut.Root.TagName.ShouldBe("div");
+        cut.Root.Class.ShouldBe("md ion-refresher refresher-md");
+    }
+
+    [Theory]
+    [InlineData("pulling", "refresher-active refresher-pulling")]
+    [InlineData("ready", "refresher-active refresher-ready")]
+    [InlineData("refreshing", "refresher-active refresher-refreshing")]
+    [InlineData("cancelling", "refresher-active refresher-cancelling")]
+    [InlineData("completing", "refresher-active refresher-completing")]
+    public void IonRefresher_StampsStateClasses(string state, string expectedClasses)
+    {
+        var cut = Context.Render<IonRefresher>(p => p.Add(nameof(IonRefresher.State), state));
+
+        foreach (var cls in expectedClasses.Split(' '))
+            cut.Root.Class.ShouldContain(cls);
+    }
+
+    [Fact]
+    public void IonRefresher_DisabledStampsClassAndNoActive()
+    {
+        var cut = Context.Render<IonRefresher>(p =>
+        {
+            p.Add(nameof(IonRefresher.Disabled), true);
+            p.Add(nameof(IonRefresher.State), "refreshing");
+        });
+
+        cut.Root.Class.ShouldContain("refresher-disabled");
+        cut.Root.Class.ShouldNotContain("refresher-active");
+    }
+
+    [Fact]
+    public void IonRefresherContent_RendersPullingAndRefreshingBlocks()
+    {
+        var cut = Context.Render<IonRefresherContent>(p =>
+        {
+            p.Add(nameof(IonRefresherContent.PullingText), "Pull");
+            p.Add(nameof(IonRefresherContent.RefreshingText), "Refresh");
+        });
+
+        cut.Root.Class.ShouldBe("md ion-refresher-content");
+        cut.FindByClass("refresher-pulling").ShouldHaveSingleItem();
+        cut.FindByClass("refresher-refreshing").ShouldHaveSingleItem();
+        cut.GetTextContent().ShouldContain("Pull");
+        cut.GetTextContent().ShouldContain("Refresh");
+    }
+
+    [Fact]
+    public void IonRefresherContent_UsesIosClass()
+    {
+        UsePlatform(Miko.Platform.HostPlatform.Ios);
+
+        var cut = Context.Render<IonRefresherContent>();
+
+        cut.Root.Class.ShouldBe("ios ion-refresher-content");
+    }
+
+    [Fact]
+    public void RefresherStyles_ShowPullingContent_WhenPulling()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonRefresher>(p =>
+        {
+            p.Add(nameof(IonRefresher.State), "pulling");
+            p.AddChildContent(builder =>
+            {
+                builder.OpenComponent<IonRefresherContent>(0);
+                builder.AddComponentParameter(1, nameof(IonRefresherContent.PullingText), "Pull");
+                builder.CloseComponent();
+            });
+        });
+
+        cut.GetComputedStyle(cut.Root)!.Display.ShouldBe(Display.Block);
+        var pulling = cut.FindByClass("refresher-pulling")
+            .Single(e => e.Class == "refresher-pulling");
+        cut.GetComputedStyle(pulling)!.Display.ShouldBe(Display.Block);
+    }
+
+    [Fact]
+    public void RefresherStyles_ShowRefreshingContent_WhenRefreshing()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonRefresher>(p =>
+        {
+            p.Add(nameof(IonRefresher.State), "refreshing");
+            p.AddChildContent(builder =>
+            {
+                builder.OpenComponent<IonRefresherContent>(0);
+                builder.AddComponentParameter(1, nameof(IonRefresherContent.RefreshingText), "Refresh");
+                builder.CloseComponent();
+            });
+        });
+
+        var refreshing = cut.FindByClass("refresher-refreshing")
+            .Single(e => e.Class == "refresher-refreshing");
+        cut.GetComputedStyle(refreshing)!.Display.ShouldBe(Display.Block);
+    }
+}

--- a/tests/Miko.Ionic.Tests/Components/IonSelectTests.cs
+++ b/tests/Miko.Ionic.Tests/Components/IonSelectTests.cs
@@ -1,0 +1,220 @@
+using Miko.Common;
+using Miko.Components;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Events;
+using Miko.Ionic.Components;
+using Miko.Testing;
+using Shouldly;
+
+namespace Miko.Ionic.Tests.Components;
+
+public class IonSelectTests : IonicComponentTestBase
+{
+    private static RenderFragment Text(string value) => builder => builder.AddContent(0, value);
+
+    private static RenderFragment Options => builder =>
+    {
+        builder.OpenComponent<IonSelectOption>(0);
+        builder.AddComponentParameter(1, nameof(IonSelectOption.Value), "a");
+        builder.AddComponentParameter(2, nameof(IonSelectOption.ChildContent), Text("Alpha"));
+        builder.CloseComponent();
+
+        builder.OpenComponent<IonSelectOption>(3);
+        builder.AddComponentParameter(4, nameof(IonSelectOption.Value), "b");
+        builder.AddComponentParameter(5, nameof(IonSelectOption.ChildContent), Text("Beta"));
+        builder.CloseComponent();
+    };
+
+    private static ComponentUnderTest RenderSelect(TestContext ctx,
+        Action<ComponentParameterBuilder<IonSelect>>? configure = null)
+        => ctx.Render<IonSelect>(p =>
+        {
+            p.Add(nameof(IonSelect.ChildContent), Options);
+            configure?.Invoke(p);
+        });
+
+    [Fact]
+    public void IonSelect_RendersDomContract()
+    {
+        var cut = RenderSelect(Context, p => p.Add(nameof(IonSelect.Placeholder), "Pick one"));
+
+        cut.Root.TagName.ShouldBe("div");
+        cut.Root.Class.ShouldContain("md ion-select");
+
+        var wrapper = cut.FindByClass("select-wrapper").Single();
+        wrapper.TagName.ShouldBe("label");
+
+        var select = cut.FindByClass("select-native").Single();
+        select.TagName.ShouldBe("select");
+        select.ShouldBeOfType<SelectElement>();
+
+        cut.FindByClass("select-icon").ShouldHaveSingleItem();
+        cut.GetTextContent().ShouldContain("Pick one");
+    }
+
+    [Fact]
+    public void IonSelect_UsesIosClass_OnIosPlatform()
+    {
+        UsePlatform(Miko.Platform.HostPlatform.Ios);
+
+        var cut = RenderSelect(Context);
+
+        cut.Root.Class.ShouldStartWith("ios ion-select");
+    }
+
+    [Fact]
+    public void IonSelect_StampsLabelFillShapeJustifyAndColorClasses()
+    {
+        var cut = RenderSelect(Context, p =>
+        {
+            p.Add(nameof(IonSelect.Label), "Status");
+            p.Add(nameof(IonSelect.Fill), "outline");
+            p.Add(nameof(IonSelect.Shape), "round");
+            p.Add(nameof(IonSelect.Justify), "space-between");
+            p.Add(nameof(IonSelect.Color), "danger");
+        });
+
+        cut.Root.Class.ShouldContain("select-label-placement-start");
+        cut.Root.Class.ShouldContain("select-fill-outline");
+        cut.Root.Class.ShouldContain("select-shape-round");
+        cut.Root.Class.ShouldContain("select-justify-space-between");
+        cut.Root.Class.ShouldContain("ion-color-danger");
+        cut.GetTextContent().ShouldContain("Status");
+    }
+
+    [Fact]
+    public void IonSelect_ValueSelectsNativeOptionAndDisplaysText()
+    {
+        var cut = RenderSelect(Context, p => p.Add(nameof(IonSelect.Value), "b"));
+
+        var select = cut.FindByClass("select-native").Single().ShouldBeOfType<SelectElement>();
+        select.Value.ShouldBe("b");
+        select.SelectedIndex.ShouldBe(1);
+        cut.Root.Class.ShouldContain("has-value");
+        cut.FindByClass("select-text").Single().TextContent.ShouldBe("Beta");
+    }
+
+    [Fact]
+    public void IonSelect_SelectedTextOverridesOptionText()
+    {
+        var cut = RenderSelect(Context, p =>
+        {
+            p.Add(nameof(IonSelect.Value), "b");
+            p.Add(nameof(IonSelect.SelectedText), "Custom Beta");
+        });
+
+        cut.FindByClass("select-text").Single().TextContent.ShouldBe("Custom Beta");
+    }
+
+    [Fact]
+    public void IonSelect_DisabledStampsClassAndNativeState()
+    {
+        var cut = RenderSelect(Context, p => p.Add(nameof(IonSelect.Disabled), true));
+
+        cut.Root.Class.ShouldContain("select-disabled");
+        cut.FindByClass("select-native").Single().IsDisabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IonSelect_RendersStartAndEndSlots()
+    {
+        var cut = RenderSelect(Context, p =>
+        {
+            p.Add(nameof(IonSelect.StartSlot), (RenderFragment)(builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddAttribute(1, "class", "start-slot");
+                builder.CloseElement();
+            }));
+            p.Add(nameof(IonSelect.EndSlot), (RenderFragment)(builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddAttribute(1, "class", "end-slot");
+                builder.CloseElement();
+            }));
+        });
+
+        cut.FindByClass("start-slot").ShouldHaveSingleItem();
+        cut.FindByClass("end-slot").ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void IonSelectOption_RendersNativeOptionAndSyncsState()
+    {
+        var cut = Context.Render<IonSelectOption>(p =>
+        {
+            p.Add(nameof(IonSelectOption.Value), "x");
+            p.Add(nameof(IonSelectOption.Selected), true);
+            p.Add(nameof(IonSelectOption.Disabled), true);
+            p.AddChildContent(Text("Option X"));
+        });
+
+        var option = cut.Root.ShouldBeOfType<OptionElement>();
+        option.TagName.ShouldBe("option");
+        option.Class.ShouldContain("ion-select-option");
+        option.Value.ShouldBe("x");
+        option.Selected.ShouldBeTrue();
+        option.IsDisabled.ShouldBeTrue();
+        option.TextContent.ShouldBe("Option X");
+    }
+
+    [Fact]
+    public void IonSelect_ValueChangedAndOnChange_AreInvokedFromNativeChange()
+    {
+        string? changedValue = null;
+        ChangeEventArgs? receivedArgs = null;
+        var cut = RenderSelect(Context, p =>
+        {
+            p.Add(nameof(IonSelect.ValueChanged),
+                EventCallback.Factory.Create<string?>(this, v => changedValue = v));
+            p.Add(nameof(IonSelect.OnChange),
+                EventCallback.Factory.Create<ChangeEventArgs>(this, e => receivedArgs = e));
+        });
+
+        var select = cut.FindByClass("select-native").Single().ShouldBeOfType<SelectElement>();
+        select.SelectedIndex = 1;
+        select.OnChange!.Invoke(new ChangeEventArgs { Target = select, NewValue = "b" });
+
+        changedValue.ShouldBe("b");
+        receivedArgs.ShouldNotBeNull();
+        receivedArgs.Target.ShouldBe(select);
+    }
+
+    [Fact]
+    public void IonSelect_Style_DefaultUsesBlockAndMinHeight()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = RenderSelect(Context);
+        var style = cut.GetComputedStyle(cut.Root)!;
+
+        style.Display.ShouldBe(Display.Block);
+        style.MinHeight.ShouldBe(Length.Px(48));
+    }
+
+    [Fact]
+    public void IonSelect_OutlineStyle_UsesBorder()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = RenderSelect(Context, p => p.Add(nameof(IonSelect.Fill), "outline"));
+        var inner = cut.FindByClass("select-wrapper-inner").Single();
+        var style = cut.GetComputedStyle(inner)!;
+
+        style.BorderTopWidth.ShouldBe(Length.Px(1));
+        style.BorderTopStyle.ShouldBe(BorderStyle.Solid);
+        style.BorderTopLeftRadius.Value.ShouldBe(4f);
+    }
+
+    [Fact]
+    public void IonSelect_IosStyle_UsesIosMinHeight()
+    {
+        UsePlatform(Miko.Platform.HostPlatform.Ios);
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = RenderSelect(Context);
+
+        cut.GetComputedStyle(cut.Root)!.MinHeight.ShouldBe(Length.Px(44));
+    }
+}

--- a/tests/Miko.Ionic.Tests/Components/IonSpinnerTests.cs
+++ b/tests/Miko.Ionic.Tests/Components/IonSpinnerTests.cs
@@ -1,0 +1,117 @@
+using Miko.Animation;
+using Miko.Common;
+using Miko.Ionic.Components;
+using Shouldly;
+
+namespace Miko.Ionic.Tests.Components;
+
+public class IonSpinnerTests : IonicComponentTestBase
+{
+    [Fact]
+    public void IonSpinner_DefaultMd_UsesCircular()
+    {
+        var cut = Context.Render<IonSpinner>();
+
+        cut.Root.TagName.ShouldBe("div");
+        cut.Root.Class.ShouldBe("md ion-spinner spinner-circular");
+        cut.FindByClass("spinner-circle").Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void IonSpinner_DefaultIos_UsesLines()
+    {
+        UsePlatform(Miko.Platform.HostPlatform.Ios);
+
+        var cut = Context.Render<IonSpinner>();
+
+        cut.Root.Class.ShouldBe("ios ion-spinner spinner-lines");
+        cut.FindByClass("spinner-line").Count.ShouldBe(8);
+    }
+
+    [Fact]
+    public void IonSpinner_Dots_RendersThreeCircles()
+    {
+        var cut = Context.Render<IonSpinner>(p => p.Add(nameof(IonSpinner.Name), "dots"));
+
+        cut.Root.Class.ShouldBe("md ion-spinner spinner-dots");
+        cut.FindByClass("spinner-circle").Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void IonSpinner_LinesSharp_RendersTwelveLines()
+    {
+        var cut = Context.Render<IonSpinner>(p => p.Add(nameof(IonSpinner.Name), "lines-sharp"));
+
+        cut.Root.Class.ShouldBe("md ion-spinner spinner-lines-sharp");
+        cut.FindByClass("spinner-line").Count.ShouldBe(12);
+    }
+
+    [Fact]
+    public void IonSpinner_UnknownName_FallsBackToLines()
+    {
+        var cut = Context.Render<IonSpinner>(p => p.Add(nameof(IonSpinner.Name), "unknown"));
+
+        cut.Root.Class.ShouldBe("md ion-spinner spinner-lines");
+        cut.FindByClass("spinner-line").Count.ShouldBe(8);
+    }
+
+    [Fact]
+    public void IonSpinner_StampsColorPausedAndCustomClasses()
+    {
+        var cut = Context.Render<IonSpinner>(p =>
+        {
+            p.Add(nameof(IonSpinner.Color), "danger");
+            p.Add(nameof(IonSpinner.Paused), true);
+            p.Add(nameof(IonSpinner.Class), "my-spinner");
+        });
+
+        cut.Root.Class.ShouldBe("md ion-spinner spinner-circular spinner-paused ion-color ion-color-danger my-spinner");
+    }
+
+    [Fact]
+    public void IonSpinner_Duration_MapsToHostAnimation()
+    {
+        var cut = Context.Render<IonSpinner>(p => p.Add(nameof(IonSpinner.Duration), 2500));
+
+        var animation = cut.Root.Style!.Animations.ShouldHaveSingleItem();
+        animation.Name.ShouldBe("ion-spinner-rotate");
+        animation.Duration.ShouldBe(2.5f);
+        animation.Infinite.ShouldBeTrue();
+        animation.TimingFunction.ShouldBe(TimingFunction.Linear);
+        animation.PlayState.ShouldBe(AnimationPlayState.Running);
+    }
+
+    [Fact]
+    public void IonSpinner_Paused_PausesHostAnimation()
+    {
+        var cut = Context.Render<IonSpinner>(p => p.Add(nameof(IonSpinner.Paused), true));
+
+        cut.Root.Style!.Animations.ShouldHaveSingleItem().PlayState.ShouldBe(AnimationPlayState.Paused);
+    }
+
+    [Fact]
+    public void IonSpinner_DefaultStyle_UsesSpinnerBox()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonSpinner>();
+        var style = cut.GetComputedStyle(cut.Root)!;
+
+        style.Display.ShouldBe(Display.InlineBlock);
+        style.Position.ShouldBe(Position.Relative);
+        style.Width.ShouldBe(Length.Px(28));
+        style.Height.ShouldBe(Length.Px(28));
+        style.Color.ShouldBe(Color.FromHex("0054e9"));
+    }
+
+    [Fact]
+    public void IonSpinner_DangerColor_UsesDangerColor()
+    {
+        Context.AddStyleSheet(IonicStyleSheetFactory.CreateAllModes());
+
+        var cut = Context.Render<IonSpinner>(p => p.Add(nameof(IonSpinner.Color), "danger"));
+
+        cut.GetComputedStyle(cut.Root)!.Color.ShouldBe(Color.FromHex("c5000f"));
+        cut.GetComputedStyle(cut.FindByClass("spinner-circle").Single())!.BorderTopColor.ShouldBe(Color.FromHex("c5000f"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Ionic ports for badge, card, chip, grid, infinite scroll, refresher, select, and spinner components
- register component styles and theme tokens for both md and ios modes
- add focused component tests for the new ports

## Tests
- dotnet test tests/Miko.Ionic.Tests/Miko.Ionic.Tests.csproj --no-restore
- dotnet test miko.slnx --no-restore