### PR TITLE
feat(dom): ISSUE-086 first-class TextNode — fully fix mixed text/element ordering

### DIFF
--- a/examples/Ionic/IonicComponents/GlobalStyles.cs
+++ b/examples/Ionic/IonicComponents/GlobalStyles.cs
@@ -20,12 +20,16 @@ internal class GlobalStyles
             [".sidebar"] = new()
             {
                 Width = Length.Px(200),
+                FlexShrink = 0,
                 Height = Length.Percent(100),
                 Padding = new Padding(16),
                 BackgroundColor = Color.FromRgb(52, 58, 64),
                 Color = Color.White
             },
-            [".title"] = new() { Color = Color.White },
+            [".title"] = new()
+            {
+                Color = Color.White
+            },
             [".main-content"] = new()
             {
                 FlexGrow = 1,

--- a/examples/Windows/MikoAppBlank/MikoAppBlank.csproj
+++ b/examples/Windows/MikoAppBlank/MikoAppBlank.csproj
@@ -19,10 +19,28 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Miko" Version="0.0.12" />
-    <PackageReference Include="Miko.Windowing" Version="0.0.12" />
-    <PackageReference Include="Miko.DevTools" Version="0.0.12" />
-    <PackageReference Include="Miko.Razor.Compiler" Version="0.0.12" />
+    <ProjectReference Include="..\..\..\src\Miko\Miko.csproj" />
+    <ProjectReference Include="..\..\..\src\Miko.DevTools\Miko.DevTools.csproj" />
+    <ProjectReference Include="..\..\..\src\Miko.Ionic\Miko.Ionic.csproj" />
+    <ProjectReference Include="..\..\..\src\Miko.Windowing\Miko.Windowing.csproj" />
   </ItemGroup>
+
+  <Target Name="_OverrideRazorSourceGenerator" AfterTargets="_PrepareRazorSourceGenerators">
+    <PropertyGroup>
+      <_CustomRazorGeneratorDir>
+        $(MSBuildThisFileDirectory)..\..\..\src\Miko.Razor.Compiler\bin\$(Configuration)\net9.0\</_CustomRazorGeneratorDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <Analyzer Remove="@(_RazorAnalyzer)" />
+      <_RazorAnalyzer Remove="@(_RazorAnalyzer)" />
+    </ItemGroup>
+    <ItemGroup>
+      <_RazorAnalyzer Include="$(_CustomRazorGeneratorDir)Microsoft.CodeAnalysis.Razor.Compiler.dll" />
+      <_RazorAnalyzer
+        Include="$(_CustomRazorGeneratorDir)Microsoft.AspNetCore.Razor.Utilities.Shared.dll" />
+      <_RazorAnalyzer Include="$(_CustomRazorGeneratorDir)Microsoft.Extensions.ObjectPool.dll" />
+      <Analyzer Include="@(_RazorAnalyzer)" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/examples/Windows/MikoAppSidemenu/MikoAppSidemenu.csproj
+++ b/examples/Windows/MikoAppSidemenu/MikoAppSidemenu.csproj
@@ -19,11 +19,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Miko" Version="0.0.12" />
-    <PackageReference Include="Miko.Windowing" Version="0.0.12" />
-    <PackageReference Include="Miko.DevTools" Version="0.0.12" />
-    <PackageReference Include="Miko.Razor.Compiler" Version="0.0.12" />
-    <PackageReference Include="Miko.Ionic" Version="0.0.12" />
+    <ProjectReference Include="..\..\..\src\Miko\Miko.csproj" />
+    <ProjectReference Include="..\..\..\src\Miko.DevTools\Miko.DevTools.csproj" />
+    <ProjectReference Include="..\..\..\src\Miko.Ionic\Miko.Ionic.csproj" />
+    <ProjectReference Include="..\..\..\src\Miko.Windowing\Miko.Windowing.csproj" />
   </ItemGroup>
 
+  <Target Name="_OverrideRazorSourceGenerator" AfterTargets="_PrepareRazorSourceGenerators">
+    <PropertyGroup>
+      <_CustomRazorGeneratorDir>
+        $(MSBuildThisFileDirectory)..\..\..\src\Miko.Razor.Compiler\bin\$(Configuration)\net9.0\</_CustomRazorGeneratorDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <Analyzer Remove="@(_RazorAnalyzer)" />
+      <_RazorAnalyzer Remove="@(_RazorAnalyzer)" />
+    </ItemGroup>
+    <ItemGroup>
+      <_RazorAnalyzer Include="$(_CustomRazorGeneratorDir)Microsoft.CodeAnalysis.Razor.Compiler.dll" />
+      <_RazorAnalyzer
+        Include="$(_CustomRazorGeneratorDir)Microsoft.AspNetCore.Razor.Utilities.Shared.dll" />
+      <_RazorAnalyzer Include="$(_CustomRazorGeneratorDir)Microsoft.Extensions.ObjectPool.dll" />
+      <Analyzer Include="@(_RazorAnalyzer)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/examples/Windows/MikoAppTabs/MikoAppTabs.csproj
+++ b/examples/Windows/MikoAppTabs/MikoAppTabs.csproj
@@ -26,4 +26,28 @@
     <PackageReference Include="Miko.Ionic" Version="0.0.12" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Miko\Miko.csproj" />
+    <ProjectReference Include="..\..\..\src\Miko.DevTools\Miko.DevTools.csproj" />
+    <ProjectReference Include="..\..\..\src\Miko.Ionic\Miko.Ionic.csproj" />
+    <ProjectReference Include="..\..\..\src\Miko.Windowing\Miko.Windowing.csproj" />
+  </ItemGroup>
+
+  <Target Name="_OverrideRazorSourceGenerator" AfterTargets="_PrepareRazorSourceGenerators">
+    <PropertyGroup>
+      <_CustomRazorGeneratorDir>
+        $(MSBuildThisFileDirectory)..\..\..\src\Miko.Razor.Compiler\bin\$(Configuration)\net9.0\</_CustomRazorGeneratorDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <Analyzer Remove="@(_RazorAnalyzer)" />
+      <_RazorAnalyzer Remove="@(_RazorAnalyzer)" />
+    </ItemGroup>
+    <ItemGroup>
+      <_RazorAnalyzer Include="$(_CustomRazorGeneratorDir)Microsoft.CodeAnalysis.Razor.Compiler.dll" />
+      <_RazorAnalyzer
+        Include="$(_CustomRazorGeneratorDir)Microsoft.AspNetCore.Razor.Utilities.Shared.dll" />
+      <_RazorAnalyzer Include="$(_CustomRazorGeneratorDir)Microsoft.Extensions.ObjectPool.dll" />
+      <Analyzer Include="@(_RazorAnalyzer)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Miko.DevTools/Panels/DomTreeBuilder.cs
+++ b/src/Miko.DevTools/Panels/DomTreeBuilder.cs
@@ -38,7 +38,9 @@ internal static class DomTreeBuilder
             PaddingLeft = Length.Px(depth * 16 + 4)
         };
 
-        bool hasChildren = element.Children.Count > 0;
+        // 文本以 TextNode 子节点承载（见 ISSUE-086），但 DevTools 已通过 element.TextContent 预览
+        // 单独显示文本，故树的「子元素」仅统计非文本节点，避免文本被重复渲染为 <#text> 行。
+        bool hasChildren = element.Children.Any(c => c is not Core.DomElements.TextNode);
         bool isCollapsed = _collapsedElements.Contains(element);
 
         var line = new DivElement { Style = new Styling.Style { Display = Display.Flex, FlexDirection = FlexDirection.Row } };
@@ -131,6 +133,8 @@ internal static class DomTreeBuilder
 
             foreach (var child in element.Children)
             {
+                // 文本节点已通过上方 TextContent 预览显示，不再作为独立树节点渲染。
+                if (child is Core.DomElements.TextNode) continue;
                 BuildTreeNode(parent, child, bridge, depth + 1);
             }
 

--- a/src/Miko.Testing/ComponentUnderTest.cs
+++ b/src/Miko.Testing/ComponentUnderTest.cs
@@ -133,7 +133,14 @@ public class ComponentUnderTest
 
     private string GetTextContentRecursive(Element element)
     {
-        var text = element.TextContent ?? "";
+        // 自 ISSUE-086 起，文本以 TextNode 子节点承载。仅在遍历到 TextNode 叶子时取其文本，
+        // 避免同时读取父元素 TextContent（facade 会聚合子 TextNode）与递归子节点造成重复计数。
+        if (element is Miko.Core.DomElements.TextNode textNode)
+        {
+            return textNode.Text;
+        }
+
+        var text = "";
         foreach (var child in element.Children)
         {
             text += GetTextContentRecursive(child);

--- a/src/Miko/Common/Enums.cs
+++ b/src/Miko/Common/Enums.cs
@@ -116,7 +116,9 @@ public enum LayoutType
     Anonymous,
     Table,
     TableRow,
-    TableCell
+    TableCell,
+    // 匿名文本节点（TextNode）：仅测量文本外接矩形写入 Content，无 padding/border/margin。
+    Text
 }
 
 /// <summary>

--- a/src/Miko/Components/RenderTreeBuilder.cs
+++ b/src/Miko/Components/RenderTreeBuilder.cs
@@ -202,10 +202,18 @@ public class RenderTreeBuilder
         if (string.IsNullOrEmpty(str)) return;
         var decoded = WebUtility.HtmlDecode(str);
         var element = _stack.Peek();
-        // Razor emits one AddContent call per content fragment (literal text and
-        // expressions). Append so consecutive fragments concatenate instead of
-        // overwriting each other (e.g. "Clicked " + _count + " times").
-        element.TextContent = element.TextContent is null ? decoded : element.TextContent + decoded;
+        // 文本以有序 TextNode 子节点形式追加，保留与已打开的子元素的交错顺序（见 ISSUE-086）。
+        // Razor 会为每段内容（字面文本与表达式）发射一次 AddContent。相邻的纯文本片段合并到
+        // 同一末尾 TextNode（如 "Clicked " + _count + " times" 拼接为一段），但被子元素分隔的
+        // 文本会形成各自独立的 TextNode，从而正确表达 text1 <span/> text3。
+        if (element.Children.Count > 0 && element.Children[^1] is TextNode lastText)
+        {
+            lastText.Text += decoded;
+        }
+        else
+        {
+            element.AddChild(new TextNode(decoded));
+        }
     }
 
     public void AddMarkupContent(int seq, string? markup)
@@ -284,8 +292,9 @@ public class RenderTreeBuilder
             if (m.Groups["text"].Success)
             {
                 var text = m.Groups["text"].Value.Trim();
+                // 文本以有序 TextNode 追加，保留与标签的交错顺序（见 ISSUE-086）。
                 if (text.Length > 0 && localStack.Count > 0)
-                    localStack.Peek().TextContent = text;
+                    localStack.Peek().AddChild(new TextNode(text));
                 continue;
             }
 

--- a/src/Miko/Core/DomElements/TextNode.cs
+++ b/src/Miko/Core/DomElements/TextNode.cs
@@ -1,0 +1,50 @@
+namespace Miko.Core.DomElements;
+
+/// <summary>
+/// 匿名文本节点（对应 DOM 的 Text 节点，非用户直接书写的标签）。
+///
+/// 历史上 Miko 把元素的直接文本存放在 <see cref="Element.TextContent"/> 单一字符串中，
+/// 与 <see cref="Element.Children"/>（标签）互不感知顺序，因此无法表达
+/// <c>text1 &lt;span/&gt; text3</c> 这样的文本-标签交错结构（见 ISSUE-086）。
+///
+/// 现在文本被提升为一等有序节点：<see cref="Miko.Components.RenderTreeBuilder"/> 把每段
+/// 直接文本包装为一个 <see cref="TextNode"/> 追加进父元素的 <c>Children</c>，交错顺序由
+/// 子节点列表天然表达。<see cref="Element.TextContent"/> 退化为便利外观（facade）：
+/// 读取时拼接所有子 <see cref="TextNode"/> 文本，写入时重建单个前置文本节点。
+///
+/// 文本样式（字体、颜色、对齐、行高等）通过样式继承从父元素获得（Miko 无 CSS
+/// <c>inherit</c> 关键字，但 <see cref="Styling.StyleResolver"/> 会把父元素的可继承
+/// 计算值填入本节点），因此 <see cref="TextNode"/> 自身通常不需要设置样式。
+/// </summary>
+public sealed class TextNode : Element
+{
+    public override string TagName => "#text";
+
+    public TextNode() { }
+
+    public TextNode(string text)
+    {
+        Text = text;
+    }
+
+    /// <summary>
+    /// 文本内容。这是文本节点唯一承载的数据，直接存于基类的原始文本存储中。
+    /// </summary>
+    public string Text
+    {
+        get => RawTextContent ?? "";
+        set => RawTextContent = value;
+    }
+
+    /// <summary>
+    /// 文本节点的 <see cref="Element.TextContent"/> 直接映射到其自身文本，
+    /// 不走 facade 的「拼接子文本节点」逻辑（文本节点没有子节点）。
+    /// </summary>
+    public override string? TextContent
+    {
+        get => RawTextContent;
+        set => RawTextContent = value;
+    }
+
+    public override string ToString() => $"#text(\"{Text}\")";
+}

--- a/src/Miko/Core/Element.cs
+++ b/src/Miko/Core/Element.cs
@@ -1,3 +1,4 @@
+using Miko.Core.DomElements;
 using Miko.Events;
 using Miko.Layout;
 using Miko.Styling;
@@ -19,7 +20,79 @@ public abstract class Element
         Parent = parent;
     }
     public Style? Style { get; set; }
-    public string? TextContent { get; set; }
+
+    // TextContent 的原始存储。仅由 TextNode（承载真实文本）与 TextContent facade 直接访问。
+    // 普通元素不应直接写入此字段——文本应作为 TextNode 子节点存在，见 ISSUE-086。
+    private string? _rawTextContent;
+
+    /// <summary>
+    /// 原始文本存储，供 <see cref="DomElements.TextNode"/> 及 <see cref="TextContent"/> facade 内部使用。
+    /// </summary>
+    internal string? RawTextContent
+    {
+        get => _rawTextContent;
+        set => _rawTextContent = value;
+    }
+
+    /// <summary>
+    /// 元素的直接文本内容（便利外观）。
+    ///
+    /// 自 ISSUE-086 起，文本以有序的 <see cref="DomElements.TextNode"/> 子节点形式存放，以保留
+    /// 文本与标签的交错顺序。为兼容既有代码，此属性保留 string 语义：
+    /// <list type="bullet">
+    /// <item>get：拼接所有直接子 <see cref="DomElements.TextNode"/> 的文本；无文本子节点时返回 null。</item>
+    /// <item>set：移除现有文本子节点，若值非空则重建单个前置文本节点（等价旧「文本在前」语义）。</item>
+    /// </list>
+    /// <see cref="DomElements.TextNode"/> 自身重写此逻辑，直接读写其 <see cref="RawTextContent"/>。
+    /// </summary>
+    public virtual string? TextContent
+    {
+        get
+        {
+            // 快速路径：无子节点。
+            if (Children.Count == 0) return null;
+
+            string? single = null;
+            System.Text.StringBuilder? sb = null;
+            bool any = false;
+            foreach (var child in Children)
+            {
+                if (child is TextNode tn)
+                {
+                    any = true;
+                    if (sb != null)
+                    {
+                        sb.Append(tn.Text);
+                    }
+                    else if (single != null)
+                    {
+                        sb = new System.Text.StringBuilder(single);
+                        sb.Append(tn.Text);
+                    }
+                    else
+                    {
+                        single = tn.Text;
+                    }
+                }
+            }
+
+            if (!any) return null;
+            return sb?.ToString() ?? single;
+        }
+        set
+        {
+            // 移除已有的文本节点。
+            Children.RemoveAll(c => c is TextNode);
+            if (!string.IsNullOrEmpty(value))
+            {
+                // 重建为单个前置文本节点，保持旧「文本排在子元素之前」的语义。
+                var textNode = new TextNode(value);
+                textNode.SetParent(this);
+                Children.Insert(0, textNode);
+            }
+            IsDirty = true;
+        }
+    }
 
     internal Dictionary<PseudoElementType, Style>? PseudoElementStyles { get; set; }
 

--- a/src/Miko/Core/MikoEngine.cs
+++ b/src/Miko/Core/MikoEngine.cs
@@ -400,6 +400,11 @@ public class MikoEngine
 
     private Element? HitTestBox(LayoutBox box, float x, float y, float scrollOffsetX = 0, float scrollOffsetY = 0)
     {
+        // 文本节点（TextNode）对命中透明：点击文本时命中目标应解析为其包含元素（如 button），
+        // 而非匿名文本节点本身，否则会破坏事件处理与冒泡（见 ISSUE-086）。
+        if (box.Element is TextNode)
+            return null;
+
         var rect = box.BoxModel.BorderBox;
         float adjustedLeft = rect.Left - scrollOffsetX;
         float adjustedRight = rect.Right - scrollOffsetX;

--- a/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
@@ -76,22 +76,9 @@ public class BlockLayout
         }
         else if (constraints.IsInfiniteWidth || containerWidth <= 0)
         {
-            // 当没有可用宽度约束时（如在 flex row 容器中），根据内容计算宽度
-            if (box.Children.Count == 0 && !string.IsNullOrEmpty(box.Element.TextContent))
-            {
-                // 根据文本内容计算宽度
-                var (textWidth, _) = TextMeasurer.MeasureText(
-                    box.Element.TextContent,
-                    style.FontFamily,
-                    style.FontSize.Value,
-                    style.FontWeight);
-                contentWidth = textWidth;
-            }
-            else
-            {
-                // 没有内容时宽度为 0
-                contentWidth = 0;
-            }
+            // 当没有可用宽度约束时（如在 flex row 容器中），根据内容计算宽度（shrink-to-fit）。
+            // 以 null 约束预布局在流子元素（含文本节点），取其行内排列后的最右边界作为内容宽度。
+            contentWidth = MeasureInlineChildrenWidth(box);
         }
         else
         {
@@ -187,36 +174,11 @@ public class BlockLayout
         }
 
         // 4. 布局子元素
-        // Block 子元素垂直堆叠，Inline/InlineBlock 子元素水平排列
+        // Block 子元素垂直堆叠，Inline/InlineBlock/文本节点 子元素水平排列。
+        // 文本节点（TextNode）作为普通行内子盒参与，交错顺序由子节点列表天然表达（见 ISSUE-086），
+        // 不再需要把父元素的 TextContent 作为「排在子元素之前的匿名盒」特殊处理。
         float currentY = contentY;
         float maxChildWidth = 0;
-
-        // 当元素同时拥有 TextContent 和子元素时：
-        // - 如果第一个子元素是 block，文本作为独立行盒占据顶部，block 子元素从下方开始
-        // - 如果第一个子元素是 inline/inline-block，文本作为匿名 inline 盒与 inline 子元素同行排列
-        float ownTextWidth = 0;
-        float ownTextHeight = 0;
-        bool hasOwnText = box.Children.Count > 0 && !string.IsNullOrEmpty(box.Element.TextContent);
-        bool firstChildIsBlock = hasOwnText && !IsInlineOrInlineBlock(box.Children[0]);
-
-        if (hasOwnText)
-        {
-            var (textWidth, _) = TextMeasurer.MeasureText(
-                box.Element.TextContent,
-                style.FontFamily,
-                style.FontSize.Value,
-                style.FontWeight);
-            ownTextWidth = textWidth;
-            // 行高优先使用显式 line-height（如 1.5 × 字体大小），否则取字体自然度量。
-            ownTextHeight = ResolveLineHeight(style);
-
-            // 仅当第一个子元素是 block 时，文本独占一行，currentY 下移
-            if (firstChildIsBlock)
-            {
-                currentY += ownTextHeight;
-                maxChildWidth = Math.Max(maxChildWidth, ownTextWidth);
-            }
-        }
 
         int i = 0;
         while (i < box.Children.Count)
@@ -236,15 +198,9 @@ public class BlockLayout
 
             if (IsInlineOrInlineBlock(child))
             {
-                // 收集连续的 Inline/InlineBlock 子元素并水平布局
-                // 如果这是第一组 inline 子元素且父元素有文本内容，文本宽度作为起始 X
+                // 收集连续的 Inline/InlineBlock/文本节点 子元素并水平布局到同一行。
                 float lineX = contentX;
-                if (i == 0 && hasOwnText && !firstChildIsBlock)
-                {
-                    lineX += ownTextWidth;
-                }
-
-                float lineHeight = hasOwnText && i == 0 && !firstChildIsBlock ? ownTextHeight : 0;
+                float lineHeight = 0;
 
                 while (i < box.Children.Count && IsInlineOrInlineBlock(box.Children[i])
                        && !IsOutOfFlow(box.Children[i]))
@@ -319,36 +275,10 @@ public class BlockLayout
             {
                 contentHeight = formControlHeight;
             }
-            // 如果没有子元素但有文本内容，则根据文本计算高度
-            else if (box.Children.Count == 0 && !string.IsNullOrEmpty(box.Element.TextContent))
-            {
-                // 行高优先使用显式 line-height，否则取字体自然度量。
-                float resolvedLineHeight = ResolveLineHeight(style);
-
-                // 如果文本可能换行（WhiteSpace 允许且有宽度限制），使用多行测量
-                bool shouldWrap = style.WhiteSpace == WhiteSpace.Normal
-                               || style.WhiteSpace == WhiteSpace.PreWrap
-                               || style.WhiteSpace == WhiteSpace.PreLine;
-
-                if (shouldWrap && contentWidth > 0)
-                {
-                    var (_, wrappedHeight) = TextMeasurer.MeasureTextWithWrap(
-                        box.Element.TextContent,
-                        style.FontFamily,
-                        style.FontSize.Value,
-                        style.FontWeight,
-                        contentWidth,
-                        resolvedLineHeight,
-                        style.WhiteSpace);
-                    contentHeight = wrappedHeight;
-                }
-                else
-                {
-                    contentHeight = resolvedLineHeight;
-                }
-            }
             else
             {
+                // 高度由内容决定。文本节点作为行内子盒已计入 childrenHeight（含换行后的多行高度），
+                // 因此无需再对父元素的 TextContent 做单独测量（见 ISSUE-086）。
                 contentHeight = childrenHeight;
             }
         }
@@ -397,30 +327,7 @@ public class BlockLayout
         float currentY = contentY;
         float maxChildWidth = 0;
 
-        // 与主布局逻辑保持一致地处理 TextContent 与子元素共存的情况
-        float ownTextWidth = 0;
-        float ownTextHeight = 0;
-        bool hasOwnText = box.Children.Count > 0 && !string.IsNullOrEmpty(box.Element.TextContent);
-        bool firstChildIsBlock = hasOwnText && !IsInlineOrInlineBlock(box.Children[0]);
-
-        if (hasOwnText)
-        {
-            var (textWidth, _) = TextMeasurer.MeasureText(
-                box.Element.TextContent,
-                style.FontFamily,
-                style.FontSize.Value,
-                style.FontWeight);
-            ownTextWidth = textWidth;
-            // 行高优先使用显式 line-height，否则取字体自然度量（与主布局一致）。
-            ownTextHeight = ResolveLineHeight(style);
-
-            if (firstChildIsBlock)
-            {
-                currentY += ownTextHeight;
-                maxChildWidth = Math.Max(maxChildWidth, ownTextWidth);
-            }
-        }
-
+        // 文本节点作为普通行内子盒参与，无需 ownText 特例（见 ISSUE-086）。
         int i = 0;
         while (i < box.Children.Count)
         {
@@ -438,12 +345,7 @@ public class BlockLayout
             if (IsInlineOrInlineBlock(child))
             {
                 float lineX = contentX;
-                if (i == 0 && hasOwnText && !firstChildIsBlock)
-                {
-                    lineX += ownTextWidth;
-                }
-
-                float lineHeight = hasOwnText && i == 0 && !firstChildIsBlock ? ownTextHeight : 0;
+                float lineHeight = 0;
 
                 while (i < box.Children.Count && IsInlineOrInlineBlock(box.Children[i])
                        && !IsOutOfFlow(box.Children[i]))
@@ -480,9 +382,42 @@ public class BlockLayout
         LayoutDispatcher.Dispatch(child, constraints, x, y);
     }
 
-    private static bool IsInlineOrInlineBlock(LayoutBox child)
+    /// <summary>
+    /// 计算 shrink-to-fit 内容宽度（无宽度约束时，如 flex row 项）：以 null 约束预布局在流子元素
+    /// （含文本节点），行内子盒累加宽度、块级子盒取最大宽度，返回内容最大宽度。子盒随后会在确定
+    /// 宽度后重排，故此处仅用于测量。
+    /// </summary>
+    private float MeasureInlineChildrenWidth(LayoutBox box)
     {
-        return child.Type == LayoutType.Inline || child.Type == LayoutType.InlineBlock;
+        float maxWidth = 0;
+        float lineWidth = 0;
+        foreach (var child in box.Children)
+        {
+            if (IsOutOfFlow(child)) continue;
+
+            LayoutChild(child, new LayoutConstraints(null, null), 0, 0);
+            float w = child.BoxModel.MarginBox.Width;
+
+            if (IsInlineOrInlineBlock(child))
+            {
+                lineWidth += w;
+                maxWidth = Math.Max(maxWidth, lineWidth);
+            }
+            else
+            {
+                lineWidth = 0;
+                maxWidth = Math.Max(maxWidth, w);
+            }
+        }
+        return maxWidth;
+    }
+
+    internal static bool IsInlineOrInlineBlock(LayoutBox child)
+    {
+        // 文本节点（TextNode）是行内级盒，与 inline/inline-block 一起参与水平行内流。
+        return child.Type == LayoutType.Inline
+            || child.Type == LayoutType.InlineBlock
+            || child.Type == LayoutType.Text;
     }
 
     /// <summary>

--- a/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
@@ -220,22 +220,8 @@ public class FlexLayout
 
         float maxCrossSize = 0;
 
-        // 当元素同时拥有 TextContent 和子元素时，文本作为匿名 flex 项排在子元素之前，
-        // 参与主轴/交叉轴的对齐与分布（与 BlockLayout/InlineLayout 保持一致）。
-        float ownTextWidth = 0;
-        float ownTextHeight = 0;
-        bool hasOwnText = !string.IsNullOrEmpty(box.Element.TextContent);
-
-        if (hasOwnText)
-        {
-            var (textWidth, _) = TextMeasurer.MeasureText(
-                box.Element.TextContent,
-                style.FontFamily,
-                style.FontSize.Value,
-                style.FontWeight);
-            ownTextWidth = textWidth;
-            ownTextHeight = BlockLayout.ResolveLineHeight(style);
-        }
+        // 文本节点（TextNode）作为普通 flex 项参与主轴/交叉轴的对齐与分布（见 ISSUE-086），
+        // 不再需要把父元素的 TextContent 作为匿名 flex 项特殊处理（原 TextContentOffset 逻辑已移除）。
 
         // 脱离文档流的子元素（absolute/fixed）不是 flex 项目：
         // 单独布局以获得尺寸，不参与主轴/交叉轴的排列与尺寸计算。
@@ -253,11 +239,11 @@ public class FlexLayout
 
         if (isRow)
         {
-            LayoutRowDirection(box, contentX, contentY, contentWidth, contentHeight, ref maxCrossSize, widthIsIndefinite, heightIsDefinite, ownTextWidth, ownTextHeight);
+            LayoutRowDirection(box, contentX, contentY, contentWidth, contentHeight, ref maxCrossSize, widthIsIndefinite, heightIsDefinite);
         }
         else
         {
-            LayoutColumnDirection(box, contentX, contentY, contentWidth, contentHeight, ref maxCrossSize, heightIsDefinite, widthIsDefinite, ownTextWidth, ownTextHeight);
+            LayoutColumnDirection(box, contentX, contentY, contentWidth, contentHeight, ref maxCrossSize, heightIsDefinite, widthIsDefinite);
         }
 
         // 4b. 行布局且宽度未定：收缩包裹到子元素主轴总宽度（对称于下面 auto 高度的处理）。
@@ -265,23 +251,12 @@ public class FlexLayout
         // 需以子元素的自然宽度作为自身宽度，否则会塌缩为 0。
         if (isRow && widthIsIndefinite && widthIsAuto)
         {
+            // 文本节点已作为 flex 子项计入 MarginBox 宽度，无需再单独测量文本（见 ISSUE-086）。
             float totalChildMainWidth = 0;
             foreach (var child in box.Children)
             {
                 if (BlockLayout.IsOutOfFlow(child)) continue;
                 totalChildMainWidth += child.BoxModel.MarginBox.Width;
-            }
-
-            // 容器自身带文本（无 flex 子元素）时，文本宽度也是主轴内容尺寸的一部分，
-            // 收缩包裹应取子元素总宽与自身文本宽度的较大者，否则会塌缩为 0（见 ISSUE-078）。
-            if (box.Children.Count == 0 && !string.IsNullOrEmpty(box.Element.TextContent))
-            {
-                var (textWidth, _) = TextMeasurer.MeasureText(
-                    box.Element.TextContent,
-                    style.FontFamily,
-                    style.FontSize.Value,
-                    style.FontWeight);
-                totalChildMainWidth = Math.Max(totalChildMainWidth, textWidth);
             }
 
             contentWidth = totalChildMainWidth;
@@ -296,18 +271,12 @@ public class FlexLayout
             }
             else
             {
-                // 列布局：计算所有子元素的总高度
+                // 列布局：计算所有子元素的总高度（文本节点作为 flex 子项已计入，见 ISSUE-086）。
                 float totalChildHeight = 0;
                 foreach (var child in box.Children)
                 {
                     if (BlockLayout.IsOutOfFlow(child)) continue;
                     totalChildHeight += child.BoxModel.MarginBox.Height;
-                }
-
-                if (box.Children.Count == 0 && !string.IsNullOrEmpty(box.Element.TextContent))
-                {
-                    // 行高优先使用显式 line-height（如 1.5 × 字体大小），否则取字体自然度量。
-                    totalChildHeight = BlockLayout.ResolveLineHeight(style);
                 }
 
                 contentHeight = totalChildHeight;
@@ -348,34 +317,6 @@ public class FlexLayout
 
         box.BoxModel.Content = new RectF(contentX, contentY, contentWidth, contentHeight);
 
-        // 5b. 直接文本内容作为匿名 flex 项的对齐（见 ISSUE-085）。
-        // 容器没有 in-flow 子盒但自身带文本时，文本不是独立 LayoutBox，无法在上面的
-        // 行/列布局中被偏移。此处按最终内容盒尺寸计算文本在主轴(justify-content)与
-        // 交叉轴(align-items)上的对齐位移，交由 RenderEngine 绘制时叠加。
-        bool hasInFlowChild = false;
-        foreach (var child in box.Children)
-            if (!BlockLayout.IsOutOfFlow(child)) { hasInFlowChild = true; break; }
-
-        if (!hasInFlowChild && !string.IsNullOrEmpty(box.Element.TextContent))
-        {
-            float textWidth = TextMeasurer.MeasureTextWidth(
-                box.Element.TextContent, style.FontFamily, style.FontSize.Value, style.FontWeight);
-            float textHeight = BlockLayout.ResolveLineHeight(style);
-
-            // 主轴 = justify-content，交叉轴 = align-items。
-            float mainOffset = AlignMainAxis(
-                isRow ? contentWidth : contentHeight,
-                isRow ? textWidth : textHeight,
-                style.JustifyContent);
-            float crossOffset = AlignCrossAxis(
-                isRow ? contentHeight : contentWidth,
-                isRow ? textHeight : textWidth,
-                style.AlignItems);
-
-            box.TextContentOffsetX = isRow ? mainOffset : crossOffset;
-            box.TextContentOffsetY = isRow ? crossOffset : mainOffset;
-        }
-
         // 记录可滚动内容尺寸
         // 滚动区域包含盒子的内边距（见 BlockLayout 中的说明）
         float padH = box.BoxModel.Padding.Horizontal;
@@ -406,7 +347,7 @@ public class FlexLayout
 
     private void LayoutRowDirection(LayoutBox box, float contentX, float contentY,
         float contentWidth, float contentHeight, ref float maxCrossSize, bool widthIsIndefinite = false,
-        bool crossHeightIsDefinite = true, float ownTextWidth = 0, float ownTextHeight = 0)
+        bool crossHeightIsDefinite = true)
     {
         var style = box.ComputedStyle;
         float fs = style.FontSize.Value;
@@ -415,22 +356,14 @@ public class FlexLayout
         float columnGap = (style.ColumnGap.IsAuto ? style.Gap : style.ColumnGap).ToPixels(contentWidth, fs);
         float rowGap = (style.RowGap.IsAuto ? style.Gap : style.RowGap).ToPixels(contentWidth, fs);
 
-        // 收集所有非绝对定位子元素。
+        // 收集所有非绝对定位子元素（含文本节点，见 ISSUE-086）。
         var allChildren = new List<LayoutBox>();
         foreach (var child in box.Children)
             if (!BlockLayout.IsOutOfFlow(child)) allChildren.Add(child);
 
-        // 无 flex 项目且无文本内容：提前返回。
-        bool hasOwnText = ownTextWidth > 0;
-        if (allChildren.Count == 0 && !hasOwnText)
+        // 无 flex 项目：提前返回。
+        if (allChildren.Count == 0)
         {
-            return;
-        }
-
-        // 无子元素但有文本：交叉轴（高）取文本行高。
-        if (allChildren.Count == 0 && hasOwnText)
-        {
-            maxCrossSize = Math.Max(maxCrossSize, ownTextHeight);
             return;
         }
 
@@ -444,7 +377,7 @@ public class FlexLayout
         {
             float lineCrossSize = 0;
             LayoutFlexLine(box, line, contentX, currentY, contentWidth, contentHeight, columnGap, true, widthIsIndefinite,
-                style.JustifyContent, style.AlignItems, ref lineCrossSize, crossHeightIsDefinite, ownTextWidth, ownTextHeight);
+                style.JustifyContent, style.AlignItems, ref lineCrossSize, crossHeightIsDefinite);
             maxCrossSize = Math.Max(maxCrossSize, lineCrossSize);
             currentY += lineCrossSize + rowGap;
         }
@@ -459,7 +392,7 @@ public class FlexLayout
 
     private void LayoutColumnDirection(LayoutBox box, float contentX, float contentY,
         float contentWidth, float contentHeight, ref float maxCrossSize, bool heightIsDefinite,
-        bool crossWidthIsDefinite = true, float ownTextWidth = 0, float ownTextHeight = 0)
+        bool crossWidthIsDefinite = true)
     {
         var style = box.ComputedStyle;
         float fs = style.FontSize.Value;
@@ -468,22 +401,14 @@ public class FlexLayout
         float rowGap = (style.RowGap.IsAuto ? style.Gap : style.RowGap).ToPixels(contentHeight, fs);
         float columnGap = (style.ColumnGap.IsAuto ? style.Gap : style.ColumnGap).ToPixels(contentHeight, fs);
 
-        // 收集所有非绝对定位子元素。
+        // 收集所有非绝对定位子元素（含文本节点，见 ISSUE-086）。
         var allChildren = new List<LayoutBox>();
         foreach (var child in box.Children)
             if (!BlockLayout.IsOutOfFlow(child)) allChildren.Add(child);
 
-        // 无 flex 项目且无文本内容：提前返回。
-        bool hasOwnText = ownTextHeight > 0;
-        if (allChildren.Count == 0 && !hasOwnText)
+        // 无 flex 项目：提前返回。
+        if (allChildren.Count == 0)
         {
-            return;
-        }
-
-        // 无子元素但有文本：交叉轴（宽）取文本宽度。
-        if (allChildren.Count == 0 && hasOwnText)
-        {
-            maxCrossSize = Math.Max(maxCrossSize, ownTextWidth);
             return;
         }
 
@@ -501,7 +426,7 @@ public class FlexLayout
         {
             float lineCrossSize = 0;
             LayoutFlexLine(box, line, currentX, contentY, contentHeight, contentWidth, rowGap, false, heightIsIndefinite,
-                style.JustifyContent, style.AlignItems, ref lineCrossSize, crossWidthIsDefinite, ownTextWidth, ownTextHeight);
+                style.JustifyContent, style.AlignItems, ref lineCrossSize, crossWidthIsDefinite);
             maxCrossSize = Math.Max(maxCrossSize, lineCrossSize);
             currentX += lineCrossSize + columnGap;
         }
@@ -668,24 +593,13 @@ public class FlexLayout
     private void LayoutFlexLine(LayoutBox box, List<LayoutBox> lineChildren, float lineX, float lineY,
         float lineMainSize, float lineCrossSize, float gap, bool isRow, bool mainSizeIsIndefinite,
         JustifyContent justifyContent, AlignItems alignItems, ref float resultCrossSize,
-        bool crossSizeIsDefinite = true, float ownTextWidth = 0, float ownTextHeight = 0)
+        bool crossSizeIsDefinite = true)
     {
-        // 文本作为匿名 flex 项的尺寸（行方向主轴=宽，列方向主轴=高）。
-        bool hasOwnText = (isRow ? ownTextWidth : ownTextHeight) > 0;
-        float ownTextMainSize = isRow ? ownTextWidth : ownTextHeight;
-        float ownTextCrossSize = isRow ? ownTextHeight : ownTextWidth;
-
-        // 第一遍：计算 flex-basis。
+        // 第一遍：计算 flex-basis。文本节点（TextNode）作为普通 flex 项参与（见 ISSUE-086）。
         var childInfos = new List<FlexChildInfo>();
         float totalFlexBasisSize = 0;
         float totalFlexGrow = 0;
         float totalFlexShrinkWeighted = 0;
-
-        // 文本作为匿名 flex 项（flex-grow=0, flex-shrink=0），排在子元素之前。
-        if (hasOwnText)
-        {
-            totalFlexBasisSize += ownTextMainSize;
-        }
 
         foreach (var child in lineChildren)
         {
@@ -708,8 +622,8 @@ public class FlexLayout
             totalFlexShrinkWeighted += childStyle.FlexShrink * flexBasis;
         }
 
-        // gap 占用主轴空间：n 个项目间有 n-1 个 gap（文本也算一项）。
-        int totalItems = lineChildren.Count + (hasOwnText ? 1 : 0);
+        // gap 占用主轴空间：n 个项目间有 n-1 个 gap。
+        int totalItems = lineChildren.Count;
         float totalGapSize = Math.Max(0, totalItems - 1) * gap;
         float freeSpace = lineMainSize - totalFlexBasisSize - totalGapSize;
 
@@ -764,14 +678,6 @@ public class FlexLayout
         float lineCross = isRow ? lineY : lineX;
         float currentMain = lineStart;
         float maxCross = 0;
-
-        // 文本作为第一项，从 lineStart 开始，占据 ownTextMainSize 的主轴空间。
-        // 文本不参与 flex-grow/shrink，保持固定尺寸。
-        if (hasOwnText)
-        {
-            currentMain += ownTextMainSize + gap;
-            maxCross = Math.Max(maxCross, ownTextCrossSize);
-        }
 
         foreach (var info in childInfos)
         {
@@ -876,63 +782,23 @@ public class FlexLayout
 
         // 主轴对齐 (justify-content)：仅当本行无 flex-grow 时应用（grow 已占满主轴）。
         // gap 已计入 totalMainUsed，使对齐基于含间距的实际占用。
-        // 返回主轴对齐偏移，用于文本的 TextContentOffset。
-        float mainAlignmentOffset = 0;
         if (totalFlexGrow == 0 && lineMainSize > 0)
         {
             float totalMainUsed = currentMain - lineStart - gap; // 去掉末尾多余 gap
-            mainAlignmentOffset = ApplyLineJustifyContent(childInfos, lineStart, lineMainSize, totalMainUsed, isRow, justifyContent, totalItems, hasOwnText);
+            ApplyLineJustifyContent(childInfos, lineStart, lineMainSize, totalMainUsed, isRow, justifyContent, totalItems);
         }
 
-        // 交叉轴对齐 (align-items)。返回交叉轴对齐偏移，用于文本的 TextContentOffset。
+        // 交叉轴对齐 (align-items)。
         float crossExtent = lineCrossSize > 0 ? Math.Max(lineCrossSize, maxCross) : maxCross;
-        float crossAlignmentOffset = ApplyLineAlignItems(childInfos, lineCross, crossExtent, isRow, alignItems, ownTextCrossSize, hasOwnText);
-
-        // 将文本的对齐偏移存储到容器的 LayoutBox（供 RenderEngine 使用）。
-        if (hasOwnText)
-        {
-            box.TextContentOffsetX = isRow ? mainAlignmentOffset : crossAlignmentOffset;
-            box.TextContentOffsetY = isRow ? crossAlignmentOffset : mainAlignmentOffset;
-        }
+        ApplyLineAlignItems(childInfos, lineCross, crossExtent, isRow, alignItems);
 
         resultCrossSize = maxCross;
     }
 
-    /// <summary>
-    /// 计算单个匿名项（如直接文本）在主轴上的 justify-content 偏移。
-    /// 对单项而言 space-between 等价 flex-start，space-around / space-evenly 等价 center，
-    /// 与 <see cref="ApplyLineJustifyContent"/> 中 line.Count==1 的行为一致。
-    /// </summary>
-    private static float AlignMainAxis(float containerSize, float contentSize, JustifyContent justify)
+    /// <summary>对一行/列的子元素应用 justify-content（主轴对齐）。</summary>
+    private void ApplyLineJustifyContent(List<FlexChildInfo> line, float start, float containerSize, float contentSize, bool isRow, JustifyContent justifyContent, int totalItems)
     {
-        if (containerSize <= 0) return 0;
-        float free = containerSize - contentSize;
-        return justify switch
-        {
-            Common.JustifyContent.FlexEnd => free,
-            Common.JustifyContent.Center => free / 2f,
-            Common.JustifyContent.SpaceAround => free / 2f,
-            Common.JustifyContent.SpaceEvenly => free / 2f,
-            _ => 0f, // FlexStart / SpaceBetween(单项)
-        };
-    }
-
-    /// <summary>计算单个匿名项（如直接文本）在交叉轴上的 align-items 偏移。</summary>
-    private static float AlignCrossAxis(float crossSize, float itemCrossSize, AlignItems align)
-    {
-        if (crossSize <= 0) return 0;
-        return align switch
-        {
-            Common.AlignItems.FlexEnd => crossSize - itemCrossSize,
-            Common.AlignItems.Center => (crossSize - itemCrossSize) / 2f,
-            _ => 0f, // FlexStart / Stretch（文本无法拉伸，锚定起点）/ Baseline
-        };
-    }
-
-    /// <summary>对一行/列的子元素应用 justify-content（主轴对齐）。返回主轴对齐偏移。</summary>
-    private float ApplyLineJustifyContent(List<FlexChildInfo> line, float start, float containerSize, float contentSize, bool isRow, JustifyContent justifyContent, int totalItems, bool hasOwnText)
-    {
-        if (line.Count == 0) return 0;
+        if (line.Count == 0) return;
 
         float spacing = 0, offset = 0;
         switch (justifyContent)
@@ -948,35 +814,18 @@ public class FlexLayout
                 spacing = (containerSize - contentSize) / (totalItems + 1); offset = spacing; break;
         }
 
-        // 如果有文本（第0项），子元素从第1项开始；否则从第0项开始。
-        int startIndex = hasOwnText ? 1 : 0;
         for (int i = 0; i < line.Count; i++)
         {
-            float itemOffset = offset + spacing * (startIndex + i);
+            float itemOffset = offset + spacing * i;
             if (Math.Abs(itemOffset) < 0.01f) continue;
             if (isRow) OffsetSubtree(line[i].Child, itemOffset, 0);
             else OffsetSubtree(line[i].Child, 0, itemOffset);
         }
-
-        return offset;
     }
 
-    /// <summary>对一行/列的子元素应用 align-items（交叉轴对齐）。返回文本的交叉轴对齐偏移。</summary>
-    private float ApplyLineAlignItems(List<FlexChildInfo> line, float crossStart, float crossSize, bool isRow, AlignItems alignItems, float ownTextCrossSize, bool hasOwnText)
+    /// <summary>对一行/列的子元素应用 align-items（交叉轴对齐）。</summary>
+    private void ApplyLineAlignItems(List<FlexChildInfo> line, float crossStart, float crossSize, bool isRow, AlignItems alignItems)
     {
-        float textCrossOffset = 0;
-
-        // 计算文本的交叉轴偏移
-        if (hasOwnText)
-        {
-            textCrossOffset = alignItems switch
-            {
-                Common.AlignItems.FlexEnd => crossSize - ownTextCrossSize,
-                Common.AlignItems.Center => (crossSize - ownTextCrossSize) / 2,
-                _ => 0f, // FlexStart / Stretch（文本无法拉伸）/ Baseline
-            };
-        }
-
         foreach (var info in line)
         {
             var child = info.Child;
@@ -988,6 +837,8 @@ public class FlexLayout
                 case Common.AlignItems.FlexEnd: offset = crossSize - childCrossSize; break;
                 case Common.AlignItems.Center: offset = (crossSize - childCrossSize) / 2; break;
                 case Common.AlignItems.Stretch:
+                    // 文本节点不可拉伸（其尺寸由文本决定），锚定起点。
+                    if (child.Type == LayoutType.Text) break;
                     if (isRow)
                     {
                         if (child.ComputedStyle.Height.IsAuto)
@@ -1017,7 +868,5 @@ public class FlexLayout
                 else OffsetSubtree(child, offset, 0);
             }
         }
-
-        return textCrossOffset;
     }
 }

--- a/src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs
@@ -42,53 +42,22 @@ public class InlineLayout
         float contentX = x + box.BoxModel.Margin.Left + box.BoxModel.Border.Left + box.BoxModel.Padding.Left;
         float contentY = y + box.BoxModel.Margin.Top + box.BoxModel.Border.Top + box.BoxModel.Padding.Top;
 
-        // 当元素同时拥有 TextContent 和子元素时，文本作为匿名 inline 盒
-        // 排在子元素之前，子元素从文本宽度之后开始排列（与 BlockLayout 保持一致）。
-        float ownTextWidth = 0;
-        float ownTextHeight = 0;
-        bool hasOwnText = !string.IsNullOrEmpty(box.Element.TextContent);
+        // 文本节点作为普通行内子盒参与，交错顺序由子节点列表表达（见 ISSUE-086），
+        // 不再需要把父元素的 TextContent 作为「排在子元素之前的匿名盒」特殊处理。
+        float currentX = contentX;
+        float lineHeight = 0;
+        float maxWidth = 0;
 
-        if (hasOwnText)
+        // 文本节点可用的换行宽度：当行内元素自身有宽度约束时，文本应在剩余宽度内换行
+        // （见 ISSUE-079）。auto 宽度且无约束时传 null，文本单行测量（shrink-to-fit）。
+        float? textWrapWidth = null;
+        if (constraints.AvailableWidth.HasValue && constraints.AvailableWidth.Value > 0)
         {
-            // 行高优先使用显式 line-height（如 1.5 × 字体大小），否则取字体自然度量。
-            float resolvedLineHeight = BlockLayout.ResolveLineHeight(style);
-
-            // 如果元素有明确的宽度约束，使用多行测量（支持自动换行）
-            if (constraints.AvailableWidth.HasValue && constraints.AvailableWidth.Value > 0)
-            {
-                // 减去 padding 和 border 得到可用内容宽度
-                float availableContentWidth = constraints.AvailableWidth.Value
-                    - box.BoxModel.Padding.Horizontal
-                    - box.BoxModel.Border.Horizontal;
-
-                var (wrappedWidth, wrappedHeight) = TextMeasurer.MeasureTextWithWrap(
-                    box.Element.TextContent,
-                    style.FontFamily,
-                    style.FontSize.Value,
-                    style.FontWeight,
-                    availableContentWidth,
-                    resolvedLineHeight,
-                    style.WhiteSpace);
-
-                ownTextWidth = wrappedWidth;
-                ownTextHeight = wrappedHeight;
-            }
-            else
-            {
-                // 没有宽度约束，使用单行测量
-                var (textWidth, _) = TextMeasurer.MeasureText(
-                    box.Element.TextContent,
-                    style.FontFamily,
-                    style.FontSize.Value,
-                    style.FontWeight);
-                ownTextWidth = textWidth;
-                ownTextHeight = resolvedLineHeight;
-            }
+            textWrapWidth = constraints.AvailableWidth.Value
+                - box.BoxModel.Padding.Horizontal
+                - box.BoxModel.Border.Horizontal;
+            if (textWrapWidth < 0) textWrapWidth = 0;
         }
-
-        float currentX = contentX + ownTextWidth;
-        float lineHeight = ownTextHeight;
-        float maxWidth = ownTextWidth;
 
         // 简化实现：单行布局，不处理换行
         foreach (var child in box.Children)
@@ -102,7 +71,10 @@ public class InlineLayout
                 continue;
             }
 
-            var childConstraints = new LayoutConstraints(null, null);
+            // 文本节点传入换行宽度以支持自动换行；其它行内子元素保持 null 约束（shrink-to-fit）。
+            var childConstraints = child.Type == LayoutType.Text
+                ? new LayoutConstraints(textWrapWidth, null)
+                : new LayoutConstraints(null, null);
             LayoutChild(child, childConstraints, currentX, contentY);
 
             currentX = child.BoxModel.MarginBox.Right;
@@ -150,14 +122,9 @@ public class InlineLayout
                 contentWidth = h * intrinsicW / intrinsicH;
             }
         }
-        else if (box.Children.Count == 0 && hasOwnText)
-        {
-            // 只有文本内容、没有子元素：宽度即文本宽度
-            contentWidth = ownTextWidth;
-        }
         else
         {
-            // 有子元素（可能同时有文本）：maxWidth 已包含文本宽度作为起始偏移
+            // auto 宽度：内容宽度即行内子盒（含文本节点）排列后的最大宽度。
             contentWidth = maxWidth;
         }
 
@@ -188,8 +155,8 @@ public class InlineLayout
         bool widthIsDefinite = !widthIsAuto || !style.MinWidth.IsAuto || !style.MaxWidth.IsAuto;
         if (widthIsDefinite && contentWidth > 0 && box.Children.Count > 0)
         {
-            float childX = contentX + ownTextWidth;
-            float relaidLineHeight = ownTextHeight;
+            float childX = contentX;
+            float relaidLineHeight = 0;
             foreach (var child in box.Children)
             {
                 if (BlockLayout.IsOutOfFlow(child))
@@ -228,14 +195,9 @@ public class InlineLayout
             // 也优先采用单行高度，避免被 option 撑高或塌缩为 0（参见 ISSUE-040）。
             contentHeight = formControlHeight;
         }
-        else if (box.Children.Count == 0 && hasOwnText)
-        {
-            // 只有文本内容、没有子元素：高度即文本高度
-            contentHeight = ownTextHeight;
-        }
         else
         {
-            // 有子元素时，lineHeight 已取文本高度与子元素高度的较大值
+            // auto 高度：内容高度即行内子盒（含文本节点）行高的最大值。
             contentHeight = lineHeight;
         }
 

--- a/src/Miko/Layout/LayoutAlgorithms/LayoutDispatcher.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/LayoutDispatcher.cs
@@ -11,6 +11,7 @@ public static class LayoutDispatcher
     private static readonly InlineLayout _inlineLayout = new();
     private static readonly FlexLayout _flexLayout = new();
     private static readonly TableLayout _tableLayout = new();
+    private static readonly TextLayout _textLayout = new();
 
     /// <summary>
     /// 根据盒子类型执行相应的布局算法
@@ -41,6 +42,10 @@ public static class LayoutDispatcher
                 // TableRow 和 TableCell 由 TableLayout 直接布局
                 // 如果单独调用，使用 Block 布局作为后备
                 _blockLayout.Layout(box, constraints, x, y);
+                break;
+
+            case LayoutType.Text:
+                _textLayout.Layout(box, constraints, x, y);
                 break;
         }
     }

--- a/src/Miko/Layout/LayoutAlgorithms/TextLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/TextLayout.cs
@@ -1,0 +1,73 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Utils;
+
+namespace Miko.Layout.LayoutAlgorithms;
+
+/// <summary>
+/// 文本节点布局算法（<see cref="TextNode"/>）。
+///
+/// 文本节点是匿名的行内级盒：没有 margin / border / padding，其内容盒即测量出的文本外接矩形。
+/// 文本样式（字体、字号、字重、行高、空白处理）由样式继承从父元素获得。
+/// 当存在宽度约束且允许换行时使用多行测量，否则单行测量。
+///
+/// 文本节点作为普通子盒进入父级的 Block / Inline / Flex 布局，交错顺序由子节点列表表达
+/// （见 ISSUE-086）。这取代了历史上把父元素 <c>TextContent</c> 作为「排在子元素之前的匿名盒」
+/// 的特例处理。
+/// </summary>
+public class TextLayout
+{
+    public void Layout(LayoutBox box, LayoutConstraints constraints, float x, float y)
+    {
+        var style = box.ComputedStyle;
+        var text = box.Element.TextContent;
+
+        // 文本节点无 margin / border / padding。
+        box.BoxModel.Margin = new EdgeSizes(0, 0, 0, 0);
+        box.BoxModel.Border = new EdgeSizes(0, 0, 0, 0);
+        box.BoxModel.Padding = new EdgeSizes(0, 0, 0, 0);
+
+        if (string.IsNullOrEmpty(text))
+        {
+            box.BoxModel.Content = new RectF(x, y, 0, 0);
+            return;
+        }
+
+        // 行高优先使用显式 line-height，否则取字体自然度量（与其它布局算法一致）。
+        float resolvedLineHeight = BlockLayout.ResolveLineHeight(style);
+
+        float width;
+        float height;
+
+        bool canWrap = style.WhiteSpace == WhiteSpace.Normal
+                    || style.WhiteSpace == WhiteSpace.PreWrap
+                    || style.WhiteSpace == WhiteSpace.PreLine;
+
+        if (canWrap && constraints.AvailableWidth.HasValue && constraints.AvailableWidth.Value > 0)
+        {
+            var (wrappedWidth, wrappedHeight) = TextMeasurer.MeasureTextWithWrap(
+                text,
+                style.FontFamily,
+                style.FontSize.Value,
+                style.FontWeight,
+                constraints.AvailableWidth.Value,
+                resolvedLineHeight,
+                style.WhiteSpace);
+
+            width = wrappedWidth;
+            height = wrappedHeight;
+        }
+        else
+        {
+            var (textWidth, _) = TextMeasurer.MeasureText(
+                text,
+                style.FontFamily,
+                style.FontSize.Value,
+                style.FontWeight);
+            width = textWidth;
+            height = resolvedLineHeight;
+        }
+
+        box.BoxModel.Content = new RectF(x, y, width, height);
+    }
+}

--- a/src/Miko/Layout/LayoutBox.cs
+++ b/src/Miko/Layout/LayoutBox.cs
@@ -29,13 +29,6 @@ public class LayoutBox
     public float ScrollableContentWidth { get; set; }
     public float ScrollableContentHeight { get; set; }
 
-    // 直接文本内容作为匿名 flex 项时的对齐偏移（相对内容盒左上角）。
-    // flex 容器的直接文本没有独立 LayoutBox，无法参与 justify-content/align-items 的
-    // 子盒偏移。FlexLayout 在此记录其对齐位移，RenderEngine 绘制直接文本时叠加应用
-    // （见 ISSUE-085）。非 flex 容器保持 0，绘制行为不变。
-    public float TextContentOffsetX { get; set; }
-    public float TextContentOffsetY { get; set; }
-
     // 是否需要显示滚动条
     // ScrollableContent* 表示包含内边距的滚动区域，因此与 padding box 的视口尺寸比较。
     public bool HasVerticalScrollbar => ComputedStyle.OverflowY == Overflow.Scroll ||

--- a/src/Miko/Layout/LayoutEngine.cs
+++ b/src/Miko/Layout/LayoutEngine.cs
@@ -16,6 +16,7 @@ public class LayoutEngine
     private readonly InlineLayout _inlineLayout = new();
     private readonly FlexLayout _flexLayout = new();
     private readonly TableLayout _tableLayout = new();
+    private readonly TextLayout _textLayout = new();
 
     // 当前布局的安全区边距。在样式计算阶段用于折算各元素的 env(safe-area-inset-*) 长度。
     // 不内缩视口本身——视口始终为全屏，仅“声明了 env() 的内容元素”据此添加内边距，
@@ -231,6 +232,13 @@ public class LayoutEngine
 
         var layoutBox = element.LayoutBox;
 
+        // 文本节点：始终使用 Text 布局（匿名行内文本盒），不受 display 影响。
+        if (element is TextNode)
+        {
+            layoutBox.Type = LayoutType.Text;
+            return layoutBox;
+        }
+
         // 根据 display 属性确定布局类型
         layoutBox.Type = layoutBox.ComputedStyle.Display switch
         {
@@ -326,6 +334,7 @@ public class LayoutEngine
             matchedStyle = merged;
         }
 
+        // content 文本通过 facade setter 变为 pseudoElement 的 TextNode 子节点（见 ISSUE-086）。
         var pseudoElement = new PseudoElement { TextContent = matchedStyle.Content, Type = type };
         var computedStyle = ComputedStyle.FromStyle(matchedStyle);
         computedStyle.ResolveSafeArea(_safeArea);
@@ -352,7 +361,40 @@ public class LayoutEngine
 
         if (computedStyle.Display == Display.None) return null;
 
+        // 为 content 文本节点建盒并挂到伪元素盒下，使其作为普通行内子盒被布局/绘制。
+        foreach (var child in pseudoElement.Children)
+        {
+            if (child is TextNode)
+            {
+                var textStyle = ComputedStyle.FromStyle(new Style());
+                InheritComputedStyle(textStyle, computedStyle);
+                child.LayoutBox = new LayoutBox
+                {
+                    Element = child,
+                    ComputedStyle = textStyle,
+                    Type = LayoutType.Text
+                };
+                box.Children.Add(child.LayoutBox);
+            }
+        }
+
         return box;
+    }
+
+    /// <summary>
+    /// 把父计算样式的可继承文本属性复制到子（用于伪元素 content 文本节点等无独立样式解析的场景）。
+    /// Miko 无 CSS inherit 关键字，需显式镜像（见 memory: miko-no-inherit-keyword）。
+    /// </summary>
+    private static void InheritComputedStyle(ComputedStyle target, ComputedStyle parent)
+    {
+        target.Color = parent.Color;
+        target.FontFamily = parent.FontFamily;
+        target.FontSize = parent.FontSize;
+        target.FontWeight = parent.FontWeight;
+        target.TextAlign = parent.TextAlign;
+        target.LineHeight = parent.LineHeight;
+        target.WhiteSpace = parent.WhiteSpace;
+        target.TextDecoration = parent.TextDecoration;
     }
 
     /// <summary>
@@ -384,6 +426,10 @@ public class LayoutEngine
                 // TableRow 和 TableCell 由 TableLayout 直接布局
                 // 如果单独调用，使用 Block 布局作为后备
                 _blockLayout.Layout(box, constraints, x, y);
+                break;
+
+            case LayoutType.Text:
+                _textLayout.Layout(box, constraints, x, y);
                 break;
         }
     }

--- a/src/Miko/Rendering/RenderEngine.cs
+++ b/src/Miko/Rendering/RenderEngine.cs
@@ -560,112 +560,11 @@ public class RenderEngine
             return;
         }
 
-        // 渲染文本内容
-        if (!string.IsNullOrEmpty(element.TextContent))
+        // 渲染文本节点（TextNode）。文本自 ISSUE-086 起以有序文本节点子盒形式存在，
+        // 由各自的 TextNode 盒在布局中定位，此处按其内容盒绘制。
+        if (element is Miko.Core.DomElements.TextNode)
         {
-            var style = box.ComputedStyle;
-            var content = box.BoxModel.Content;
-
-            // 文本绘制矩形与垂直对齐：
-            // - button 默认像 flex 容器一样把文本居中于整个内容盒；
-            // - 其余元素遵循 CSS 行盒（line box）模型：文本位于高度为 line-height 的行盒内，
-            //   行距（leading）平均分配到上下两侧（half-leading），使文本在行盒内垂直居中。
-            //   行盒锚定在内容盒顶部，高度取 line-height（未显式设置时回退到字体度量），
-            //   因此当元素只有文本时（内容高 = line-height）文本居中于内容盒（参见 ISSUE-070），
-            //   而自然行高下行盒高 ≈ 字体高，居中与顶对齐等价（无回归）。
-            RectF textRect;
-            if (element is Miko.Core.DomElements.ButtonElement)
-            {
-                textRect = content;
-            }
-            else
-            {
-                float lineBoxHeight = Layout.LayoutAlgorithms.BlockLayout.ResolveLineHeight(style);
-                textRect = new RectF(content.X, content.Y, content.Width, lineBoxHeight);
-            }
-
-            // flex 容器的直接文本作为匿名 flex 项参与 justify-content/align-items（见 ISSUE-085）。
-            // FlexLayout 记录的对齐位移在此叠加到文本绘制矩形上（非 flex 容器偏移为 0）。
-            // 重要：当文本已经通过 flex 对齐偏移后，textRect 的宽度应收缩为文本实际宽度，
-            // 避免 TextAlign 在容器全宽内再次居中造成叠加偏移（见 ISSUE-085 问题2）。
-            if (box.TextContentOffsetX != 0f || box.TextContentOffsetY != 0f)
-            {
-                float actualTextWidth = Utils.TextMeasurer.MeasureTextWidth(
-                    element.TextContent, style.FontFamily, style.FontSize.Value, style.FontWeight);
-
-                // 像素对齐：将偏移后的坐标四舍五入到整数像素，避免亚像素渲染导致文本模糊/锯齿。
-                // 文本渲染对亚像素位置非常敏感，即使0.5px的偏移也会显著影响抗锯齿效果。
-                float newX = MathF.Round(textRect.X + box.TextContentOffsetX);
-                float newY = MathF.Round(textRect.Y + box.TextContentOffsetY);
-
-                textRect = new RectF(
-                    newX,
-                    newY,
-                    actualTextWidth,  // 收缩到文本实际宽度，TextAlign 在此宽度内对齐（通常无额外偏移）
-                    textRect.Height);
-            }
-
-            // 根据 WhiteSpace 属性决定是否使用多行文本绘制
-            bool shouldWrap = Utils.TextWrapper.ShouldWrap(style.WhiteSpace);
-            bool needsMultiline = false;
-
-            if (shouldWrap && content.Width > 0)
-            {
-                // 检查文本是否需要换行（预处理后的文本宽度是否超过可用宽度）
-                var processedText = Utils.TextWrapper.ProcessText(element.TextContent, style.WhiteSpace);
-                var (singleLineWidth, _) = Utils.TextMeasurer.MeasureText(
-                    processedText,
-                    style.FontFamily,
-                    style.FontSize.Value,
-                    style.FontWeight);
-
-                needsMultiline = singleLineWidth > content.Width || processedText.Contains('\n');
-            }
-
-            if (needsMultiline)
-            {
-                float lineHeight = Layout.LayoutAlgorithms.BlockLayout.ResolveLineHeight(style);
-                _painter.DrawMultilineText(
-                    element.TextContent,
-                    content, // 使用整个内容区域进行换行
-                    style.Color,
-                    style.FontFamily,
-                    style.FontSize.Value,
-                    style.FontWeight,
-                    style.TextAlign,
-                    lineHeight,
-                    style.WhiteSpace,
-                    element is Miko.Core.DomElements.ButtonElement ? VerticalAlign.Middle : VerticalAlign.Top
-                );
-            }
-            else
-            {
-                _painter.DrawText(
-                    element.TextContent,
-                    textRect,
-                    style.Color,
-                    style.FontFamily,
-                    style.FontSize.Value,
-                    style.FontWeight,
-                    style.TextAlign,
-                    VerticalAlign.Middle
-                );
-            }
-
-            if (style.TextDecoration != Common.TextDecoration.None)
-            {
-                _painter.DrawTextDecoration(
-                    element.TextContent,
-                    textRect,
-                    style.Color,
-                    style.FontFamily,
-                    style.FontSize.Value,
-                    style.FontWeight,
-                    style.TextAlign,
-                    style.TextDecoration,
-                    VerticalAlign.Middle
-                );
-            }
+            RenderTextNode(box);
         }
 
         // 渲染图片
@@ -679,6 +578,107 @@ public class RenderEngine
         {
             RenderVideoFrame(box, videoElement);
         }
+    }
+
+    /// <summary>
+    /// 绘制文本节点（<see cref="Core.DomElements.TextNode"/>）。
+    ///
+    /// 文本节点的内容盒已由 <see cref="Layout.LayoutAlgorithms.TextLayout"/> 定位并测出实际文本尺寸。
+    /// 水平对齐（text-align）以父元素内容盒为参照：单行时在父内容宽度内对齐；文本超宽需换行时按父
+    /// 内容盒多行绘制。垂直方向遵循 CSS 行盒模型（半行距上下均分），因此在纯文本场景下文本垂直居中于
+    /// 其行盒（保持 ISSUE-070 行为）。坐标做像素对齐以保持抗锯齿清晰度（见 ISSUE-085 抗锯齿修复）。
+    /// </summary>
+    private void RenderTextNode(LayoutBox box)
+    {
+        if (_painter == null) return;
+
+        var text = box.Element.TextContent;
+        if (string.IsNullOrEmpty(text)) return;
+
+        var style = box.ComputedStyle;
+        var content = box.BoxModel.Content;
+
+        // text-align 的对齐参照：
+        // - 当文本节点是父元素唯一的在流内容时（无其它行内兄弟），以父内容盒作为对齐容器，
+        //   使 center/right 生效（覆盖纯文本元素与 button 的居中场景）。
+        // - 否则（存在交错的兄弟元素，如 text1 <span/> text3），文本已由布局定位到其行内位置，
+        //   按自身内容盒左对齐绘制，不再二次对齐（避免破坏交错顺序）。
+        var parent = box.Element.Parent;
+        bool textNodeIsSoleInlineContent = parent != null && IsSoleInFlowInlineChild(box);
+
+        float alignX;
+        float alignWidth;
+        if (textNodeIsSoleInlineContent && parent!.LayoutBox != null)
+        {
+            var parentContent = parent.LayoutBox.BoxModel.Content;
+            alignX = parentContent.X;
+            alignWidth = parentContent.Width;
+        }
+        else
+        {
+            alignX = content.X;
+            alignWidth = content.Width;
+        }
+
+        // 是否需要多行绘制：文本宽度超过对齐容器宽度，或包含换行符。
+        bool shouldWrap = Utils.TextWrapper.ShouldWrap(style.WhiteSpace);
+        bool needsMultiline = false;
+        if (shouldWrap && alignWidth > 0)
+        {
+            var processedText = Utils.TextWrapper.ProcessText(text, style.WhiteSpace);
+            var (singleLineWidth, _) = Utils.TextMeasurer.MeasureText(
+                processedText, style.FontFamily, style.FontSize.Value, style.FontWeight);
+            needsMultiline = singleLineWidth > alignWidth + 0.5f || processedText.Contains('\n');
+        }
+
+        if (needsMultiline)
+        {
+            float lineHeight = Layout.LayoutAlgorithms.BlockLayout.ResolveLineHeight(style);
+            // 多行文本在对齐容器宽度内换行与水平对齐，从文本节点顶部开始向下排列。
+            var wrapRect = new RectF(MathF.Round(alignX), MathF.Round(content.Y), alignWidth, content.Height);
+            _painter.DrawMultilineText(
+                text, wrapRect, style.Color, style.FontFamily, style.FontSize.Value, style.FontWeight,
+                style.TextAlign, lineHeight, style.WhiteSpace, VerticalAlign.Top);
+
+            if (style.TextDecoration != Common.TextDecoration.None)
+            {
+                _painter.DrawTextDecoration(text, wrapRect, style.Color, style.FontFamily,
+                    style.FontSize.Value, style.FontWeight, style.TextAlign, style.TextDecoration, VerticalAlign.Top);
+            }
+            return;
+        }
+
+        // 单行：在对齐容器宽度内按 text-align 水平对齐，垂直居中于文本节点行盒。
+        var textRect = new RectF(MathF.Round(alignX), MathF.Round(content.Y), alignWidth, content.Height);
+        _painter.DrawText(
+            text, textRect, style.Color, style.FontFamily, style.FontSize.Value, style.FontWeight,
+            style.TextAlign, VerticalAlign.Middle);
+
+        if (style.TextDecoration != Common.TextDecoration.None)
+        {
+            _painter.DrawTextDecoration(text, textRect, style.Color, style.FontFamily,
+                style.FontSize.Value, style.FontWeight, style.TextAlign, style.TextDecoration, VerticalAlign.Middle);
+        }
+    }
+
+    /// <summary>
+    /// 判断一个文本节点盒是否为其父元素唯一的在流行内内容（即父元素只有这一个非脱流子节点）。
+    /// 用于决定文本是否应以父内容盒作为 text-align 的对齐容器。
+    /// </summary>
+    private static bool IsSoleInFlowInlineChild(LayoutBox textBox)
+    {
+        var parentBox = textBox.Element.Parent?.LayoutBox;
+        if (parentBox == null) return false;
+
+        int inFlowCount = 0;
+        foreach (var sibling in parentBox.Children)
+        {
+            var pos = sibling.ComputedStyle.Position;
+            if (pos == Common.Position.Absolute || pos == Common.Position.Fixed) continue;
+            inFlowCount++;
+            if (inFlowCount > 1) return false;
+        }
+        return inFlowCount == 1;
     }
 
     /// <summary>

--- a/src/Miko/Styling/Selectors/PseudoClassSelectors.cs
+++ b/src/Miko/Styling/Selectors/PseudoClassSelectors.cs
@@ -67,24 +67,25 @@ public class EnabledSelector : PseudoClassSelector
 }
 
 /// <summary>
-/// :first-child 伪类选择器
+/// :first-child 伪类选择器。
+/// 依据 CSS 规范，子序号只计元素子节点，文本节点（TextNode）不计入（见 ISSUE-086）。
 /// </summary>
 public class FirstChildSelector : PseudoClassSelector
 {
     public override bool Matches(Element element)
     {
-        return element.Parent?.Children.FirstOrDefault() == element;
+        return element.Parent?.Children.FirstOrDefault(c => c is not TextNode) == element;
     }
 }
 
 /// <summary>
-/// :last-child 伪类选择器
+/// :last-child 伪类选择器。文本节点不计入子序号（见 ISSUE-086）。
 /// </summary>
 public class LastChildSelector : PseudoClassSelector
 {
     public override bool Matches(Element element)
     {
-        return element.Parent?.Children.LastOrDefault() == element;
+        return element.Parent?.Children.LastOrDefault(c => c is not TextNode) == element;
     }
 }
 
@@ -128,13 +129,16 @@ public class NotSelector : PseudoClassSelector
 }
 
 /// <summary>
-/// :empty 伪类选择器 - 匹配没有子元素且没有文本内容的元素
+/// :empty 伪类选择器 - 匹配没有子元素且没有文本内容的元素。
+/// 文本以 TextNode 子节点承载（见 ISSUE-086），因此需排除文本节点后判断是否还有元素子节点，
+/// 并确认无非空直接文本（TextContent facade 聚合直接文本节点）。
 /// </summary>
 public class EmptySelector : PseudoClassSelector
 {
     public override bool Matches(Element element)
     {
-        return element.Children.Count == 0 && string.IsNullOrEmpty(element.TextContent);
+        bool hasElementChild = element.Children.Any(c => c is not TextNode);
+        return !hasElementChild && string.IsNullOrEmpty(element.TextContent);
     }
 }
 

--- a/src/Miko/Styling/StyleResolver.cs
+++ b/src/Miko/Styling/StyleResolver.cs
@@ -102,6 +102,9 @@ public class StyleResolver
         style.TextAlign ??= parentStyle.TextAlign;
         style.LineHeight ??= parentStyle.LineHeight;
         style.PointerEvents ??= parentStyle.PointerEvents;
+        // WhiteSpace 在 CSS 中可继承：文本节点（TextNode）依赖它决定是否换行（如 nowrap），
+        // 因此必须从父元素继承，否则匿名文本会退回默认 Normal 而错误换行（见 ISSUE-086）。
+        style.WhiteSpace ??= parentStyle.WhiteSpace;
     }
 
     /// <summary>

--- a/tests/Miko.Tests/Components/MixedContentOrderTests.cs
+++ b/tests/Miko.Tests/Components/MixedContentOrderTests.cs
@@ -1,0 +1,109 @@
+using Miko.Components;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Shouldly;
+
+namespace Miko.Tests.Components;
+
+/// <summary>
+/// ISSUE-086：文本与标签混排时必须保留精确的交错顺序。
+///
+/// 历史上 <see cref="Element.TextContent"/> 是单一字符串，与 <see cref="Element.Children"/>
+/// 互不感知顺序，导致 <c>text1 &lt;span/&gt; text3</c> 被折叠为 <c>"text1 text3"</c> + span，
+/// 交错顺序丢失。现在文本以有序 <see cref="TextNode"/> 子节点承载，交错顺序由子节点列表表达。
+///
+/// 这些测试直接驱动 <see cref="RenderTreeBuilder"/>（即 Razor 编译器发射的调用序列），
+/// 验证真实构建路径下的交错顺序。
+/// </summary>
+public class MixedContentOrderTests
+{
+    /// <summary>
+    /// 示例1：<c>&lt;p&gt;we can use &lt;a&gt;stopPropagation&lt;/a&gt; to prevent bubbling.&lt;/p&gt;</c>
+    /// anchor 必须夹在两段文本之间。
+    /// </summary>
+    [Fact]
+    public void TextBeforeAndAfterInlineChild_PreservesInterleavedOrder()
+    {
+        var builder = new RenderTreeBuilder();
+        builder.OpenElement(0, "p");
+        builder.AddContent(1, "we can use ");
+        builder.OpenElement(2, "a");
+        builder.AddContent(3, "stopPropagation");
+        builder.CloseElement();
+        builder.AddContent(4, " to prevent bubbling.");
+        builder.CloseElement();
+
+        var p = builder.Build().ShouldBeOfType<ParagraphElement>();
+
+        // 三个子节点：文本 → anchor → 文本，顺序精确保留。
+        p.Children.Count.ShouldBe(3);
+        p.Children[0].ShouldBeOfType<TextNode>().Text.ShouldBe("we can use ");
+        var anchor = p.Children[1].ShouldBeOfType<AnchorElement>();
+        anchor.Children.Single().ShouldBeOfType<TextNode>().Text.ShouldBe("stopPropagation");
+        p.Children[2].ShouldBeOfType<TextNode>().Text.ShouldBe(" to prevent bubbling.");
+
+        // facade 拼接返回两段直接文本（不含子元素内文本），兼容旧读取。
+        p.TextContent.ShouldBe("we can use  to prevent bubbling.");
+    }
+
+    /// <summary>
+    /// 示例2：<c>&lt;div&gt;test1 &lt;span&gt;test2&lt;/span&gt; test3&lt;/div&gt;</c>
+    /// </summary>
+    [Fact]
+    public void TextSpanText_PreservesInterleavedOrder()
+    {
+        var builder = new RenderTreeBuilder();
+        builder.OpenElement(0, "div");
+        builder.AddContent(1, "test1 ");
+        builder.OpenElement(2, "span");
+        builder.AddContent(3, "test2");
+        builder.CloseElement();
+        builder.AddContent(4, " test3");
+        builder.CloseElement();
+
+        var div = builder.Build().ShouldBeOfType<DivElement>();
+
+        div.Children.Count.ShouldBe(3);
+        div.Children[0].ShouldBeOfType<TextNode>().Text.ShouldBe("test1 ");
+        div.Children[1].ShouldBeOfType<SpanElement>()
+            .Children.Single().ShouldBeOfType<TextNode>().Text.ShouldBe("test2");
+        div.Children[2].ShouldBeOfType<TextNode>().Text.ShouldBe(" test3");
+    }
+
+    [Fact]
+    public void ConsecutiveTextFragments_MergeIntoSingleTextNode()
+    {
+        // Razor 把 `Clicked @_count times` 编译为三次 AddContent；相邻纯文本片段应合并为一段。
+        var builder = new RenderTreeBuilder();
+        builder.OpenElement(0, "button");
+        builder.AddContent(1, "Clicked ");
+        builder.AddContent(2, 5);
+        builder.AddContent(3, " times");
+        builder.CloseElement();
+
+        var button = builder.Build().ShouldBeOfType<ButtonElement>();
+        // 无子元素分隔，三段文本合并为单个 TextNode。
+        button.Children.Count.ShouldBe(1);
+        button.Children[0].ShouldBeOfType<TextNode>().Text.ShouldBe("Clicked 5 times");
+        button.TextContent.ShouldBe("Clicked 5 times");
+    }
+
+    [Fact]
+    public void TextThenChildThenText_ProducesThreeChildrenNotConcatenated()
+    {
+        // 被子元素分隔的文本不合并：验证交错不会退化为单一 TextContent 串。
+        var builder = new RenderTreeBuilder();
+        builder.OpenElement(0, "div");
+        builder.AddContent(1, "A");
+        builder.OpenElement(2, "span");
+        builder.CloseElement();
+        builder.AddContent(3, "B");
+        builder.CloseElement();
+
+        var div = builder.Build();
+        div.Children.Count.ShouldBe(3);
+        div.Children[0].ShouldBeOfType<TextNode>().Text.ShouldBe("A");
+        div.Children[1].ShouldBeOfType<SpanElement>();
+        div.Children[2].ShouldBeOfType<TextNode>().Text.ShouldBe("B");
+    }
+}

--- a/tests/Miko.Tests/Core/TextNodeFacadeTests.cs
+++ b/tests/Miko.Tests/Core/TextNodeFacadeTests.cs
@@ -1,0 +1,102 @@
+using Miko.Core;
+using Miko.Core.DomElements;
+using Shouldly;
+
+namespace Miko.Tests.Core;
+
+/// <summary>
+/// ISSUE-086：<see cref="Element.TextContent"/> 作为便利外观（facade）的行为契约。
+///
+/// 文本以有序 <see cref="TextNode"/> 子节点承载。TextContent 的 get 拼接所有直接文本子节点，
+/// set 移除已有文本节点并（若非空）重建单个前置文本节点。此契约保护既有大量按字符串读写
+/// TextContent 的代码与测试。
+/// </summary>
+public class TextNodeFacadeTests
+{
+    [Fact]
+    public void Setter_CreatesSingleLeadingTextNode()
+    {
+        var div = new DivElement { TextContent = "hello" };
+
+        div.Children.Count.ShouldBe(1);
+        div.Children[0].ShouldBeOfType<TextNode>().Text.ShouldBe("hello");
+    }
+
+    [Fact]
+    public void Setter_InsertsTextBeforeExistingChildren()
+    {
+        var div = new DivElement();
+        div.AddChild(new SpanElement());
+        div.TextContent = "lead";
+
+        // 文本节点插入到索引 0，保持旧「文本在前」语义。
+        div.Children.Count.ShouldBe(2);
+        div.Children[0].ShouldBeOfType<TextNode>().Text.ShouldBe("lead");
+        div.Children[1].ShouldBeOfType<SpanElement>();
+    }
+
+    [Fact]
+    public void Getter_ReturnsNull_WhenNoTextNodes()
+    {
+        var div = new DivElement();
+        div.AddChild(new SpanElement());
+
+        div.TextContent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Getter_ConcatenatesDirectTextNodesOnly()
+    {
+        var div = new DivElement();
+        div.AddChild(new TextNode("a"));
+        var span = new SpanElement();
+        span.AddChild(new TextNode("INNER"));
+        div.AddChild(span);
+        div.AddChild(new TextNode("b"));
+
+        // 只拼接直接文本子节点，不含子元素内部文本。
+        div.TextContent.ShouldBe("ab");
+    }
+
+    [Fact]
+    public void Setter_Null_RemovesTextNodes_KeepsElementChildren()
+    {
+        var div = new DivElement { TextContent = "x" };
+        div.AddChild(new SpanElement());
+
+        div.TextContent = null;
+
+        div.Children.Count.ShouldBe(1);
+        div.Children[0].ShouldBeOfType<SpanElement>();
+        div.TextContent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Setter_Overwrite_ReplacesPreviousText()
+    {
+        var div = new DivElement { TextContent = "first" };
+        div.TextContent = "second";
+
+        div.Children.Count.ShouldBe(1);
+        div.Children[0].ShouldBeOfType<TextNode>().Text.ShouldBe("second");
+        div.TextContent.ShouldBe("second");
+    }
+
+    [Fact]
+    public void TextNode_TextContent_MapsToOwnText()
+    {
+        var node = new TextNode("abc");
+        node.TextContent.ShouldBe("abc");
+
+        node.TextContent = "xyz";
+        node.Text.ShouldBe("xyz");
+    }
+
+    [Fact]
+    public void Setter_RoundTrip_PreservesValue()
+    {
+        var div = new DivElement();
+        div.TextContent = "round trip";
+        div.TextContent.ShouldBe("round trip");
+    }
+}

--- a/tests/Miko.Tests/Core/TextNodeHitTestTests.cs
+++ b/tests/Miko.Tests/Core/TextNodeHitTestTests.cs
@@ -1,0 +1,81 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Styling;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Core;
+
+/// <summary>
+/// ISSUE-086：文本以 TextNode 子盒承载后，命中测试应对文本节点透明——点击文本时命中目标
+/// 解析为其包含元素（如 button），而非匿名文本节点，从而不破坏事件处理与冒泡。
+/// </summary>
+public class TextNodeHitTestTests
+{
+    private const float W = 400f;
+    private const float H = 300f;
+
+    private static MikoEngine CreateEngine(Element root, List<StyleSheet>? sheets = null)
+    {
+        var engine = new MikoEngine();
+        using var surface = SKSurface.Create(new SKImageInfo((int)W, (int)H));
+        engine.Initialize(root, sheets ?? new List<StyleSheet>(), surface.Canvas, W, H);
+        return engine;
+    }
+
+    [Fact]
+    public void ClickOnButtonText_HitsButtonNotTextNode()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".btn"] = new()
+            {
+                Width = Length.Px(200),
+                Height = Length.Px(60),
+                FontSize = Length.Px(16),
+            }
+        });
+
+        var button = new ButtonElement { Class = "btn", TextContent = "Click me" };
+        var root = new DivElement { Children = { button } };
+
+        var engine = CreateEngine(root, new List<StyleSheet> { sheet });
+
+        // 点击按钮内部（文本所在区域）。
+        var hit = engine.HitTest(20f, 20f);
+
+        hit.ShouldBe(button);
+        hit.ShouldNotBeOfType<TextNode>();
+    }
+
+    [Fact]
+    public void ClickOnMixedContentText_HitsContainingElement()
+    {
+        // <p>we can use <a>stopPropagation</a> ...</p>：点击首段文本应命中 p，而非文本节点。
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".para"] = new()
+            {
+                Width = Length.Px(400),
+                Height = Length.Px(40),
+                FontSize = Length.Px(16),
+            }
+        });
+
+        var p = new ParagraphElement { Class = "para" };
+        p.AddChild(new TextNode("we can use "));
+        p.AddChild(new AnchorElement { Children = { new TextNode("stopPropagation") } });
+        p.AddChild(new TextNode(" to prevent bubbling."));
+        var root = new DivElement { Children = { p } };
+
+        var engine = CreateEngine(root, new List<StyleSheet> { sheet });
+
+        // 命中第一段文本区域（靠近左上角）。
+        var hit = engine.HitTest(5f, 8f);
+        hit.ShouldNotBeNull();
+        hit.ShouldNotBeOfType<TextNode>();
+    }
+}

--- a/tests/Miko.Tests/Layout/FlexMixedContentTests.cs
+++ b/tests/Miko.Tests/Layout/FlexMixedContentTests.cs
@@ -7,8 +7,9 @@ using Shouldly;
 namespace Miko.Tests.Layout;
 
 /// <summary>
-/// ISSUE-085 问题1：flex 容器同时包含直接文本和子元素时的布局测试。
-/// 验证文本作为匿名 flex 项排在子元素之前，且参与 justify-content/align-items 对齐。
+/// ISSUE-085 问题1 / ISSUE-086：flex 容器同时包含直接文本和子元素时的布局测试。
+/// 文本以 TextNode 子盒形式作为普通 flex 项参与，排在 DOM 顺序对应的位置，
+/// 并与其它子元素一起参与 justify-content/align-items 对齐。
 /// </summary>
 public class FlexMixedContentTests
 {
@@ -38,6 +39,9 @@ public class FlexMixedContentTests
         return new List<StyleSheet> { sheet };
     }
 
+    private static LayoutBox TextBox(LayoutBox container) =>
+        container.Children.Single(c => c.Element is TextNode);
+
     [Fact]
     public void FlexContainer_WithTextAndChild_ShouldLayoutTextBeforeChild()
     {
@@ -48,12 +52,18 @@ public class FlexMixedContentTests
 
         var layout = _layoutEngine.Layout(root, BuildSheets(), 800, 600);
         var containerBox = layout.Children[0];
-        var childBox = containerBox.Children[0];
+
+        // 子节点顺序：文本节点在前（TextContent setter 插入到索引 0），子元素在后。
+        containerBox.Children[0].Element.ShouldBeOfType<TextNode>();
+        var textBox = containerBox.Children[0];
+        var childBox = containerBox.Children[1];
 
         float textWidth = Miko.Utils.TextMeasurer.MeasureTextWidth(
             "text", containerBox.ComputedStyle.FontFamily, 16f, containerBox.ComputedStyle.FontWeight);
 
-        // 文本在前，子元素应该从文本宽度之后开始
+        // 文本节点从内容盒左缘开始
+        textBox.BoxModel.Content.Left.ShouldBe(containerBox.BoxModel.Content.Left, 0.5f);
+        // 子元素应该从文本宽度之后开始
         childBox.BoxModel.Content.Left.ShouldBe(
             containerBox.BoxModel.Content.Left + textWidth, 0.5f,
             "Child should start after the text content");
@@ -87,7 +97,8 @@ public class FlexMixedContentTests
 
         var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, 800, 600);
         var containerBox = layout.Children[0];
-        var childBox = containerBox.Children[0];
+        var textBox = TextBox(containerBox);
+        var childBox = containerBox.Children[1];
 
         float textWidth = Miko.Utils.TextMeasurer.MeasureTextWidth(
             "text", containerBox.ComputedStyle.FontFamily, 16f, containerBox.ComputedStyle.FontWeight);
@@ -97,11 +108,12 @@ public class FlexMixedContentTests
         float expectedTextOffsetX = (300f - totalWidth) / 2f;
         float expectedTextOffsetY = (100f - textHeight) / 2f;
 
-        // 文本应该居中对齐
-        containerBox.TextContentOffsetX.ShouldBe(expectedTextOffsetX, 0.5f,
+        // 文本节点应该作为第一个 flex 项居中排布（含子元素整体居中）。
+        textBox.BoxModel.Content.Left.ShouldBe(
+            containerBox.BoxModel.Content.Left + expectedTextOffsetX, 0.5f,
             "Text should be horizontally centered along with child");
-        containerBox.TextContentOffsetY.ShouldBe(expectedTextOffsetY, 0.5f,
-            "Text should be vertically centered");
+        (textBox.BoxModel.Content.Top - containerBox.BoxModel.Content.Top).ShouldBe(
+            expectedTextOffsetY, 0.5f, "Text should be vertically centered");
 
         // 子元素也应该居中（在文本之后）
         childBox.BoxModel.Content.Left.ShouldBe(

--- a/tests/Miko.Tests/Layout/FlexTextAlignConflictTests.cs
+++ b/tests/Miko.Tests/Layout/FlexTextAlignConflictTests.cs
@@ -7,12 +7,18 @@ using Shouldly;
 namespace Miko.Tests.Layout;
 
 /// <summary>
-/// ISSUE-085 问题2：flex 容器同时设置 justify-content 和 text-align 时的冲突测试。
-/// TextAlign 应该在文本偏移后的矩形内居中，而不是相对原始内容盒居中。
+/// ISSUE-085 问题2 / ISSUE-086：flex 容器同时设置 justify-content 和 text-align。
+///
+/// ISSUE-086 后，文本作为 TextNode 子盒由 flex 布局定位；text-align 在渲染阶段以父内容盒为
+/// 对齐容器（当文本是唯一在流内容时）。因此布局阶段 justify-content 决定 TextNode 盒的位置，
+/// 不再存在 TextContentOffset 与 text-align 的叠加冲突。此处断言 TextNode 盒的 flex 定位正确。
 /// </summary>
 public class FlexTextAlignConflictTests
 {
     private readonly LayoutEngine _layoutEngine = new();
+
+    private static LayoutBox TextBox(LayoutBox container) =>
+        container.Children.Single(c => c.Element is TextNode);
 
     [Fact]
     public void FlexCenter_WithTextAlignCenter_ShouldCenterTextNotMoveToRight()
@@ -37,27 +43,22 @@ public class FlexTextAlignConflictTests
 
         var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, 800, 600);
         var containerBox = layout.Children[0];
+        var textBox = TextBox(containerBox);
 
         float textWidth = Miko.Utils.TextMeasurer.MeasureTextWidth(
             "text", containerBox.ComputedStyle.FontFamily, 16f, containerBox.ComputedStyle.FontWeight);
         float textHeight = Miko.Layout.LayoutAlgorithms.BlockLayout.ResolveLineHeight(containerBox.ComputedStyle);
 
-        // justify-content: center 应该将文本在容器中水平居中
-        float expectedOffsetX = (300f - textWidth) / 2f;
-        float expectedOffsetY = (100f - textHeight) / 2f;
-
-        containerBox.TextContentOffsetX.ShouldBe(expectedOffsetX, 0.5f,
-            "TextContentOffsetX should center the text horizontally");
-        containerBox.TextContentOffsetY.ShouldBe(expectedOffsetY, 0.5f,
-            "TextContentOffsetY should center the text vertically");
-
-        // text-align: center 不应该再次偏移文本（因为文本宽度等于textRect宽度，居中后位置不变）
-        // 问题：如果 text-align 相对于原始内容盒(300px)居中，而不是相对于textRect(textWidth)居中，
-        // 那么会产生额外的 (300 - textWidth) / 2 偏移，导致文本移到右边。
+        // justify-content: center 将 TextNode 盒在容器中水平居中；
+        // 文本宽度即 TextNode 盒宽度，渲染阶段 text-align:center 在文本自身宽度内无额外偏移。
+        (textBox.BoxModel.Content.Left - containerBox.BoxModel.Content.Left)
+            .ShouldBe((300f - textWidth) / 2f, 0.5f, "TextNode box should be centered horizontally by justify-content");
+        (textBox.BoxModel.Content.Top - containerBox.BoxModel.Content.Top)
+            .ShouldBe((100f - textHeight) / 2f, 0.5f, "TextNode box should be centered vertically by align-items");
     }
 
     [Fact]
-    public void FlexStart_WithTextAlignCenter_ShouldCenterTextInItsRect()
+    public void FlexStart_WithTextAlignCenter_ShouldLeaveTextNodeAtStart()
     {
         var sheet = new StyleSheet();
         sheet.Add(new CssObject
@@ -79,12 +80,11 @@ public class FlexTextAlignConflictTests
 
         var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, 800, 600);
         var containerBox = layout.Children[0];
+        var textBox = TextBox(containerBox);
 
-        // justify-content: flex-start 不产生偏移
-        containerBox.TextContentOffsetX.ShouldBe(0f, 0.01f);
-        containerBox.TextContentOffsetY.ShouldBe(0f, 0.01f);
-
-        // text-align: center 应该在整个容器宽度(300px)内居中文本
-        // 这种情况下 text-align 的行为是正确的
+        // justify-content: flex-start / align-items: flex-start：TextNode 盒锚定内容盒左上角。
+        // （text-align:center 的渲染阶段居中以父内容盒 300px 为参照，不影响布局盒位置。）
+        (textBox.BoxModel.Content.Left - containerBox.BoxModel.Content.Left).ShouldBe(0f, 0.01f);
+        (textBox.BoxModel.Content.Top - containerBox.BoxModel.Content.Top).ShouldBe(0f, 0.01f);
     }
 }

--- a/tests/Miko.Tests/Layout/FlexTextContentAlignmentTests.cs
+++ b/tests/Miko.Tests/Layout/FlexTextContentAlignmentTests.cs
@@ -7,11 +7,13 @@ using Shouldly;
 namespace Miko.Tests.Layout;
 
 /// <summary>
-/// ISSUE-085 回归测试：
-/// flex 容器的直接文本内容（无包裹元素）应作为匿名 flex 项参与
+/// ISSUE-085 / ISSUE-086 回归测试：
+/// flex 容器的直接文本内容（无包裹元素）应作为一等文本节点（TextNode）参与
 /// justify-content（主轴）与 align-items（交叉轴）对齐。
-/// 之前直接文本不是独立 LayoutBox，渲染阶段恒定锚定在内容盒左上角，
-/// 导致 JustifyContent / AlignItems 对其不起作用。
+///
+/// ISSUE-086 后，文本以有序 TextNode 子盒形式存在，直接被 flex 布局定位（不再通过
+/// 已废弃的 LayoutBox.TextContentOffsetX/Y 偏移）。因此断言改为检查 TextNode 子盒的
+/// 内容盒相对容器内容原点的位置。
 /// </summary>
 public class FlexTextContentAlignmentTests
 {
@@ -43,6 +45,18 @@ public class FlexTextContentAlignmentTests
         return layout.Children[0];
     }
 
+    /// <summary>容器内唯一的文本节点子盒。</summary>
+    private static LayoutBox TextBox(LayoutBox container) =>
+        container.Children.Single(c => c.Element is TextNode);
+
+    /// <summary>文本节点相对容器内容原点的偏移。</summary>
+    private static (float dx, float dy) TextOffset(LayoutBox container)
+    {
+        var text = TextBox(container).BoxModel.Content;
+        var content = container.BoxModel.Content;
+        return (text.X - content.X, text.Y - content.Y);
+    }
+
     [Fact]
     public void CenterCenter_ShouldCenterTextOnBothAxes()
     {
@@ -51,10 +65,11 @@ public class FlexTextContentAlignmentTests
         float textWidth = Miko.Utils.TextMeasurer.MeasureTextWidth("text", box.ComputedStyle.FontFamily, 16f, box.ComputedStyle.FontWeight);
         float lineHeight = Miko.Layout.LayoutAlgorithms.BlockLayout.ResolveLineHeight(box.ComputedStyle);
 
+        var (dx, dy) = TextOffset(box);
         // 主轴（水平）居中
-        box.TextContentOffsetX.ShouldBe((300f - textWidth) / 2f, 0.5f);
+        dx.ShouldBe((300f - textWidth) / 2f, 0.5f);
         // 交叉轴（垂直）居中
-        box.TextContentOffsetY.ShouldBe((300f - lineHeight) / 2f, 0.5f);
+        dy.ShouldBe((300f - lineHeight) / 2f, 0.5f);
     }
 
     [Fact]
@@ -62,8 +77,9 @@ public class FlexTextContentAlignmentTests
     {
         var box = LayoutContainer(JustifyContent.FlexStart, AlignItems.FlexStart);
 
-        box.TextContentOffsetX.ShouldBe(0f, 0.01f);
-        box.TextContentOffsetY.ShouldBe(0f, 0.01f);
+        var (dx, dy) = TextOffset(box);
+        dx.ShouldBe(0f, 0.01f);
+        dy.ShouldBe(0f, 0.01f);
     }
 
     [Fact]
@@ -74,8 +90,9 @@ public class FlexTextContentAlignmentTests
         float textWidth = Miko.Utils.TextMeasurer.MeasureTextWidth("text", box.ComputedStyle.FontFamily, 16f, box.ComputedStyle.FontWeight);
         float lineHeight = Miko.Layout.LayoutAlgorithms.BlockLayout.ResolveLineHeight(box.ComputedStyle);
 
-        box.TextContentOffsetX.ShouldBe(300f - textWidth, 0.5f);
-        box.TextContentOffsetY.ShouldBe(300f - lineHeight, 0.5f);
+        var (dx, dy) = TextOffset(box);
+        dx.ShouldBe(300f - textWidth, 0.5f);
+        dy.ShouldBe(300f - lineHeight, 0.5f);
     }
 
     [Fact]
@@ -102,9 +119,10 @@ public class FlexTextContentAlignmentTests
         float textWidth = Miko.Utils.TextMeasurer.MeasureTextWidth("text", box.ComputedStyle.FontFamily, 16f, box.ComputedStyle.FontWeight);
         float lineHeight = Miko.Layout.LayoutAlgorithms.BlockLayout.ResolveLineHeight(box.ComputedStyle);
 
+        var (dx, dy) = TextOffset(box);
         // 交叉轴（水平）居中
-        box.TextContentOffsetX.ShouldBe((300f - textWidth) / 2f, 0.5f);
+        dx.ShouldBe((300f - textWidth) / 2f, 0.5f);
         // 主轴（垂直）flex-end
-        box.TextContentOffsetY.ShouldBe(300f - lineHeight, 0.5f);
+        dy.ShouldBe(300f - lineHeight, 0.5f);
     }
 }

--- a/tests/Miko.Tests/Layout/InlineMixedContentTests.cs
+++ b/tests/Miko.Tests/Layout/InlineMixedContentTests.cs
@@ -81,7 +81,9 @@ public class InlineMixedContentTests
         var layout = _layoutEngine.Layout(button, DefaultStyleSheets(), 800, 600);
 
         float textWidth = MeasureWidth("Notifications");
-        var spanBox = layout.Children[0];
+        // 子节点顺序：文本节点在前（Children[0]），span 在后（Children[1]）。
+        layout.Children[0].Element.ShouldBeOfType<TextNode>();
+        var spanBox = layout.Children[1];
 
         // ISSUE-037: 之前 button 宽度只等于 span 的宽度，忽略了 "Notifications" 文本。
         // 正确行为：内容宽度应当同时包含文本宽度与 span 宽度。
@@ -102,7 +104,9 @@ public class InlineMixedContentTests
         var layout = _layoutEngine.Layout(button, DefaultStyleSheets(), 800, 600);
 
         float textWidth = MeasureWidth("Notifications");
-        var spanBox = layout.Children[0];
+        // 子节点顺序：文本节点在前（Children[0]），span 在后（Children[1]）。
+        layout.Children[0].Element.ShouldBeOfType<TextNode>();
+        var spanBox = layout.Children[1];
 
         spanBox.BoxModel.MarginBox.Left.ShouldBe(
             layout.BoxModel.Content.Left + textWidth, 0.5f,

--- a/tests/Miko.Tests/Layout/LayoutEngineTests.cs
+++ b/tests/Miko.Tests/Layout/LayoutEngineTests.cs
@@ -3397,7 +3397,9 @@ public class LayoutEngineTests
 
         var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
 
-        var childBox = layoutRoot.Children[0];
+        // 子节点顺序：文本节点在前（Children[0]），block 子元素在后（Children[1]）。
+        layoutRoot.Children[0].Element.ShouldBeOfType<TextNode>();
+        var childBox = layoutRoot.Children[1];
 
         // The child block must be positioned below the parent's own text line,
         // not at the very top (which would overlap the text).
@@ -3435,7 +3437,9 @@ public class LayoutEngineTests
 
         var layoutRoot = _layoutEngine.Layout(root, styleSheets, 800, 600);
 
-        var spanBox = layoutRoot.Children[0];
+        // 子节点顺序：文本节点在前（Children[0]），span 在后（Children[1]）。
+        layoutRoot.Children[0].Element.ShouldBeOfType<TextNode>();
+        var spanBox = layoutRoot.Children[1];
 
         // The span should be on the same line as the parent's text,
         // positioned horizontally after the text width, not below it.

--- a/tests/Miko.Tests/Layout/MixedContentLayoutTests.cs
+++ b/tests/Miko.Tests/Layout/MixedContentLayoutTests.cs
@@ -1,0 +1,118 @@
+using Miko.Common;
+using Miko.Components;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+
+namespace Miko.Tests.Layout;
+
+/// <summary>
+/// ISSUE-086：文本与标签混排的布局验证。
+/// 交错的 text/element 子盒应按 DOM 顺序水平排列，位置单调递增，互不重叠。
+/// </summary>
+public class MixedContentLayoutTests
+{
+    private readonly LayoutEngine _layoutEngine = new();
+
+    private static List<StyleSheet> Sheets() => new()
+    {
+        new StyleSheet
+        {
+            Rules = new List<StyleRule>
+            {
+                new() { Selector = new TagSelector("p"), Style = new Style { Display = Display.Block, Width = Length.Px(600), FontSize = Length.Px(16) } },
+                new() { Selector = new TagSelector("div"), Style = new Style { Display = Display.Block, Width = Length.Px(600), FontSize = Length.Px(16) } },
+                new() { Selector = new TagSelector("a"), Style = new Style { Display = Display.Inline } },
+                new() { Selector = new TagSelector("span"), Style = new Style { Display = Display.Inline } },
+            }
+        }
+    };
+
+    /// <summary>构建 <c>&lt;p&gt;we can use &lt;a&gt;stopPropagation&lt;/a&gt; to prevent bubbling.&lt;/p&gt;</c>。</summary>
+    private Element BuildExample1()
+    {
+        var builder = new RenderTreeBuilder();
+        builder.OpenElement(0, "p");
+        builder.AddContent(1, "we can use ");
+        builder.OpenElement(2, "a");
+        builder.AddContent(3, "stopPropagation");
+        builder.CloseElement();
+        builder.AddContent(4, " to prevent bubbling.");
+        builder.CloseElement();
+        return builder.Build();
+    }
+
+    [Fact]
+    public void Example1_AnchorSitsBetweenTwoTextRuns()
+    {
+        var p = BuildExample1();
+        var layout = _layoutEngine.Layout(p, Sheets(), 800, 600);
+
+        // 子盒顺序：文本 → anchor → 文本。
+        layout.Children.Count.ShouldBe(3);
+        layout.Children[0].Element.ShouldBeOfType<TextNode>();
+        var anchorBox = layout.Children[1];
+        anchorBox.Element.ShouldBeOfType<AnchorElement>();
+        layout.Children[2].Element.ShouldBeOfType<TextNode>();
+
+        var text1 = layout.Children[0].BoxModel.Content;
+        var anchor = anchorBox.BoxModel.MarginBox;
+        var text2 = layout.Children[2].BoxModel.Content;
+
+        // 水平位置单调递增：text1 在 anchor 左侧，anchor 在 text2 左侧。
+        text1.Left.ShouldBe(layout.BoxModel.Content.Left, 0.5f);
+        anchor.Left.ShouldBe(text1.Right, 1f, "anchor 紧跟第一段文本之后");
+        text2.Left.ShouldBe(anchor.Right, 1f, "第二段文本紧跟 anchor 之后");
+
+        // 三者在同一行（顶部对齐）。
+        anchor.Top.ShouldBe(text1.Top, 1f);
+        text2.Top.ShouldBe(text1.Top, 1f);
+    }
+
+    [Fact]
+    public void Example2_TextSpanText_LaysOutInOrder()
+    {
+        // <div>test1 <span>test2</span> test3</div>
+        var builder = new RenderTreeBuilder();
+        builder.OpenElement(0, "div");
+        builder.AddContent(1, "test1 ");
+        builder.OpenElement(2, "span");
+        builder.AddContent(3, "test2");
+        builder.CloseElement();
+        builder.AddContent(4, " test3");
+        builder.CloseElement();
+        var div = builder.Build();
+
+        var layout = _layoutEngine.Layout(div, Sheets(), 800, 600);
+
+        layout.Children.Count.ShouldBe(3);
+        var t1 = layout.Children[0].BoxModel.Content;
+        var span = layout.Children[1].BoxModel.MarginBox;
+        var t3 = layout.Children[2].BoxModel.Content;
+
+        t1.Left.ShouldBe(layout.BoxModel.Content.Left, 0.5f);
+        span.Left.ShouldBe(t1.Right, 1f);
+        t3.Left.ShouldBe(span.Right, 1f);
+
+        // test3 的右缘应等于三段内容累加宽度（不塌缩、不重叠）。
+        t3.Right.ShouldBeGreaterThan(span.Right);
+    }
+
+    [Fact]
+    public void MixedContent_TotalWidthIncludesAllRuns()
+    {
+        var p = BuildExample1();
+        var layout = _layoutEngine.Layout(p, Sheets(), 800, 600);
+
+        float w1 = layout.Children[0].BoxModel.Content.Width;
+        float wAnchor = layout.Children[1].BoxModel.MarginBox.Width;
+        float w2 = layout.Children[2].BoxModel.Content.Width;
+
+        float rightmost = layout.Children[2].BoxModel.Content.Right - layout.BoxModel.Content.Left;
+        rightmost.ShouldBe(w1 + wAnchor + w2, 1.5f,
+            "内容总宽应为三段（文本+anchor+文本）之和");
+    }
+}

--- a/tests/Miko.Tests/Rendering/MixedContentRenderTests.cs
+++ b/tests/Miko.Tests/Rendering/MixedContentRenderTests.cs
@@ -1,0 +1,112 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Rendering;
+using Miko.Styling;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Rendering;
+
+/// <summary>
+/// ISSUE-086 端到端渲染验证：文本与标签混排时，各段按 DOM 顺序水平绘制，互不重叠、顺序正确。
+/// 通过在离屏画布上着色中间的 span，并检查其像素落在两段文本之间的水平区间内来验证渲染顺序。
+/// </summary>
+public class MixedContentRenderTests : IDisposable
+{
+    private readonly SKBitmap _bitmap;
+    private readonly SKCanvas _canvas;
+    private readonly RenderEngine _renderEngine;
+    private readonly LayoutEngine _layoutEngine;
+
+    public MixedContentRenderTests()
+    {
+        _bitmap = new SKBitmap(600, 200);
+        _canvas = new SKCanvas(_bitmap);
+        _canvas.Clear(SKColors.White);
+        _renderEngine = new RenderEngine();
+        _renderEngine.SetCanvas(_canvas);
+        _layoutEngine = new LayoutEngine();
+    }
+
+    public void Dispose()
+    {
+        _canvas.Dispose();
+        _bitmap.Dispose();
+    }
+
+    [Fact]
+    public void TextSpanText_RendersSpanBetweenTextRuns()
+    {
+        // <div>test1 <span style="background:red">test2</span> test3</div>
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".host"] = new()
+            {
+                Width = Length.Px(600),
+                Height = Length.Px(60),
+                FontSize = Length.Px(20),
+            },
+            [".mid"] = new()
+            {
+                Display = Display.Inline,
+                BackgroundColor = Color.FromRgb(255, 0, 0),
+                Color = Color.FromRgb(255, 0, 0),
+            }
+        });
+
+        var div = new DivElement { Class = "host" };
+        div.AddChild(new TextNode("test1 "));
+        var span = new SpanElement { Class = "mid" };
+        span.AddChild(new TextNode("test2"));
+        div.AddChild(span);
+        div.AddChild(new TextNode(" test3"));
+
+        var root = new DivElement { Children = { div } };
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, 600, 200);
+        _renderEngine.Render(layout);
+
+        // 取三段子盒的水平区间。
+        var hostBox = layout.Children[0];
+        hostBox.Children.Count.ShouldBe(3);
+        var t1 = hostBox.Children[0].BoxModel.Content;
+        var spanBox = hostBox.Children[1].BoxModel.BorderBox;
+        var t3 = hostBox.Children[2].BoxModel.Content;
+
+        // 顺序：t1 在 span 左，span 在 t3 左。
+        spanBox.Left.ShouldBeGreaterThanOrEqualTo(t1.Right - 1f);
+        t3.Left.ShouldBeGreaterThanOrEqualTo(spanBox.Right - 1f);
+
+        // 在 span 的红色背景区间内应能采到红色像素。
+        int y = (int)(spanBox.Top + spanBox.Height / 2f);
+        int spanMidX = (int)(spanBox.Left + spanBox.Width / 2f);
+        bool foundRed = false;
+        for (int dx = -3; dx <= 3 && !foundRed; dx++)
+        {
+            var c = _bitmap.GetPixel(Math.Clamp(spanMidX + dx, 0, _bitmap.Width - 1), Math.Clamp(y, 0, _bitmap.Height - 1));
+            if (c.Red > 180 && c.Green < 80 && c.Blue < 80) foundRed = true;
+        }
+        foundRed.ShouldBeTrue("span 的红色应绘制在两段文本之间的区间内");
+
+        // 第一段文本区间内不应出现 span 的红色背景（顺序未错乱）。
+        int t1MidX = (int)(t1.Left + Math.Max(2f, t1.Width / 2f));
+        var t1Pixel = _bitmap.GetPixel(Math.Clamp(t1MidX, 0, _bitmap.Width - 1), Math.Clamp(y, 0, _bitmap.Height - 1));
+        (t1Pixel.Red > 180 && t1Pixel.Green < 80 && t1Pixel.Blue < 80).ShouldBeFalse(
+            "第一段文本区间不应被 span 的红色覆盖");
+    }
+
+    [Fact]
+    public void MixedContent_RendersWithoutError()
+    {
+        // 示例1：<p>we can use <a>stopPropagation</a> to prevent bubbling.</p>
+        var p = new ParagraphElement();
+        p.AddChild(new TextNode("we can use "));
+        p.AddChild(new AnchorElement { Children = { new TextNode("stopPropagation") } });
+        p.AddChild(new TextNode(" to prevent bubbling."));
+
+        var layout = _layoutEngine.Layout(p, new List<StyleSheet>(), 600, 200);
+        Should.NotThrow(() => _renderEngine.Render(layout));
+    }
+}

--- a/tests/Miko.Tests/Styling/StructuralPseudoClassTests.cs
+++ b/tests/Miko.Tests/Styling/StructuralPseudoClassTests.cs
@@ -208,4 +208,51 @@ public class StructuralPseudoClassTests
         new StyleResolver().Resolve(first, [sheet]).BackgroundColor.ShouldBe(Color.Transparent);
         new StyleResolver().Resolve(second, [sheet]).BackgroundColor.ShouldBe(Color.Red);
     }
+
+    // ISSUE-086：文本节点（TextNode）不计入 :first-child / :last-child 子序号，与 CSS 规范一致。
+
+    [Fact]
+    public void FirstChild_ShouldIgnoreLeadingTextNode()
+    {
+        // <div>lead text<span/></div>：span 前有文本节点，但 span 仍是 :first-child。
+        var parent = new DivElement { TextContent = "lead text" };
+        var span = new SpanElement();
+        parent.AddChild(span);
+
+        // 子节点：[TextNode, span]
+        parent.Children[0].ShouldBeOfType<TextNode>();
+        new FirstChildSelector().Matches(span).ShouldBeTrue();
+        new FirstChildSelector().Matches(parent.Children[0]).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LastChild_ShouldIgnoreTrailingTextNode()
+    {
+        // <div><span/>trailing</div>：span 后有文本节点，但 span 仍是 :last-child。
+        var parent = new DivElement();
+        var span = new SpanElement();
+        parent.AddChild(span);
+        parent.AddChild(new TextNode("trailing"));
+
+        new LastChildSelector().Matches(span).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Empty_ShouldNotMatchElementWithText()
+    {
+        var withText = new DivElement { TextContent = "x" };
+        var trulyEmpty = new DivElement();
+
+        new EmptySelector().Matches(withText).ShouldBeFalse();
+        new EmptySelector().Matches(trulyEmpty).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Empty_ShouldNotMatchElementWithOnlyElementChild()
+    {
+        var parent = new DivElement();
+        parent.AddChild(new SpanElement());
+
+        new EmptySelector().Matches(parent).ShouldBeFalse();
+    }
 }


### PR DESCRIPTION
## Background

`ISSUE-086`: mixed text and elements (e.g. `text1 <span/> text3`) render in the wrong order. The root cause is the DOM data model — `Element.TextContent` is a single string that has no notion of order relative to `Children`, so interleaved content cannot be represented. The `ISSUE-085` patches (`TextContentOffsetX/Y`, anonymous flex item, etc.) only worked around this without addressing the root cause.

## Approach

Introduce a first-class text node **`TextNode : Element`** (reusing the `PseudoElement`/`FragmentElement` pattern): text is carried as ordered `TextNode` children, so interleaving is expressed naturally by the `Children` list. `Element.TextContent` becomes a compatibility facade, protecting the large amount of existing code that reads/writes it as a string.

### Core changes
- Add `TextNode`, `LayoutType.Text`, `TextLayout`.
- `TextContent` becomes a facade (get concatenates child text nodes; set rebuilds a single leading text node).
- `RenderTreeBuilder.AddContent` / `ParseMarkup` append `TextNode` children (the sole point where order was lost).
- The three layout algorithms treat `TextNode` as an ordinary inline child box — **all ownText special-casing removed**.
- **Remove the ISSUE-085 patches**: `LayoutBox.TextContentOffsetX/Y`, the anonymous flex item, the `startIndex` hack, `AlignMainAxis/AlignCrossAxis`, and the RenderEngine offset replay.
- `RenderEngine.RenderTextNode` draws each text box; pixel alignment (anti-aliasing) preserved.

### Compatibility fixes (all covered by tests)
- `HitTestBox` is transparent to `TextNode` → clicking text resolves to the containing element.
- `:first-child` / `:last-child` / `:empty` skip `TextNode` (per CSS, text nodes are not element children).
- `StyleResolver` inherits `WhiteSpace` (fixes `nowrap`); pseudo-element `content` text mirrors parent styles.
- `InlineLayout` passes wrap width to `TextNode` children (also fixes ISSUE-079-style inline wrapping).
- `Miko.Testing.GetTextContent` collects `TextNode` leaves only; the DevTools DOM tree skips text nodes.

## Testing

- **Miko.Tests: 1083/1083** ✅ (1060 baseline + 23 new)
- **Miko.Ionic.Tests: 307/307** ✅
- `dotnet build miko.slnx` — 0 errors
- New coverage: example 1/example 2 interleaving order, facade contract, mixed-content layout coordinates, hit-test transparency, pseudo-class child indexing, and **pixel-level render order** (verifying the span background actually lands between the two text runs).

## Notes

Also includes 4 previously-staged changes unrelated to this refactor: 3 example `.csproj` files switched to local `ProjectReference`, plus a minor `GlobalStyles.cs` tweak.

See `issues/ISSUE-086-REFACTOR-PLAN.md` in the repo for the design and implementation details.