### PR TITLE
feat(rendering): add Input/TextArea overflow handling with text clipping

### DIFF
--- a/src/Miko/Components/RenderTreeBuilder.cs
+++ b/src/Miko/Components/RenderTreeBuilder.cs
@@ -23,10 +23,13 @@ public class RenderTreeBuilder
         ["p"] = () => new ParagraphElement(),
         ["button"] = () => new ButtonElement(),
         ["input"] = () => new InputElement(),
+        ["textarea"] = () => new TextAreaElement(),
         ["select"] = () => new SelectElement(),
         ["option"] = () => new OptionElement(),
         ["optgroup"] = () => new OptGroupElement(),
         ["label"] = () => new LabelElement(),
+        ["br"] = () => new BrElement(),
+        ["hr"] = () => new HrElement(),
         ["h1"] = () => new H1Element(),
         ["h2"] = () => new H2Element(),
         ["h3"] = () => new H3Element(),
@@ -39,6 +42,9 @@ public class RenderTreeBuilder
         ["img"] = () => new ImageElement(),
         ["video"] = () => new VideoElement(),
         ["table"] = () => new TableElement(),
+        ["caption"] = () => new CaptionElement(),
+        ["colgroup"] = () => new ColgroupElement(),
+        ["col"] = () => new ColElement(),
         ["thead"] = () => new TheadElement(),
         ["tbody"] = () => new TbodyElement(),
         ["tfoot"] = () => new TfootElement(),
@@ -59,12 +65,30 @@ public class RenderTreeBuilder
     public void CloseElement()
     {
         var element = _stack.Pop();
+        NormalizeTextArea(element);
         if (_stack.Count > 0)
             _stack.Peek().AddChild(element);
         else
             // 顶层元素：经 AttachToTree 处理多根（多个顶层元素并入一个透明片段），
             // 避免后一个根覆盖前一个（如 <video/> 之后再跟条件块时丢失 video）。
             AttachToTree(element);
+    }
+
+    /// <summary>
+    /// HTML 中 textarea 的初始文本写在标签内容里（<c>&lt;textarea&gt;初始值&lt;/textarea&gt;</c>），
+    /// 而非 value 属性。这里把其子文本节点回收进 <see cref="TextAreaElement.Value"/> 并移除，
+    /// 使这些文本作为可编辑内容由元素统一渲染，而不是作为普通子节点参与布局。
+    /// 若 value 属性已显式提供，则以属性为准，仅清理子文本节点。
+    /// </summary>
+    private static void NormalizeTextArea(Element element)
+    {
+        if (element is not TextAreaElement textArea) return;
+        var childText = textArea.TextContent;
+        if (textArea.Value is null && !string.IsNullOrEmpty(childText))
+        {
+            textArea.Value = childText;
+        }
+        textArea.Children.RemoveAll(c => c is TextNode);
     }
 
     public void AddAttribute(int seq, string name, string? value)
@@ -101,6 +125,16 @@ public class RenderTreeBuilder
                 img.Source = value; break;
             case "placeholder" when element is ImageElement placeholderImg:
                 placeholderImg.Placeholder = value; break;
+            case "placeholder" when element is TextAreaElement textArea:
+                textArea.Placeholder = value; break;
+            case "value" when element is TextAreaElement valueTextArea:
+                valueTextArea.Value = value; break;
+            case "rows" when element is TextAreaElement rowsTextArea:
+                if (int.TryParse(value, out var rows)) rowsTextArea.Rows = rows;
+                break;
+            case "cols" when element is TextAreaElement colsTextArea:
+                if (int.TryParse(value, out var cols)) colsTextArea.Cols = cols;
+                break;
             case "src" when element is VideoElement video:
                 video.Source = value; break;
             case "poster" when element is VideoElement video:
@@ -307,6 +341,7 @@ public class RenderTreeBuilder
                 if (localStack.Count > 0)
                 {
                     var el = localStack.Pop();
+                    NormalizeTextArea(el);
                     if (localStack.Count > 0)
                         localStack.Peek().AddChild(el);
                     else
@@ -342,6 +377,7 @@ public class RenderTreeBuilder
         while (localStack.Count > 0)
         {
             var el = localStack.Pop();
+            NormalizeTextArea(el);
             if (localStack.Count > 0)
                 localStack.Peek().AddChild(el);
             else

--- a/src/Miko/Core/DomElements/ITextEditable.cs
+++ b/src/Miko/Core/DomElements/ITextEditable.cs
@@ -1,0 +1,34 @@
+namespace Miko.Core.DomElements;
+
+/// <summary>
+/// 可编辑文本控件的公共抽象：由 <see cref="InputElement"/>（单行文本类）与
+/// <see cref="TextAreaElement"/>（多行）实现，供
+/// <see cref="Miko.Platform.MikoInteractionController"/> 以统一方式处理键盘编辑与文本输入
+/// （插入、退格、删除、光标移动），避免为每种控件重复实现相同的编辑逻辑。
+/// </summary>
+public interface ITextEditable
+{
+    /// <summary>当前文本值</summary>
+    string? Value { get; set; }
+
+    /// <summary>光标位置（字符索引）</summary>
+    int CursorPosition { get; set; }
+
+    /// <summary>是否接受编辑（如 InputElement 仅在文本/密码类型时可编辑）</summary>
+    bool IsEditable { get; }
+
+    /// <summary>是否为多行控件（多行控件的回车键应插入换行而非提交）</summary>
+    bool IsMultiline { get; }
+
+    /// <summary>在光标处插入文本</summary>
+    void InsertText(string text);
+
+    /// <summary>删除光标前一个字符，成功返回 true</summary>
+    bool Backspace();
+
+    /// <summary>删除光标后一个字符，成功返回 true</summary>
+    bool Delete();
+
+    /// <summary>将光标移动到文本末尾</summary>
+    void MoveCursorToEnd();
+}

--- a/src/Miko/Core/DomElements/InteractiveElements.cs
+++ b/src/Miko/Core/DomElements/InteractiveElements.cs
@@ -36,7 +36,7 @@ public class ButtonElement : Element
 /// <summary>
 /// 输入框元素
 /// </summary>
-public class InputElement : Element
+public class InputElement : Element, ITextEditable
 {
     public override string TagName => "input";
 
@@ -44,6 +44,16 @@ public class InputElement : Element
     /// 输入框类型，默认为 Text
     /// </summary>
     public InputType Type { get; set; } = InputType.Text;
+
+    /// <summary>
+    /// input 仅在文本 / 密码类型下接受键盘文本编辑。
+    /// </summary>
+    public bool IsEditable => Type is InputType.Text or InputType.Password;
+
+    /// <summary>
+    /// input 始终为单行控件。
+    /// </summary>
+    public bool IsMultiline => false;
 
     /// <summary>
     /// 输入框的值
@@ -74,6 +84,109 @@ public class InputElement : Element
     /// 当前数值（用于 Range）
     /// </summary>
     public float NumericValue { get; set; } = 50;
+
+    /// <summary>
+    /// 光标位置（字符索引）
+    /// </summary>
+    public int CursorPosition { get; set; }
+
+    /// <summary>
+    /// 插入文本到当前光标位置
+    /// </summary>
+    public void InsertText(string text)
+    {
+        var current = Value ?? string.Empty;
+        var pos = Math.Clamp(CursorPosition, 0, current.Length);
+        Value = current.Insert(pos, text);
+        CursorPosition = pos + text.Length;
+        IsDirty = true;
+    }
+
+    /// <summary>
+    /// 删除光标前一个字符
+    /// </summary>
+    public bool Backspace()
+    {
+        var current = Value ?? string.Empty;
+        if (CursorPosition > 0 && current.Length > 0)
+        {
+            var pos = Math.Clamp(CursorPosition, 0, current.Length);
+            Value = current.Remove(pos - 1, 1);
+            CursorPosition = pos - 1;
+            IsDirty = true;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// 删除光标后一个字符
+    /// </summary>
+    public bool Delete()
+    {
+        var current = Value ?? string.Empty;
+        if (CursorPosition < current.Length)
+        {
+            Value = current.Remove(CursorPosition, 1);
+            IsDirty = true;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// 将光标移动到文本末尾
+    /// </summary>
+    public void MoveCursorToEnd()
+    {
+        CursorPosition = (Value ?? string.Empty).Length;
+    }
+}
+
+/// <summary>
+/// 多行文本输入框元素 (textarea)。
+///
+/// 与 <see cref="InputElement"/>（单行）不同，textarea 支持多行文本：其内容高度默认由
+/// <see cref="Rows"/> 行文本撑起（见 UA 默认样式），并支持插入换行符。文本编辑逻辑
+/// （插入 / 删除 / 光标移动）与 <see cref="InputElement"/> 保持一致的语义。
+///
+/// HTML 中 textarea 的初始文本写在标签内容里而非 value 属性，因此
+/// <see cref="Miko.Components.RenderTreeBuilder"/> 会把其子文本节点回收进 <see cref="Value"/>，
+/// 使这些文本不作为普通子节点参与布局，而是作为可编辑内容由本元素统一渲染。
+/// </summary>
+public class TextAreaElement : Element, ITextEditable
+{
+    public override string TagName => "textarea";
+
+    /// <summary>
+    /// 文本内容
+    /// </summary>
+    public string? Value { get; set; }
+
+    /// <summary>
+    /// textarea 始终接受键盘文本编辑。
+    /// </summary>
+    public bool IsEditable => true;
+
+    /// <summary>
+    /// textarea 是多行控件（回车插入换行）。
+    /// </summary>
+    public bool IsMultiline => true;
+
+    /// <summary>
+    /// 占位符文本
+    /// </summary>
+    public string? Placeholder { get; set; }
+
+    /// <summary>
+    /// 可见行数（默认 2，与浏览器一致），用于自动高度计算
+    /// </summary>
+    public int Rows { get; set; } = 2;
+
+    /// <summary>
+    /// 可见列数（默认 20，与浏览器一致），用于自动宽度计算
+    /// </summary>
+    public int Cols { get; set; } = 20;
 
     /// <summary>
     /// 光标位置（字符索引）

--- a/src/Miko/Core/DomElements/TextElements.cs
+++ b/src/Miko/Core/DomElements/TextElements.cs
@@ -1,0 +1,26 @@
+namespace Miko.Core.DomElements;
+
+/// <summary>
+/// 强制换行元素 (br)。
+///
+/// <c>br</c> 是行内级的空元素：它不产生任何可见盒，但会强制结束当前行盒，
+/// 使其后的行内内容排到新的一行。布局阶段由
+/// <see cref="Layout.LayoutAlgorithms.BlockLayout"/> 识别并作为“行分隔标记”处理
+/// （见 <see cref="Layout.LayoutAlgorithms.BlockLayout.IsForcedLineBreak"/>）。
+/// </summary>
+public class BrElement : Element
+{
+    public override string TagName => "br";
+}
+
+/// <summary>
+/// 主题分隔线元素 (hr)。
+///
+/// <c>hr</c> 是块级元素，浏览器默认渲染为一条水平分隔线。Miko 通过 UA 默认样式
+/// （<see cref="Styling.StyleResolver"/>）为其设置一条上边框来绘制该线条，内容高度为 0，
+/// 因此无需在渲染层做特殊处理，直接复用既有的边框绘制路径。
+/// </summary>
+public class HrElement : Element
+{
+    public override string TagName => "hr";
+}

--- a/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
@@ -77,8 +77,9 @@ public class BlockLayout
         else if (constraints.IsInfiniteWidth || containerWidth <= 0)
         {
             // 当没有可用宽度约束时（如在 flex row 容器中），根据内容计算宽度（shrink-to-fit）。
-            // 以 null 约束预布局在流子元素（含文本节点），取其行内排列后的最右边界作为内容宽度。
-            contentWidth = MeasureInlineChildrenWidth(box);
+            // textarea 有由 cols 决定的固有宽度；否则以 null 约束预布局在流子元素（含文本节点），
+            // 取其行内排列后的最右边界作为内容宽度。
+            contentWidth = GetTextFormControlContentWidth(box) ?? MeasureInlineChildrenWidth(box);
         }
         else
         {
@@ -206,6 +207,18 @@ public class BlockLayout
                        && !IsOutOfFlow(box.Children[i]))
                 {
                     var inlineChild = box.Children[i];
+
+                    // 遇到强制换行标记（br）：结束当前行盒，其后的行内内容排到新的一行。
+                    // br 自身不占宽度，但会贡献至少一行的高度（保证空 br 也能换行）。
+                    if (IsForcedLineBreak(inlineChild))
+                    {
+                        var brConstraints = new LayoutConstraints(0, null);
+                        LayoutChild(inlineChild, brConstraints, lineX, currentY);
+                        lineHeight = Math.Max(lineHeight, ResolveLineHeight(box.ComputedStyle));
+                        i++;
+                        break;
+                    }
+
                     // 传入父内容宽度作为可用宽度，使 inline-block 子元素的百分比宽度
                     // 能相对包含块解析（auto 宽度仍由内容决定，不受影响）。
                     var childConstraints = new LayoutConstraints(childAvailableWidth, childAvailableHeight);
@@ -351,6 +364,16 @@ public class BlockLayout
                        && !IsOutOfFlow(box.Children[i]))
                 {
                     var inlineChild = box.Children[i];
+
+                    // 强制换行标记（br）：结束当前行盒（见主布局逻辑说明）。
+                    if (IsForcedLineBreak(inlineChild))
+                    {
+                        LayoutChild(inlineChild, new LayoutConstraints(0, null), lineX, currentY);
+                        lineHeight = Math.Max(lineHeight, ResolveLineHeight(box.ComputedStyle));
+                        i++;
+                        break;
+                    }
+
                     // 传入父内容宽度，使 inline-block 子元素的百分比宽度能相对包含块解析。
                     var childConstraints = new LayoutConstraints(childAvailableWidth, null);
                     LayoutChild(inlineChild, childConstraints, lineX, currentY);
@@ -421,6 +444,13 @@ public class BlockLayout
     }
 
     /// <summary>
+    /// 该盒子是否为强制换行标记（<c>&lt;br&gt;</c>）。br 是行内级空元素，本身不产生可见盒，
+    /// 但在行内流中会结束当前行盒，使其后的行内内容排到新的一行。
+    /// </summary>
+    internal static bool IsForcedLineBreak(LayoutBox child)
+        => child.Element is Miko.Core.DomElements.BrElement;
+
+    /// <summary>
     /// replaced 元素（video / img）的内禀尺寸（CSS 像素）。
     /// 媒体已加载时返回真实尺寸；video 未知时回退到 HTML 默认 300×150。
     /// img 未加载完成时返回 (0, 0)（无内禀尺寸，需 CSS 显式定尺寸以避免加载前后的重排抖动）。
@@ -452,17 +482,21 @@ public class BlockLayout
     }
 
     /// <summary>
-    /// 是否为“单行文本表单控件”：其盒子高度应由一行文本撑起，且其子元素不在常规流中
-    /// 参与盒子高度（如 select 的 option 由下拉层叠加渲染，不计入闭合态的高度）。
-    /// 目前包括 input（文本类）与 select。
+    /// 是否为“文本表单控件”：其盒子高度应由文本（行高/字体度量）撑起，且其子元素不在常规流中
+    /// 参与盒子高度（如 select 的 option 由下拉层叠加渲染，不计入闭合态的高度；textarea 的文本
+    /// 由元素自身渲染，不作为子节点参与布局）。
+    /// 目前包括 input（文本类）、select 与 textarea。
     /// </summary>
     internal static bool IsTextFormControl(LayoutBox box)
         => box.Element is Miko.Core.DomElements.InputElement
-        || box.Element is Miko.Core.DomElements.SelectElement;
+        || box.Element is Miko.Core.DomElements.SelectElement
+        || box.Element is Miko.Core.DomElements.TextAreaElement;
 
     /// <summary>
-    /// 单行文本表单控件（input[text/password]、select）在自动高度时，
-    /// 其内容高度应由一行文本占据：优先取显式行高（line-height），否则取字体度量高度。
+    /// 文本表单控件在自动高度时的内容高度：
+    /// - input[text/password]、select：由一行文本占据（一行高度）；
+    /// - textarea：由其 <see cref="Core.DomElements.TextAreaElement.Rows"/> 行文本占据（多行高度）。
+    /// 优先取显式行高（line-height），否则取字体度量高度。
     /// 返回 null 表示该盒子不适用此规则（应回退到常规的内容高度计算）。
     /// </summary>
     internal static float? GetTextFormControlContentHeight(LayoutBox box)
@@ -470,7 +504,34 @@ public class BlockLayout
         if (!IsTextFormControl(box))
             return null;
 
-        return ResolveLineHeight(box.ComputedStyle);
+        float lineHeight = ResolveLineHeight(box.ComputedStyle);
+
+        // textarea 高度由可见行数（rows）撑起。
+        if (box.Element is Miko.Core.DomElements.TextAreaElement textArea)
+            return lineHeight * Math.Max(1, textArea.Rows);
+
+        return lineHeight;
+    }
+
+    /// <summary>
+    /// textarea 在自动宽度时的内容宽度：由其 <see cref="Core.DomElements.TextAreaElement.Cols"/>
+    /// 列数乘以字体平均字符宽度得到（对齐浏览器 <c>&lt;textarea cols&gt;</c> 的固有宽度语义）。
+    /// 返回 null 表示该盒子不适用此规则（应回退到常规的内容宽度计算）。
+    /// </summary>
+    /// <remarks>
+    /// 浏览器以字体的“平均字符宽度”（约等于数字 '0' 的字宽）× cols 作为 textarea 的固有内容宽度。
+    /// Miko 无字体 avgCharWidth 度量接口，这里以字符 '0' 的实测宽度近似平均字宽，与浏览器观感一致。
+    /// </remarks>
+    internal static float? GetTextFormControlContentWidth(LayoutBox box)
+    {
+        if (box.Element is not Miko.Core.DomElements.TextAreaElement textArea)
+            return null;
+
+        var style = box.ComputedStyle;
+        float avgCharWidth = TextMeasurer.MeasureTextWidth(
+            "0", style.FontFamily, style.FontSize.Value, style.FontWeight);
+
+        return avgCharWidth * Math.Max(1, textArea.Cols);
     }
 
     /// <summary>

--- a/src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs
@@ -124,8 +124,8 @@ public class InlineLayout
         }
         else
         {
-            // auto 宽度：内容宽度即行内子盒（含文本节点）排列后的最大宽度。
-            contentWidth = maxWidth;
+            // auto 宽度：textarea 由 cols 列数撑起固有宽度；否则为行内子盒（含文本节点）排列后的最大宽度。
+            contentWidth = BlockLayout.GetTextFormControlContentWidth(box) ?? maxWidth;
         }
 
         // 先应用 min/max-width 约束，得到确定的内容宽度，再据此重排子元素与计算高度。

--- a/src/Miko/Platform/MikoInteractionController.cs
+++ b/src/Miko/Platform/MikoInteractionController.cs
@@ -399,6 +399,12 @@ public sealed class MikoInteractionController
         {
             HandleInputClick(inputElement);
         }
+        else if (target is TextAreaElement textAreaElement)
+        {
+            CloseAllSelects();
+            SetFocusCore(textAreaElement);
+            textAreaElement.MoveCursorToEnd();
+        }
         else if (target is SelectElement selectElement2)
         {
             HandleSelectClick(selectElement2);
@@ -596,22 +602,22 @@ public sealed class MikoInteractionController
                 if (handler(key)) return true;
             }
 
-            if (_focusedElement is not InputElement input) return false;
-            if (input.Type != InputType.Text && input.Type != InputType.Password) return false;
+            if (_focusedElement is not ITextEditable editable || !editable.IsEditable) return false;
+            var editableElement = (Element)_focusedElement;
 
             var keyName = key.ToString();
             bool ctrl = mods.HasFlag(MikoKeyModifiers.Control);
 
             var keyArgs = new KeyboardEventArgs
             {
-                Target = input,
+                Target = editableElement,
                 Key = keyName,
                 CtrlKey = ctrl,
                 ShiftKey = mods.HasFlag(MikoKeyModifiers.Shift),
                 AltKey = mods.HasFlag(MikoKeyModifiers.Alt),
                 Bubbles = true
             };
-            DispatchWithSyncContext(input, EventTypes.KeyDown, keyArgs);
+            DispatchWithSyncContext(editableElement, EventTypes.KeyDown, keyArgs);
 
             ProcessKeyAction(key);
             return false;
@@ -638,40 +644,48 @@ public sealed class MikoInteractionController
 
     private void ProcessKeyAction(MikoKey key)
     {
-        if (_focusedElement is not InputElement input) return;
-        if (input.Type != InputType.Text && input.Type != InputType.Password) return;
+        if (_focusedElement is not ITextEditable editable || !editable.IsEditable) return;
+        var element = (Element)_focusedElement;
 
         switch (key)
         {
             case MikoKey.Backspace:
-                if (input.Backspace())
-                    DispatchInputEvent(input);
+                if (editable.Backspace())
+                    DispatchInputEvent(element, editable);
                 break;
             case MikoKey.Delete:
-                if (input.Delete())
-                    DispatchInputEvent(input);
+                if (editable.Delete())
+                    DispatchInputEvent(element, editable);
                 break;
             case MikoKey.Left:
-                if (input.CursorPosition > 0)
+                if (editable.CursorPosition > 0)
                 {
-                    input.CursorPosition--;
-                    input.IsDirty = true;
+                    editable.CursorPosition--;
+                    element.IsDirty = true;
                 }
                 break;
             case MikoKey.Right:
-                if (input.CursorPosition < (input.Value ?? string.Empty).Length)
+                if (editable.CursorPosition < (editable.Value ?? string.Empty).Length)
                 {
-                    input.CursorPosition++;
-                    input.IsDirty = true;
+                    editable.CursorPosition++;
+                    element.IsDirty = true;
                 }
                 break;
             case MikoKey.Home:
-                input.CursorPosition = 0;
-                input.IsDirty = true;
+                editable.CursorPosition = 0;
+                element.IsDirty = true;
                 break;
             case MikoKey.End:
-                input.MoveCursorToEnd();
-                input.IsDirty = true;
+                editable.MoveCursorToEnd();
+                element.IsDirty = true;
+                break;
+            case MikoKey.Enter:
+                // 多行控件（textarea）回车插入换行；单行控件不处理（可用于表单提交，由上层处理）。
+                if (editable.IsMultiline)
+                {
+                    editable.InsertText("\n");
+                    DispatchInputEvent(element, editable);
+                }
                 break;
         }
     }
@@ -681,27 +695,27 @@ public sealed class MikoInteractionController
     {
         lock (_sync)
         {
-            if (_focusedElement is not InputElement input) return;
-            if (input.Type != InputType.Text && input.Type != InputType.Password) return;
+            if (_focusedElement is not ITextEditable editable || !editable.IsEditable) return;
+            var element = (Element)_focusedElement;
 
             foreach (var character in text)
             {
                 if (char.IsControl(character)) continue;
-                input.InsertText(character.ToString());
+                editable.InsertText(character.ToString());
             }
-            DispatchInputEvent(input);
+            DispatchInputEvent(element, editable);
         }
     }
 
-    private void DispatchInputEvent(InputElement input)
+    private void DispatchInputEvent(Element element, ITextEditable editable)
     {
         var inputArgs = new InputEventArgs
         {
-            Target = input,
-            Data = input.Value ?? string.Empty,
+            Target = element,
+            Data = editable.Value ?? string.Empty,
             Bubbles = true
         };
-        DispatchWithSyncContext(input, EventTypes.Input, inputArgs);
+        DispatchWithSyncContext(element, EventTypes.Input, inputArgs);
     }
 
     private void DispatchChange(Element element)

--- a/src/Miko/Rendering/Painter.cs
+++ b/src/Miko/Rendering/Painter.cs
@@ -458,7 +458,7 @@ public class Painter
     /// <summary>
     /// 绘制多行文本（支持换行）
     /// </summary>
-    public void DrawMultilineText(string text, RectF rect, Color color, string fontFamily, float fontSize, FontWeight fontWeight, TextAlign textAlign, float lineHeight, WhiteSpace whiteSpace, VerticalAlign verticalAlign = VerticalAlign.Top)
+    public void DrawMultilineText(string text, RectF rect, Color color, string fontFamily, float fontSize, FontWeight fontWeight, TextAlign textAlign, float lineHeight, WhiteSpace whiteSpace, VerticalAlign verticalAlign = VerticalAlign.Top, bool breakLongWords = false)
     {
         if (string.IsNullOrEmpty(text) || color.A == 0) return;
 
@@ -466,7 +466,7 @@ public class Painter
         var processedText = Utils.TextWrapper.ProcessText(text, whiteSpace);
 
         // 分行
-        var lines = Utils.TextWrapper.WrapText(processedText, fontFamily, fontSize, fontWeight, rect.Width, whiteSpace);
+        var lines = Utils.TextWrapper.WrapText(processedText, fontFamily, fontSize, fontWeight, rect.Width, whiteSpace, breakLongWords);
 
         if (lines.Count == 0) return;
 

--- a/src/Miko/Rendering/RenderEngine.cs
+++ b/src/Miko/Rendering/RenderEngine.cs
@@ -553,6 +553,13 @@ public class RenderEngine
             return;
         }
 
+        // 渲染多行文本框
+        if (element is TextAreaElement textAreaElement)
+        {
+            RenderTextAreaElement(box, textAreaElement);
+            return;
+        }
+
         // 渲染下拉选择框
         if (element is SelectElement selectElement)
         {
@@ -816,6 +823,7 @@ public class RenderEngine
                 break;
 
             case InputType.Password:
+                _painter.SaveClip(box.BoxModel.PaddingBox);
                 if (!string.IsNullOrEmpty(inputElement.Value))
                 {
                     _painter.DrawPasswordText(
@@ -843,15 +851,24 @@ public class RenderEngine
                     var maskedText = new string('●', (inputElement.Value ?? string.Empty).Length);
                     _painter.DrawTextCursor(contentRect, maskedText, inputElement.CursorPosition, style.FontFamily, style.FontSize.Value, style.FontWeight);
                 }
+                _painter.Restore();
                 break;
 
             case InputType.Text:
             default:
+                // 单行输入：内容超出内容宽度后，按光标位置水平滚动，使光标始终可见；
+                // 超出内容盒的文本被裁剪不显示（对齐浏览器 input 的行为）。
+                _painter.SaveClip(box.BoxModel.PaddingBox);
                 if (!string.IsNullOrEmpty(inputElement.Value))
                 {
+                    float scrollX = ComputeInputScrollOffset(
+                        inputElement.Value, inputElement.CursorPosition, contentRect.Width,
+                        style.FontFamily, style.FontSize.Value, style.FontWeight, isFocused);
+                    var scrolledRect = new RectF(
+                        contentRect.X - scrollX, contentRect.Y, contentRect.Width + scrollX, contentRect.Height);
                     _painter.DrawText(
                         inputElement.Value,
-                        contentRect,
+                        scrolledRect,
                         style.Color,
                         style.FontFamily,
                         style.FontSize.Value,
@@ -859,26 +876,145 @@ public class RenderEngine
                         TextAlign.Left,
                         VerticalAlign.Middle
                     );
+                    if (isFocused)
+                    {
+                        _painter.DrawTextCursor(scrolledRect, inputElement.Value, inputElement.CursorPosition, style.FontFamily, style.FontSize.Value, style.FontWeight);
+                    }
                 }
-                else if (!string.IsNullOrEmpty(inputElement.Placeholder) && !isFocused)
+                else
                 {
-                    _painter.DrawText(
-                        inputElement.Placeholder,
-                        contentRect,
-                        Color.Gray,
-                        style.FontFamily,
-                        style.FontSize.Value,
-                        style.FontWeight,
-                        TextAlign.Left,
-                        VerticalAlign.Middle
-                    );
+                    if (!string.IsNullOrEmpty(inputElement.Placeholder) && !isFocused)
+                    {
+                        _painter.DrawText(
+                            inputElement.Placeholder,
+                            contentRect,
+                            Color.Gray,
+                            style.FontFamily,
+                            style.FontSize.Value,
+                            style.FontWeight,
+                            TextAlign.Left,
+                            VerticalAlign.Middle
+                        );
+                    }
+                    if (isFocused)
+                    {
+                        _painter.DrawTextCursor(contentRect, string.Empty, 0, style.FontFamily, style.FontSize.Value, style.FontWeight);
+                    }
                 }
-                if (isFocused)
-                {
-                    _painter.DrawTextCursor(contentRect, inputElement.Value ?? string.Empty, inputElement.CursorPosition, style.FontFamily, style.FontSize.Value, style.FontWeight);
-                }
+                _painter.Restore();
                 break;
         }
+    }
+
+    /// <summary>
+    /// 计算单行输入框的水平滚动偏移：当光标前文本宽度超过内容宽度时，向左滚动使光标落在内容盒右边缘，
+    /// 保持光标可见；否则不滚动（从文本起始处显示，右侧超出部分被裁剪）。
+    /// 仅在聚焦时滚动跟随光标；未聚焦时从起始处显示（offset=0）。
+    /// </summary>
+    private static float ComputeInputScrollOffset(
+        string text, int cursorPosition, float contentWidth,
+        string fontFamily, float fontSize, FontWeight fontWeight, bool isFocused)
+    {
+        if (!isFocused || contentWidth <= 0) return 0;
+
+        int pos = Math.Clamp(cursorPosition, 0, text.Length);
+        float caretX = Utils.TextMeasurer.MeasureTextWidth(
+            text.Substring(0, pos), fontFamily, fontSize, fontWeight);
+
+        return caretX > contentWidth ? caretX - contentWidth : 0;
+    }
+
+    /// <summary>
+    /// 渲染多行文本框元素 (textarea)。
+    ///
+    /// 文本在内容盒内按行盒自顶向下多行绘制（white-space: pre-wrap），过长的行在内容宽度内换行。
+    /// 无内容且未聚焦时绘制灰色占位符。聚焦时在光标所在行/列绘制文本光标。
+    /// </summary>
+    private void RenderTextAreaElement(LayoutBox box, TextAreaElement textArea)
+    {
+        if (_painter == null) return;
+
+        var style = box.ComputedStyle;
+        var contentRect = box.BoxModel.Content;
+        bool isFocused = textArea.HasState(Miko.Core.ElementState.Focus);
+        float lineHeight = Layout.LayoutAlgorithms.BlockLayout.ResolveLineHeight(style);
+
+        // 裁剪到内容盒（padding box 内）：超出内容宽/高的软换行文本与光标不应溢出控件绘制。
+        // textarea 采用软换行，任何超出内容宽度的内容都换行（breakLongWords: true），
+        // 但换行后总高度仍可能超过可见高度，故仍需裁剪。
+        _painter.SaveClip(box.BoxModel.PaddingBox);
+
+        if (!string.IsNullOrEmpty(textArea.Value))
+        {
+            _painter.DrawMultilineText(
+                textArea.Value,
+                contentRect,
+                style.Color,
+                style.FontFamily,
+                style.FontSize.Value,
+                style.FontWeight,
+                TextAlign.Left,
+                lineHeight,
+                Common.WhiteSpace.PreWrap,
+                VerticalAlign.Top,
+                breakLongWords: true);
+        }
+        else if (!string.IsNullOrEmpty(textArea.Placeholder) && !isFocused)
+        {
+            _painter.DrawMultilineText(
+                textArea.Placeholder,
+                contentRect,
+                Color.Gray,
+                style.FontFamily,
+                style.FontSize.Value,
+                style.FontWeight,
+                TextAlign.Left,
+                lineHeight,
+                Common.WhiteSpace.PreWrap,
+                VerticalAlign.Top,
+                breakLongWords: true);
+        }
+
+        if (isFocused)
+        {
+            RenderTextAreaCursor(box, textArea, lineHeight);
+        }
+
+        _painter.Restore();
+    }
+
+    /// <summary>
+    /// 绘制 textarea 的文本光标。textarea 采用软换行，因此光标所在的视觉行/列需按与绘制一致的
+    /// 换行规则（含逐字符断行）重新计算：先取光标前文本，按内容宽度软换行后，光标定位在最后一段
+    /// 视觉行的行尾。
+    /// </summary>
+    private void RenderTextAreaCursor(LayoutBox box, TextAreaElement textArea, float lineHeight)
+    {
+        if (_painter == null) return;
+
+        var style = box.ComputedStyle;
+        var contentRect = box.BoxModel.Content;
+        var value = textArea.Value ?? string.Empty;
+        int pos = Math.Clamp(textArea.CursorPosition, 0, value.Length);
+        var before = value.Substring(0, pos);
+
+        // 与绘制一致：按内容宽度对“光标前文本”软换行（含长单词逐字符断行），
+        // 视觉行号为换行结果的行数-1，当前列文本为最后一段视觉行。
+        var processed = Utils.TextWrapper.ProcessText(before, Common.WhiteSpace.PreWrap);
+        var lines = Utils.TextWrapper.WrapText(
+            processed, style.FontFamily, style.FontSize.Value, style.FontWeight,
+            contentRect.Width, Common.WhiteSpace.PreWrap, breakLongWords: true);
+
+        int lineIndex = lines.Count > 0 ? lines.Count - 1 : 0;
+        // 若光标前文本以显式换行结尾，WrapText 会为末尾空段补一行；此处直接取最后一段作为当前行。
+        var currentLine = lines.Count > 0 ? lines[^1] : string.Empty;
+
+        float lineTop = contentRect.Top + lineIndex * lineHeight;
+        // 复用单行光标绘制：以当前行文本 + 光标位于该行末尾，定位在当前行的行盒内。
+        var cursorRect = new RectF(contentRect.X, lineTop, contentRect.Width, lineHeight);
+        _painter.DrawTextCursor(
+            cursorRect, currentLine, currentLine.Length,
+            style.FontFamily, style.FontSize.Value, style.FontWeight);
     }
 
     /// <summary>

--- a/src/Miko/Styling/StyleResolver.cs
+++ b/src/Miko/Styling/StyleResolver.cs
@@ -239,6 +239,43 @@ public class StyleResolver
                 ApplyInputDefaultStyles(element, style);
                 break;
 
+            case "textarea":
+                // Browser default: display: inline-block, 1px solid border, white background,
+                // 允许换行（white-space: pre-wrap）与滚动。高度由 rows 行文本在布局阶段撑起
+                // （见 BlockLayout.GetTextFormControlContentHeight），此处不写死像素高度。
+                style.Display ??= Common.Display.InlineBlock;
+                style.BoxSizing ??= Common.BoxSizing.BorderBox;
+                style.PaddingTop ??= Common.Length.Px(2);
+                style.PaddingRight ??= Common.Length.Px(2);
+                style.PaddingBottom ??= Common.Length.Px(2);
+                style.PaddingLeft ??= Common.Length.Px(2);
+                style.BorderWidth ??= Common.Length.Px(1);
+                style.BorderStyle ??= Common.BorderStyle.Solid;
+                style.BorderColor ??= Common.Color.Gray;
+                style.BackgroundColor ??= Common.Color.White;
+                style.WhiteSpace ??= Common.WhiteSpace.PreWrap;
+                break;
+
+            case "br":
+                // Browser default: display: inline。br 是强制换行标记，不产生可见盒，
+                // 由 BlockLayout 识别并结束当前行盒（见 IsForcedLineBreak）。
+                style.Display ??= Common.Display.Inline;
+                break;
+
+            case "hr":
+                // Browser default: display: block, margin: 0.5em auto, border + inset 线条。
+                // Miko 无 border 的 3D inset 样式，用一条 1px 实线上边框绘制分隔线，
+                // 内容高度为 0，因此直接复用既有的边框绘制路径。
+                style.Display ??= Common.Display.Block;
+                style.MarginTop ??= Common.Length.Px(8);      // ~0.5em at 16px
+                style.MarginBottom ??= Common.Length.Px(8);
+                style.MarginLeft ??= Common.Length.Auto;
+                style.MarginRight ??= Common.Length.Auto;
+                style.BorderTopWidth ??= Common.Length.Px(1);
+                style.BorderTopStyle ??= Common.BorderStyle.Solid;
+                style.BorderTopColor ??= Common.Color.Gray;
+                break;
+
             case "img":
                 // Browser default: display: inline, border: 0
                 style.Display ??= Common.Display.Inline;

--- a/src/Miko/Utils/TextWrapper.cs
+++ b/src/Miko/Utils/TextWrapper.cs
@@ -126,6 +126,11 @@ public static class TextWrapper
     /// <param name="fontWeight">字体粗细</param>
     /// <param name="availableWidth">可用宽度</param>
     /// <param name="whiteSpace">WhiteSpace 样式</param>
+    /// <param name="breakLongWords">
+    /// 是否对超过整行宽度的连续长单词做逐字符断行（对齐 CSS <c>overflow-wrap: anywhere</c>）。
+    /// textarea 等表单控件采用软换行：任何超出内容宽度的内容都应换行而非溢出，故传 true；
+    /// 普通文本节点默认 false，仅在单词（空格）边界换行，保持既有行为。
+    /// </param>
     /// <returns>分行后的文本列表</returns>
     public static List<string> WrapText(
         string text,
@@ -133,7 +138,8 @@ public static class TextWrapper
         float fontSize,
         FontWeight fontWeight,
         float availableWidth,
-        WhiteSpace whiteSpace)
+        WhiteSpace whiteSpace,
+        bool breakLongWords = false)
     {
         var lines = new List<string>();
 
@@ -160,7 +166,7 @@ public static class TextWrapper
                 continue;
             }
 
-            WrapParagraph(paragraph, fontFamily, fontSize, fontWeight, availableWidth, lines);
+            WrapParagraph(paragraph, fontFamily, fontSize, fontWeight, availableWidth, lines, breakLongWords);
         }
 
         return lines;
@@ -172,7 +178,8 @@ public static class TextWrapper
         float fontSize,
         FontWeight fontWeight,
         float availableWidth,
-        List<string> lines)
+        List<string> lines,
+        bool breakLongWords = false)
     {
         if (availableWidth <= 0)
         {
@@ -207,25 +214,63 @@ public static class TextWrapper
                 // 保存当前行并开始新行
                 lines.Add(currentLine.ToString());
                 currentLine.Clear();
-                currentLine.Append(word);
-                currentWidth = TextMeasurer.MeasureTextWidth(word, fontFamily, fontSize, fontWeight);
+                currentWidth = 0;
             }
-            else
+
+            // 单词自身就超过整行宽度：按字符断行（overflow-wrap: anywhere）。
+            // 仅在启用 breakLongWords 时执行，否则保持旧行为（长单词整体溢出）。
+            float soloWordWidth = TextMeasurer.MeasureTextWidth(word, fontFamily, fontSize, fontWeight);
+            if (breakLongWords && currentLine.Length == 0 && soloWordWidth > availableWidth)
             {
-                // 继续添加到当前行
-                if (currentLine.Length > 0)
-                {
-                    currentLine.Append(' ');
-                }
-                currentLine.Append(word);
-                currentWidth += wordWidth;
+                BreakLongWord(word, fontFamily, fontSize, fontWeight, availableWidth, lines, currentLine, ref currentWidth);
+                continue;
             }
+
+            // 继续添加到当前行
+            if (currentLine.Length > 0)
+            {
+                currentLine.Append(' ');
+                currentWidth += TextMeasurer.MeasureTextWidth(" ", fontFamily, fontSize, fontWeight);
+            }
+            currentLine.Append(word);
+            currentWidth += soloWordWidth;
         }
 
         // 添加最后一行
         if (currentLine.Length > 0)
         {
             lines.Add(currentLine.ToString());
+        }
+    }
+
+    /// <summary>
+    /// 逐字符断开一个超过整行宽度的长单词，填满每一行。最后一段（未满一行）不落盘，
+    /// 而是留在 <paramref name="currentLine"/> 中，以便后续单词能继续拼接在同一行。
+    /// </summary>
+    private static void BreakLongWord(
+        string word,
+        string fontFamily,
+        float fontSize,
+        FontWeight fontWeight,
+        float availableWidth,
+        List<string> lines,
+        System.Text.StringBuilder currentLine,
+        ref float currentWidth)
+    {
+        foreach (var ch in word)
+        {
+            float charWidth = TextMeasurer.MeasureTextWidth(ch.ToString(), fontFamily, fontSize, fontWeight);
+
+            // 当前行放不下这个字符（且行内已有内容）：换行。
+            if (currentLine.Length > 0 && currentWidth + charWidth > availableWidth)
+            {
+                lines.Add(currentLine.ToString());
+                currentLine.Clear();
+                currentWidth = 0;
+            }
+
+            currentLine.Append(ch);
+            currentWidth += charWidth;
         }
     }
 }

--- a/tests/Miko.Tests/Core/P0ElementsTests.cs
+++ b/tests/Miko.Tests/Core/P0ElementsTests.cs
@@ -1,0 +1,252 @@
+using Miko.Common;
+using Miko.Components;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Shouldly;
+
+namespace Miko.Tests.Core;
+
+/// <summary>
+/// P0 新增标签（textarea、br、hr）及表格 caption/colgroup/col 工厂注册的测试。
+/// 覆盖：工厂注册、UA 默认样式、以及 br 的强制换行与 textarea 的多行高度布局行为。
+/// </summary>
+public class P0ElementsTests
+{
+    private readonly LayoutEngine _layoutEngine = new();
+    private readonly StyleResolver _styleResolver = new();
+
+    // ---------------------------------------------------------------------
+    // 工厂注册（RenderTreeBuilder._tagMap）
+    // ---------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("textarea", typeof(TextAreaElement))]
+    [InlineData("br", typeof(BrElement))]
+    [InlineData("hr", typeof(HrElement))]
+    [InlineData("caption", typeof(CaptionElement))]
+    [InlineData("colgroup", typeof(ColgroupElement))]
+    [InlineData("col", typeof(ColElement))]
+    public void OpenElement_ForNewTags_CreatesCorrectElement(string tag, Type expected)
+    {
+        var builder = new RenderTreeBuilder();
+        builder.OpenElement(0, tag);
+        builder.CloseElement();
+
+        builder.Build().ShouldBeOfType(expected);
+    }
+
+    // ---------------------------------------------------------------------
+    // textarea 默认样式与布局
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void TextArea_DefaultStyles_MatchBrowser()
+    {
+        var computed = _styleResolver.Resolve(new TextAreaElement(), []);
+
+        computed.Display.ShouldBe(Display.InlineBlock);
+        computed.BoxSizing.ShouldBe(BoxSizing.BorderBox);
+        computed.BorderTopWidth.Value.ShouldBe(1);
+        computed.WhiteSpace.ShouldBe(WhiteSpace.PreWrap);
+    }
+
+    [Fact]
+    public void TextArea_AutoHeight_IsDerivedFromRows()
+    {
+        // rows=3 时内容高度应约为 3 行文本高度（>1 行，随 rows 增长）。
+        var oneRow = new TextAreaElement { Rows = 1 };
+        var threeRows = new TextAreaElement { Rows = 3 };
+
+        var oneRowBox = _layoutEngine.Layout(oneRow, [], 800, 600);
+        var threeRowBox = _layoutEngine.Layout(threeRows, [], 800, 600);
+
+        float oneRowHeight = oneRowBox.BoxModel.Content.Height;
+        oneRowHeight.ShouldBeGreaterThan(0);
+        threeRowBox.BoxModel.Content.Height.ShouldBe(oneRowHeight * 3, 0.5);
+    }
+
+    [Fact]
+    public void TextArea_AutoWidth_IsDerivedFromCols()
+    {
+        // 问题1修复：默认 cols=20，内容宽度应约为 20 × 平均字符宽度（远大于 0），
+        // 而非塌缩为 0（仅剩 padding+border）。
+        var textArea = new TextAreaElement(); // Cols = 20 (默认)
+        var root = _layoutEngine.Layout(textArea, [], 800, 600);
+
+        float avgCharWidth = Miko.Utils.TextMeasurer.MeasureTextWidth(
+            "0", root.ComputedStyle.FontFamily, root.ComputedStyle.FontSize.Value, root.ComputedStyle.FontWeight);
+        avgCharWidth.ShouldBeGreaterThan(0);
+
+        // 内容宽度应等于 cols × 平均字符宽度
+        root.BoxModel.Content.Width.ShouldBe(avgCharWidth * 20, 0.5);
+        // 且明显大于 0（回归保护：修复前为 0）
+        root.BoxModel.Content.Width.ShouldBeGreaterThan(avgCharWidth * 10);
+    }
+
+    [Fact]
+    public void TextArea_AutoWidth_ScalesWithCols()
+    {
+        // cols 越大，内容宽度越宽（成比例）。
+        var narrow = new TextAreaElement { Cols = 10 };
+        var wide = new TextAreaElement { Cols = 40 };
+
+        var narrowBox = _layoutEngine.Layout(narrow, [], 800, 600);
+        var wideBox = _layoutEngine.Layout(wide, [], 800, 600);
+
+        float narrowWidth = narrowBox.BoxModel.Content.Width;
+        narrowWidth.ShouldBeGreaterThan(0);
+        wideBox.BoxModel.Content.Width.ShouldBe(narrowWidth * 4, 0.5);
+    }
+
+    [Fact]
+    public void TextArea_ExplicitWidth_OverridesColsDefault()
+    {
+        // 显式 width 应覆盖由 cols 推导的默认宽度。
+        var textArea = new TextAreaElement { Cols = 20, Style = new Style { Width = Length.Px(300) } };
+        var root = _layoutEngine.Layout(textArea, [], 800, 600);
+
+        // border-box：内容宽度 = 300 - padding(2+2) - border(1+1) = 294
+        root.BoxModel.Content.Width.ShouldBe(294, 0.5);
+    }
+
+    [Fact]
+    public void TextArea_InitialTextContent_IsCollapsedIntoValue()
+    {
+        // HTML 中 textarea 的初始文本写在标签内容里，应回收进 Value 而非作为子节点参与布局。
+        var builder = new RenderTreeBuilder();
+        builder.OpenElement(0, "textarea");
+        builder.AddContent(1, "hello");
+        builder.CloseElement();
+
+        var textArea = builder.Build().ShouldBeOfType<TextAreaElement>();
+        textArea.Value.ShouldBe("hello");
+        textArea.Children.ShouldNotContain(c => c is TextNode);
+    }
+
+    [Fact]
+    public void TextArea_ValueAttribute_TakesPrecedenceOverContent()
+    {
+        var builder = new RenderTreeBuilder();
+        builder.OpenElement(0, "textarea");
+        builder.AddAttribute(1, "value", "from-attr");
+        builder.AddContent(2, "from-content");
+        builder.CloseElement();
+
+        var textArea = builder.Build().ShouldBeOfType<TextAreaElement>();
+        textArea.Value.ShouldBe("from-attr");
+    }
+
+    [Fact]
+    public void TextArea_RowsAndColsAttributes_AreParsed()
+    {
+        var builder = new RenderTreeBuilder();
+        builder.OpenElement(0, "textarea");
+        builder.AddAttribute(1, "rows", "5");
+        builder.AddAttribute(2, "cols", "40");
+        builder.CloseElement();
+
+        var textArea = builder.Build().ShouldBeOfType<TextAreaElement>();
+        textArea.Rows.ShouldBe(5);
+        textArea.Cols.ShouldBe(40);
+    }
+
+    // ---------------------------------------------------------------------
+    // textarea 文本编辑（ITextEditable）
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void TextArea_InsertAndBackspace_EditsValueAtCursor()
+    {
+        var textArea = new TextAreaElement();
+        textArea.InsertText("ab");
+        textArea.InsertText("c");
+
+        textArea.Value.ShouldBe("abc");
+        textArea.CursorPosition.ShouldBe(3);
+
+        textArea.Backspace().ShouldBeTrue();
+        textArea.Value.ShouldBe("ab");
+        textArea.CursorPosition.ShouldBe(2);
+    }
+
+    [Fact]
+    public void TextArea_IsMultilineAndEditable()
+    {
+        var textArea = new TextAreaElement();
+        ((ITextEditable)textArea).IsEditable.ShouldBeTrue();
+        ((ITextEditable)textArea).IsMultiline.ShouldBeTrue();
+    }
+
+    // ---------------------------------------------------------------------
+    // br 强制换行
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Br_DefaultDisplay_IsInline()
+    {
+        _styleResolver.Resolve(new BrElement(), []).Display.ShouldBe(Display.Inline);
+    }
+
+    [Fact]
+    public void Br_ForcesLineBreak_PushesFollowingTextToNewLine()
+    {
+        // <div>a<br/>b</div>：a 与 b 应分处两行，b 的顶部不小于 a 的底部。
+        var div = new DivElement();
+        div.AddChild(new TextNode("a"));
+        div.AddChild(new BrElement());
+        div.AddChild(new TextNode("b"));
+
+        var root = _layoutEngine.Layout(div, [], 800, 600);
+
+        // 布局树：a、br、b 三个行内子盒
+        var boxes = root.Children;
+        boxes.Count.ShouldBe(3);
+        var aBox = boxes[0];
+        var bBox = boxes[2];
+
+        bBox.BoxModel.MarginBox.Top.ShouldBeGreaterThanOrEqualTo(aBox.BoxModel.MarginBox.Bottom - 0.5f);
+    }
+
+    [Fact]
+    public void Br_WithoutBreak_KeepsTextOnSameLine()
+    {
+        // 对照组：无 br 时 a、b 同处一行（顶部一致）。
+        var div = new DivElement();
+        div.AddChild(new TextNode("a"));
+        div.AddChild(new TextNode("b"));
+
+        var root = _layoutEngine.Layout(div, [], 800, 600);
+        var aBox = root.Children[0];
+        var bBox = root.Children[1];
+
+        bBox.BoxModel.MarginBox.Top.ShouldBe(aBox.BoxModel.MarginBox.Top, 0.5);
+    }
+
+    // ---------------------------------------------------------------------
+    // hr 主题分隔线
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Hr_DefaultStyles_HaveTopBorderLine()
+    {
+        var computed = _styleResolver.Resolve(new HrElement(), []);
+
+        computed.Display.ShouldBe(Display.Block);
+        computed.BorderTopWidth.Value.ShouldBe(1);
+        computed.BorderTopStyle.ShouldBe(BorderStyle.Solid);
+        computed.ComputedBorderTop.IsVisible.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Hr_Layout_FillsWidthWithZeroContentHeight()
+    {
+        // hr 无内容：内容高度为 0，但因 1px 上边框，border-box 高度为 1。
+        var hr = new HrElement();
+        var root = _layoutEngine.Layout(hr, [], 800, 600);
+
+        root.BoxModel.Content.Height.ShouldBe(0);
+        root.BoxModel.BorderBox.Height.ShouldBe(1);
+        root.BoxModel.Content.Width.ShouldBeGreaterThan(0);
+    }
+}

--- a/tests/Miko.Tests/Rendering/InputTextAreaOverflowTests.cs
+++ b/tests/Miko.Tests/Rendering/InputTextAreaOverflowTests.cs
@@ -1,0 +1,307 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Fonts;
+using Miko.Layout;
+using Miko.Rendering;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Miko.Utils;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Rendering;
+
+/// <summary>
+/// 问题「Input 和 TextArea 内容超出后渲染错误」的回归测试。
+///
+/// - Input：内容超出宽度后应按光标水平滚动保持光标可见，且超出内容盒的文本被裁剪不显示。
+/// - TextArea：内容超出行宽应自动换行（含无空格长文本的逐字符断行），且超出内容盒的文本被裁剪。
+/// </summary>
+public class InputTextAreaOverflowTests : IDisposable
+{
+    private readonly SKBitmap _bitmap;
+    private readonly SKCanvas _canvas;
+    private readonly RenderEngine _renderEngine;
+    private readonly LayoutEngine _layoutEngine;
+
+    public InputTextAreaOverflowTests()
+    {
+        _bitmap = new SKBitmap(400, 300);
+        _canvas = new SKCanvas(_bitmap);
+        _canvas.Clear(SKColors.White);
+        _renderEngine = new RenderEngine();
+        _renderEngine.SetCanvas(_canvas);
+        _layoutEngine = new LayoutEngine();
+    }
+
+    public void Dispose()
+    {
+        _canvas.Dispose();
+        _bitmap.Dispose();
+    }
+
+    // 是否存在“非白色”像素（即被绘制的黑色文本）位于给定列范围内。
+    private bool HasDarkPixelInColumns(int xStart, int xEnd, int yStart, int yEnd)
+    {
+        xStart = Math.Max(0, xStart);
+        yStart = Math.Max(0, yStart);
+        xEnd = Math.Min(_bitmap.Width, xEnd);
+        yEnd = Math.Min(_bitmap.Height, yEnd);
+        for (int y = yStart; y < yEnd; y++)
+        {
+            for (int x = xStart; x < xEnd; x++)
+            {
+                var c = _bitmap.GetPixel(x, y);
+                // 文本为黑色；背景为白色。取一个明显的暗度阈值。
+                if (c.Red < 128 && c.Green < 128 && c.Blue < 128)
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    // ---------------------------------------------------------------------
+    // TextWrapper：无空格长文本应逐字符断行（overflow-wrap: anywhere）
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void WrapText_LongUnbrokenWord_WithBreakLongWords_WrapsIntoMultipleLines()
+    {
+        float avail = 80;
+        var text = "abcdefghijklmnopqrstuvwxyz0123456789"; // 无空格，远超 avail
+
+        var withoutBreak = TextWrapper.WrapText(text, "Arial", 16, FontWeight.Normal, avail, WhiteSpace.PreWrap, breakLongWords: false);
+        var withBreak = TextWrapper.WrapText(text, "Arial", 16, FontWeight.Normal, avail, WhiteSpace.PreWrap, breakLongWords: true);
+
+        // 旧行为：长单词整体成一行（溢出）
+        withoutBreak.Count.ShouldBe(1);
+        // 新行为：按字符断成多行
+        withBreak.Count.ShouldBeGreaterThan(1);
+
+        // 每一行的宽度都不超过可用宽度
+        foreach (var line in withBreak)
+        {
+            TextMeasurer.MeasureTextWidth(line, "Arial", 16, FontWeight.Normal)
+                .ShouldBeLessThanOrEqualTo(avail + 0.5f);
+        }
+
+        // 断行不丢字符
+        string.Concat(withBreak).ShouldBe(text);
+    }
+
+    [Fact]
+    public void WrapText_MixedSpacedAndLongWord_BreaksOnlyTheLongWord()
+    {
+        float avail = 120;
+        var text = "hi supercalifragilisticexpialidocioussupercalifragilistic ok";
+
+        var lines = TextWrapper.WrapText(text, "Arial", 16, FontWeight.Normal, avail, WhiteSpace.PreWrap, breakLongWords: true);
+
+        lines.Count.ShouldBeGreaterThan(1);
+        foreach (var line in lines)
+        {
+            TextMeasurer.MeasureTextWidth(line, "Arial", 16, FontWeight.Normal)
+                .ShouldBeLessThanOrEqualTo(avail + 0.5f);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // TextArea：自动换行 + 裁剪
+    // ---------------------------------------------------------------------
+
+    private TextAreaElement CreateSizedTextArea(string value, out LayoutBox box, bool focused = false)
+    {
+        var ta = new TextAreaElement { Value = value };
+        ta.Class = "ta";
+        if (focused) ta.SetState(ElementState.Focus);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(new ClassSelector("ta"), new Style
+        {
+            Width = Length.Px(100),
+            Height = Length.Px(60),
+            BoxSizing = BoxSizing.BorderBox,
+            FontSize = Length.Px(16),
+            PaddingTop = Length.Px(2),
+            PaddingBottom = Length.Px(2),
+            PaddingLeft = Length.Px(2),
+            PaddingRight = Length.Px(2),
+            BorderWidth = Length.Px(1),
+            BorderStyle = BorderStyle.Solid,
+            BorderColor = Color.Gray,
+        });
+
+        box = _layoutEngine.Layout(ta, new List<StyleSheet> { sheet }, 400, 300);
+        return ta;
+    }
+
+    [Fact]
+    public void TextArea_LongUnbrokenText_DoesNotRenderBeyondContentBox()
+    {
+        var box = default(LayoutBox)!;
+        CreateSizedTextArea(new string('W', 200), out box); // 无空格长文本
+
+        _renderEngine.Render(box);
+
+        var padding = box.BoxModel.PaddingBox;
+        // 内容盒右侧之外（含边框区右侧）不应有暗色文本像素。
+        int rightEdge = (int)Math.Ceiling(padding.Right);
+        HasDarkPixelInColumns(rightEdge + 2, rightEdge + 60, 0, 300)
+            .ShouldBeFalse("textarea overflow text must be clipped to the content/padding box");
+    }
+
+    [Fact]
+    public void TextArea_LongText_WrapsAndRendersMultipleLines()
+    {
+        var box = default(LayoutBox)!;
+        CreateSizedTextArea(new string('W', 200), out box);
+
+        _renderEngine.Render(box);
+
+        var content = box.BoxModel.Content;
+        // 第一行区域应有文本
+        int firstLineTop = (int)content.Top;
+        HasDarkPixelInColumns((int)content.X, (int)content.Right, firstLineTop, firstLineTop + 18)
+            .ShouldBeTrue("first wrapped line should render text");
+
+        // 第二行区域（下移一行高度）也应有文本 —— 证明发生了换行
+        int secondLineTop = (int)(content.Top + 18);
+        HasDarkPixelInColumns((int)content.X, (int)content.Right, secondLineTop, secondLineTop + 18)
+            .ShouldBeTrue("second wrapped line should render text (proves wrapping happened)");
+    }
+
+    [Fact]
+    public void TextArea_OverflowingVerticalContent_IsClippedBelowBox()
+    {
+        var box = default(LayoutBox)!;
+        // 很多行，超过 60px 高度
+        CreateSizedTextArea(string.Join("\n", Enumerable.Range(0, 30).Select(i => "line" + i)), out box);
+
+        _renderEngine.Render(box);
+
+        var padding = box.BoxModel.PaddingBox;
+        int bottomEdge = (int)Math.Ceiling(padding.Bottom);
+        HasDarkPixelInColumns((int)padding.X, (int)padding.Right, bottomEdge + 3, bottomEdge + 60)
+            .ShouldBeFalse("textarea content below the box must be clipped");
+    }
+
+    // ---------------------------------------------------------------------
+    // Input：水平滚动 + 裁剪
+    // ---------------------------------------------------------------------
+
+    private InputElement CreateSizedInput(string value, int cursorPos, bool focused, out LayoutBox box)
+    {
+        var input = new InputElement { Type = InputType.Text, Value = value, CursorPosition = cursorPos };
+        input.Class = "inp";
+        if (focused) input.SetState(ElementState.Focus);
+
+        var sheet = new StyleSheet();
+        sheet.AddRule(new ClassSelector("inp"), new Style
+        {
+            Width = Length.Px(80),
+            Height = Length.Px(24),
+            BoxSizing = BoxSizing.BorderBox,
+            FontSize = Length.Px(16),
+            PaddingTop = Length.Px(1),
+            PaddingBottom = Length.Px(1),
+            PaddingLeft = Length.Px(2),
+            PaddingRight = Length.Px(2),
+            BorderWidth = Length.Px(1),
+            BorderStyle = BorderStyle.Solid,
+            BorderColor = Color.Gray,
+        });
+
+        box = _layoutEngine.Layout(input, new List<StyleSheet> { sheet }, 400, 300);
+        return input;
+    }
+
+    [Fact]
+    public void Input_LongValue_DoesNotRenderBeyondContentBox()
+    {
+        var box = default(LayoutBox)!;
+        // 光标在末尾，聚焦 —— 应向左滚动，右侧不应溢出
+        var value = "abcdefghijklmnopqrstuvwxyz";
+        CreateSizedInput(value, value.Length, focused: true, out box);
+
+        _renderEngine.Render(box);
+
+        var padding = box.BoxModel.PaddingBox;
+        int rightEdge = (int)Math.Ceiling(padding.Right);
+        HasDarkPixelInColumns(rightEdge + 2, rightEdge + 80, 0, 300)
+            .ShouldBeFalse("input overflow text must be clipped to the content/padding box");
+    }
+
+    [Fact]
+    public void Input_FocusedWithCursorAtEnd_ScrollsSoCursorIsVisible()
+    {
+        var box = default(LayoutBox)!;
+        var value = "abcdefghijklmnopqrstuvwxyz";
+        var input = CreateSizedInput(value, value.Length, focused: true, out box);
+
+        _renderEngine.Render(box);
+
+        var content = box.BoxModel.Content;
+        // 光标在末尾且滚动后应位于内容盒右边缘附近 —— 该列范围内应有暗色像素（光标或文本尾字符）。
+        int nearRight = (int)(content.Right - 8);
+        HasDarkPixelInColumns(nearRight, (int)Math.Ceiling(content.Right), (int)content.Top, (int)content.Bottom)
+            .ShouldBeTrue("caret/tail char should be visible near the right edge when scrolled to end");
+    }
+
+    [Fact]
+    public void Input_ScrollOffset_IsZero_WhenTextFits()
+    {
+        // 短文本完全放得下：不滚动。通过“最左列有文本”来验证起始处从左边缘绘制。
+        var box = default(LayoutBox)!;
+        CreateSizedInput("ab", 2, focused: true, out box);
+
+        _renderEngine.Render(box);
+
+        var content = box.BoxModel.Content;
+        HasDarkPixelInColumns((int)content.X, (int)content.X + 20, (int)content.Top, (int)content.Bottom)
+            .ShouldBeTrue("short text should render from the left edge (no scroll)");
+    }
+
+    [Fact]
+    public void Input_CursorAtStart_ShowsTextStart_ClipsRightOverflow()
+    {
+        // 光标在最左：不滚动，从起始处显示；右侧超出部分被裁剪不显示（问题描述的行为）。
+        var box = default(LayoutBox)!;
+        var value = "abcdefghijklmnopqrstuvwxyz";
+        CreateSizedInput(value, 0, focused: true, out box);
+
+        _renderEngine.Render(box);
+
+        var content = box.BoxModel.Content;
+        var padding = box.BoxModel.PaddingBox;
+
+        // 起始处（左边缘）有文本
+        HasDarkPixelInColumns((int)content.X, (int)content.X + 12, (int)content.Top, (int)content.Bottom)
+            .ShouldBeTrue("with cursor at start, text should render from the beginning");
+
+        // 内容盒右侧之外无文本（被裁剪）
+        int rightEdge = (int)Math.Ceiling(padding.Right);
+        HasDarkPixelInColumns(rightEdge + 2, rightEdge + 80, 0, 300)
+            .ShouldBeFalse("right overflow must be clipped when cursor is at start");
+    }
+
+    [Fact]
+    public void Input_Unfocused_DoesNotScroll_ClipsOverflow()
+    {
+        // 未聚焦：从起始处显示（不跟随光标滚动），右侧仍被裁剪。
+        var box = default(LayoutBox)!;
+        var value = "abcdefghijklmnopqrstuvwxyz";
+        CreateSizedInput(value, value.Length, focused: false, out box);
+
+        _renderEngine.Render(box);
+
+        var content = box.BoxModel.Content;
+        var padding = box.BoxModel.PaddingBox;
+
+        HasDarkPixelInColumns((int)content.X, (int)content.X + 12, (int)content.Top, (int)content.Bottom)
+            .ShouldBeTrue("unfocused input renders from start");
+        int rightEdge = (int)Math.Ceiling(padding.Right);
+        HasDarkPixelInColumns(rightEdge + 2, rightEdge + 80, 0, 300)
+            .ShouldBeFalse("unfocused overflow must be clipped");
+    }
+}


### PR DESCRIPTION
## Summary

Adds overflow handling for `Input` and `TextArea` elements so text that exceeds the content box is clipped and scrolled correctly instead of bleeding outside the element.

## Changes

- Add `ITextEditable` interface for text editing capabilities
- Implement horizontal scroll for `Input` when content overflows
- Add automatic line wrapping for `TextArea` with character-breaking for long words
- Enhance `TextWrapper` with break-anywhere support and safe wrapping limits
- Add content clipping in `Painter` to prevent overflow text rendering
- Add `TextElements.cs` for reusable text-editing element utilities
- Fix `RenderEngine` to properly clip text within content boxes

## Tests

- `tests/Miko.Tests/Core/P0ElementsTests.cs`
- `tests/Miko.Tests/Rendering/InputTextAreaOverflowTests.cs`

Resolves text overflow issues in `Input` and `TextArea` elements.