### PR TITLE
feat(styling): ISSUE-091 support vw/vh viewport length units

### DIFF
--- a/src/Miko/Common/Enums.cs
+++ b/src/Miko/Common/Enums.cs
@@ -131,6 +131,10 @@ public enum LengthUnit
     Auto,
     Rem,
     Em,
+    /// <summary>视窗宽度单位：<c>1vw</c> = 视口宽度的 1%。</summary>
+    Vw,
+    /// <summary>视窗高度单位：<c>1vh</c> = 视口高度的 1%。</summary>
+    Vh,
     /// <summary>无单位数值。用于无单位 line-height：实际像素 = 该系数 × 字体大小。</summary>
     Number
 }

--- a/src/Miko/Common/Length.cs
+++ b/src/Miko/Common/Length.cs
@@ -17,6 +17,7 @@ public struct Length
 
     // 各单位分量。最终像素值 =
     //   px + rem*RootFontSize + em*fontSize + number*fontSize + percent/100*containerSize
+    //   + vw/100*viewportWidth + vh/100*viewportHeight（由 ResolveViewport 在样式计算阶段折算）
     //   + safe* * 对应方向的安全区 inset（在样式计算阶段由 ResolveSafeArea 折算）。
     // number 为无单位系数（用于无单位 line-height，按字体大小缩放）。
     private float _px;
@@ -24,6 +25,10 @@ public struct Length
     private float _rem;
     private float _percent;
     private float _number;
+    // CSS 视窗单位系数：vw 相对视口宽度、vh 相对视口高度（1vw = 视口宽度的 1%）。在已知视口尺寸前
+    // 不参与 ToPixels；由 ResolveViewport 在样式计算阶段折算进 _px 后清零，使其后的布局透明无感。
+    private float _vw;
+    private float _vh;
     // CSS env(safe-area-inset-*) 系数（通常为 1，可用 calc 缩放）。在已知安全区边距前不参与
     // ToPixels；由 ResolveSafeArea 在样式计算阶段折算进 _px 后清零，使其后的布局透明无感。
     private float _safeTop;
@@ -35,6 +40,7 @@ public struct Length
     public Length(float value, LengthUnit unit = LengthUnit.Px)
     {
         _px = _em = _rem = _percent = _number = 0;
+        _vw = _vh = 0;
         _safeTop = _safeRight = _safeBottom = _safeLeft = 0;
         _isAuto = false;
 
@@ -45,6 +51,8 @@ public struct Length
             case LengthUnit.Rem: _rem = value; break;
             case LengthUnit.Percent: _percent = value; break;
             case LengthUnit.Number: _number = value; break;
+            case LengthUnit.Vw: _vw = value; break;
+            case LengthUnit.Vh: _vh = value; break;
             case LengthUnit.Auto: _isAuto = true; break;
         }
     }
@@ -53,6 +61,10 @@ public struct Length
     public static Length Percent(float value) => new Length(value, LengthUnit.Percent);
     public static Length Rem(float value) => new Length(value, LengthUnit.Rem);
     public static Length Em(float value) => new Length(value, LengthUnit.Em);
+    /// <summary>视窗宽度单位：<c>1vw</c> = 视口宽度的 1%。由 <see cref="ResolveViewport"/> 折算成 px。</summary>
+    public static Length Vw(float value) => new Length(value, LengthUnit.Vw);
+    /// <summary>视窗高度单位：<c>1vh</c> = 视口高度的 1%。由 <see cref="ResolveViewport"/> 折算成 px。</summary>
+    public static Length Vh(float value) => new Length(value, LengthUnit.Vh);
     /// <summary>无单位数值（如无单位 line-height）：解析为 系数 × 字体大小。</summary>
     public static Length Number(float value) => new Length(value, LengthUnit.Number);
     public static Length Auto => new Length(0, LengthUnit.Auto);
@@ -87,6 +99,8 @@ public struct Length
             if (_rem != 0) nonZero++;
             if (_percent != 0) nonZero++;
             if (_number != 0) nonZero++;
+            if (_vw != 0) nonZero++;
+            if (_vh != 0) nonZero++;
             if (_safeTop != 0) nonZero++;
             if (_safeRight != 0) nonZero++;
             if (_safeBottom != 0) nonZero++;
@@ -105,10 +119,12 @@ public struct Length
         get
         {
             if (_isAuto) return 0;
-            if (_em != 0 && _px == 0 && _rem == 0 && _percent == 0 && _number == 0) return _em;
-            if (_rem != 0 && _px == 0 && _em == 0 && _percent == 0 && _number == 0) return _rem;
-            if (_percent != 0 && _px == 0 && _em == 0 && _rem == 0 && _number == 0) return _percent;
-            if (_number != 0 && _px == 0 && _em == 0 && _rem == 0 && _percent == 0) return _number;
+            if (_em != 0 && _px == 0 && _rem == 0 && _percent == 0 && _number == 0 && _vw == 0 && _vh == 0) return _em;
+            if (_rem != 0 && _px == 0 && _em == 0 && _percent == 0 && _number == 0 && _vw == 0 && _vh == 0) return _rem;
+            if (_percent != 0 && _px == 0 && _em == 0 && _rem == 0 && _number == 0 && _vw == 0 && _vh == 0) return _percent;
+            if (_number != 0 && _px == 0 && _em == 0 && _rem == 0 && _percent == 0 && _vw == 0 && _vh == 0) return _number;
+            if (_vw != 0 && _px == 0 && _em == 0 && _rem == 0 && _percent == 0 && _number == 0 && _vh == 0) return _vw;
+            if (_vh != 0 && _px == 0 && _em == 0 && _rem == 0 && _percent == 0 && _number == 0 && _vw == 0) return _vh;
             return _px;
         }
     }
@@ -121,10 +137,12 @@ public struct Length
         get
         {
             if (_isAuto) return LengthUnit.Auto;
-            if (_em != 0 && _px == 0 && _rem == 0 && _percent == 0 && _number == 0) return LengthUnit.Em;
-            if (_rem != 0 && _px == 0 && _em == 0 && _percent == 0 && _number == 0) return LengthUnit.Rem;
-            if (_percent != 0 && _px == 0 && _em == 0 && _rem == 0 && _number == 0) return LengthUnit.Percent;
-            if (_number != 0 && _px == 0 && _em == 0 && _rem == 0 && _percent == 0) return LengthUnit.Number;
+            if (_em != 0 && _px == 0 && _rem == 0 && _percent == 0 && _number == 0 && _vw == 0 && _vh == 0) return LengthUnit.Em;
+            if (_rem != 0 && _px == 0 && _em == 0 && _percent == 0 && _number == 0 && _vw == 0 && _vh == 0) return LengthUnit.Rem;
+            if (_percent != 0 && _px == 0 && _em == 0 && _rem == 0 && _number == 0 && _vw == 0 && _vh == 0) return LengthUnit.Percent;
+            if (_number != 0 && _px == 0 && _em == 0 && _rem == 0 && _percent == 0 && _vw == 0 && _vh == 0) return LengthUnit.Number;
+            if (_vw != 0 && _px == 0 && _em == 0 && _rem == 0 && _percent == 0 && _number == 0 && _vh == 0) return LengthUnit.Vw;
+            if (_vh != 0 && _px == 0 && _em == 0 && _rem == 0 && _percent == 0 && _number == 0 && _vw == 0) return LengthUnit.Vh;
             return LengthUnit.Px;
         }
     }
@@ -132,6 +150,36 @@ public struct Length
     /// <summary>该长度是否含未折算的 env(safe-area-inset-*) 分量。</summary>
     public bool HasSafeAreaComponent =>
         _safeTop != 0 || _safeRight != 0 || _safeBottom != 0 || _safeLeft != 0;
+
+    /// <summary>该长度是否含未折算的视窗单位（vw/vh）分量。</summary>
+    public bool HasViewportComponent => _vw != 0 || _vh != 0;
+
+    /// <summary>
+    /// 折算视窗单位（vw/vh）分量：<c>vw</c> 乘视口宽度、<c>vh</c> 乘视口高度（各按 1% 计），
+    /// 并入 px 分量后清零视窗系数。其余分量（px/em/rem/percent/number/safe*）保持不变，
+    /// 因此可与 calc 风格的复合长度共存（如 <c>calc(100vw - 240px)</c>）。
+    /// 在样式计算阶段（已知视口尺寸时）调用一次即可，之后该长度的 ToPixels 行为与普通长度完全一致。
+    /// </summary>
+    /// <param name="viewportWidth">视口宽度（逻辑像素），用于折算 vw。</param>
+    /// <param name="viewportHeight">视口高度（逻辑像素），用于折算 vh。</param>
+    public Length ResolveViewport(float viewportWidth, float viewportHeight)
+    {
+        if (_isAuto || !HasViewportComponent) return this;
+
+        return new Length
+        {
+            _px = _px + _vw / 100f * viewportWidth + _vh / 100f * viewportHeight,
+            _em = _em,
+            _rem = _rem,
+            _percent = _percent,
+            _number = _number,
+            // 视窗分量已折算进 _px，清零避免重复折算。
+            _safeTop = _safeTop,
+            _safeRight = _safeRight,
+            _safeBottom = _safeBottom,
+            _safeLeft = _safeLeft,
+        };
+    }
 
     /// <summary>
     /// 折算 env(safe-area-inset-*) 分量：将各方向系数乘以对应的安全区边距并并入 px 分量，
@@ -154,6 +202,8 @@ public struct Length
             _rem = _rem,
             _percent = _percent,
             _number = _number,
+            _vw = _vw,
+            _vh = _vh,
             // 安全区分量已折算进 _px，清零避免重复折算。
         };
     }
@@ -195,6 +245,8 @@ public struct Length
             _rem = x._rem + y._rem,
             _percent = x._percent + y._percent,
             _number = x._number + y._number,
+            _vw = x._vw + y._vw,
+            _vh = x._vh + y._vh,
             _safeTop = x._safeTop + y._safeTop,
             _safeRight = x._safeRight + y._safeRight,
             _safeBottom = x._safeBottom + y._safeBottom,
@@ -212,6 +264,8 @@ public struct Length
             _rem = x._rem - y._rem,
             _percent = x._percent - y._percent,
             _number = x._number - y._number,
+            _vw = x._vw - y._vw,
+            _vh = x._vh - y._vh,
             _safeTop = x._safeTop - y._safeTop,
             _safeRight = x._safeRight - y._safeRight,
             _safeBottom = x._safeBottom - y._safeBottom,
@@ -229,6 +283,8 @@ public struct Length
             _rem = -x._rem,
             _percent = -x._percent,
             _number = -x._number,
+            _vw = -x._vw,
+            _vh = -x._vh,
             _safeTop = -x._safeTop,
             _safeRight = -x._safeRight,
             _safeBottom = -x._safeBottom,
@@ -247,6 +303,8 @@ public struct Length
             _rem = x._rem * factor,
             _percent = x._percent * factor,
             _number = x._number * factor,
+            _vw = x._vw * factor,
+            _vh = x._vh * factor,
             _safeTop = x._safeTop * factor,
             _safeRight = x._safeRight * factor,
             _safeBottom = x._safeBottom * factor,
@@ -266,6 +324,8 @@ public struct Length
             _rem = x._rem / divisor,
             _percent = x._percent / divisor,
             _number = x._number / divisor,
+            _vw = x._vw / divisor,
+            _vh = x._vh / divisor,
             _safeTop = x._safeTop / divisor,
             _safeRight = x._safeRight / divisor,
             _safeBottom = x._safeBottom / divisor,
@@ -292,6 +352,8 @@ public struct Length
                 LengthUnit.Rem => $"{_rem}rem",
                 LengthUnit.Percent => $"{_percent}%",
                 LengthUnit.Number => $"{_number}",
+                LengthUnit.Vw => $"{_vw}vw",
+                LengthUnit.Vh => $"{_vh}vh",
                 _ => Value.ToString()
             };
         }
@@ -303,6 +365,8 @@ public struct Length
         if (_number != 0) parts.Add($"{_number}");
         if (_px != 0) parts.Add($"{_px}px");
         if (_percent != 0) parts.Add($"{_percent}%");
+        if (_vw != 0) parts.Add($"{_vw}vw");
+        if (_vh != 0) parts.Add($"{_vh}vh");
         if (_safeTop != 0) parts.Add(SafeAreaString("top", _safeTop));
         if (_safeRight != 0) parts.Add(SafeAreaString("right", _safeRight));
         if (_safeBottom != 0) parts.Add(SafeAreaString("bottom", _safeBottom));

--- a/src/Miko/Layout/LayoutEngine.cs
+++ b/src/Miko/Layout/LayoutEngine.cs
@@ -23,6 +23,9 @@ public class LayoutEngine
     // 从而全屏浮层（菜单遮罩等）仍覆盖整个屏幕（见 ISSUE-054）。
     private SafeAreaInsets _safeArea;
 
+    // 当前布局的视口尺寸。用于折算各元素（含伪元素）的 vw/vh 视窗单位（见 ISSUE-091）。
+    private ViewportInfo _viewport = new(0, 0);
+
     /// <summary>
     /// 执行布局计算
     /// </summary>
@@ -36,8 +39,9 @@ public class LayoutEngine
         _safeArea = safeArea;
 
         // 视口为全屏：env(safe-area-inset-*) 由各内容元素按需折算成内边距，浮层不受影响。
-        // 1. 样式计算：为每个元素计算最终样式（并折算其 env() 安全区分量）。
+        // 1. 样式计算：为每个元素计算最终样式（并折算其 env() 安全区分量与 vw/vh 视窗分量）。
         var viewport = new ViewportInfo(viewportWidth, viewportHeight);
+        _viewport = viewport;
         ComputeStyles(root, styleSheets, viewport);
 
         // 2. 构建布局树：根据 display 属性过滤和组织
@@ -170,6 +174,11 @@ public class LayoutEngine
     private void ComputeStyles(Element element, List<StyleSheet> styleSheets, ViewportInfo viewport)
     {
         var computedStyle = _styleResolver.Resolve(element, styleSheets, viewport);
+
+        // 折算该元素声明的视窗单位（vw/vh）为像素。vw/vh 始终相对整个视口，与包含块无关，
+        // 故在此（样式计算阶段、已知视口时）一次折算，之后布局对其无感（font-size 中的 vw/vh
+        // 已由 StyleResolver 经 FromStyle 单独折算，须先于其 em 解析）。
+        computedStyle.ResolveViewport(viewport);
 
         // 折算该元素声明的 env(safe-area-inset-*) 长度为像素（桌面/零安全区时为空操作）。
         computedStyle.ResolveSafeArea(_safeArea);
@@ -335,12 +344,15 @@ public class LayoutEngine
         }
 
         // 伪元素继承其宿主元素的自定义变量作用域，使 content:/color: 等的 Var(...) 可解析。
+        // 传入视口以折算伪元素自身 font-size 中的 vw/vh（须先于其 em 解析）。
         var hostVarScope = element.LayoutBox?.ComputedStyle?.Vars;
-        var computedStyle = ComputedStyle.FromStyle(matchedStyle, varScope: hostVarScope);
+        var computedStyle = ComputedStyle.FromStyle(matchedStyle, varScope: hostVarScope, viewport: _viewport);
         // content 文本通过 facade setter 变为 pseudoElement 的 TextNode 子节点（见 ISSUE-086）。
         // Content 可能是 Var(...) 引用，用计算样式解析后的具体值。
         computedStyle.TryResolveStyleProperty(matchedStyle.Content ?? default, out string? resolvedContent);
         var pseudoElement = new PseudoElement { TextContent = resolvedContent, Type = type };
+        // 折算伪元素声明的 vw/vh 视窗分量与 env() 安全区分量（与普通元素一致）。
+        computedStyle.ResolveViewport(_viewport);
         computedStyle.ResolveSafeArea(_safeArea);
 
         pseudoElement.LayoutBox = new LayoutBox

--- a/src/Miko/Styling/CalcValue.cs
+++ b/src/Miko/Styling/CalcValue.cs
@@ -1,0 +1,127 @@
+using Miko.Common;
+
+namespace Miko.Styling;
+
+/// <summary>
+/// 延迟求值的 calc 表达式（对应 CSS 的 <c>calc(...)</c>）。
+/// 封装一个「变量作用域 → 长度」的闭包：变量的具体值只有在样式计算阶段、拿到作用域后才已知，
+/// 因此 <c>-1 * Var("--bs-border-width")</c> 这类含变量的算术会先构造成 <see cref="CalcValue{T}"/>，
+/// 推迟到 <see cref="ComputedStyle"/> 解析属性时再对当前作用域求值。
+/// <para>
+/// 运算按 <see cref="Length"/> 的分量语义进行（px/em/rem/percent 不提前折算），故 calc 结果里的
+/// 相对单位会一路保留到布局阶段解析——无需在此重复实现单位算术。
+/// </para>
+/// <para>
+/// 当前仅面向 <b>长度域</b>（实际构造的恒为 <c>T = Length</c>）：运算符只接受/产出
+/// <see cref="Length"/> / <see cref="VarReference"/> / <c>float</c>，因此 Color/枚举/字符串
+/// 天然无法参与 calc（编译期即被类型系统拦下），无需运行时判定。
+/// </para>
+/// </summary>
+public readonly struct CalcValue<T>
+{
+    // 作用域 → 长度；返回 null 表示引用的变量未解析（缺失且无回退，或类型不匹配）。
+    private readonly Func<Dictionary<string, VarValue>?, Length?> _eval;
+
+    internal CalcValue(Func<Dictionary<string, VarValue>?, Length?> eval) => _eval = eval;
+
+    /// <summary>
+    /// 对给定的变量作用域求值。任一引用的变量未解析时返回 <c>false</c>（调用方据此保留默认值，
+    /// 与未解析的 <c>Var(...)</c> 行为一致）。
+    /// </summary>
+    public bool TryEvaluate(Dictionary<string, VarValue>? scope, out T value)
+    {
+        if (_eval != null && _eval(scope) is { } length)
+        {
+            // 长度域：内部恒为 Length，此处的装箱转换在 T == Length 时是恒等的。
+            value = (T)(object)length;
+            return true;
+        }
+
+        value = default!;
+        return false;
+    }
+
+    /// <summary>从变量引用创建 calc 叶子：按现有 Var 解析路径（作用域命中 → 回退值）取长度。</summary>
+    public static CalcValue<T> FromVar(VarReference reference)
+    {
+        // VarReference 是结构体：闭包不能捕获 this，故先复制字段到局部（见 CS1673）。
+        var name = reference.Name;
+        var fallback = reference.Fallback;
+        return new CalcValue<T>(scope =>
+        {
+            if (scope != null && scope.TryGetValue(name, out var resolved) && resolved.TryGet<Length>(out var value))
+                return value;
+            if (fallback is { } fb && fb.TryGet<Length>(out var fbValue))
+                return fbValue;
+            return null;
+        });
+    }
+
+    /// <summary>从具体长度创建 calc 叶子（恒定值）。</summary>
+    public static CalcValue<T> FromLength(Length value) => new CalcValue<T>(_ => value);
+
+    // ---- 运算符 ----
+    // 全部返回 CalcValue<T>，按 Length 语义组合；任一操作数未解析（null）则整体未解析（null）。
+
+    public static CalcValue<T> operator -(CalcValue<T> x)
+    {
+        var xe = x._eval;
+        return new CalcValue<T>(s => xe(s) is { } l ? -l : (Length?)null);
+    }
+
+    public static CalcValue<T> operator *(float factor, CalcValue<T> x)
+    {
+        var xe = x._eval;
+        return new CalcValue<T>(s => xe(s) is { } l ? factor * l : (Length?)null);
+    }
+
+    public static CalcValue<T> operator *(CalcValue<T> x, float factor) => factor * x;
+
+    public static CalcValue<T> operator /(CalcValue<T> x, float divisor)
+    {
+        var xe = x._eval;
+        return new CalcValue<T>(s => xe(s) is { } l ? l / divisor : (Length?)null);
+    }
+
+    public static CalcValue<T> operator +(CalcValue<T> x, CalcValue<T> y)
+    {
+        var xe = x._eval;
+        var ye = y._eval;
+        return new CalcValue<T>(s => xe(s) is { } a && ye(s) is { } b ? a + b : (Length?)null);
+    }
+
+    public static CalcValue<T> operator -(CalcValue<T> x, CalcValue<T> y)
+    {
+        var xe = x._eval;
+        var ye = y._eval;
+        return new CalcValue<T>(s => xe(s) is { } a && ye(s) is { } b ? a - b : (Length?)null);
+    }
+
+    public static CalcValue<T> operator +(CalcValue<T> x, Length y) => x + FromLength(y);
+    public static CalcValue<T> operator +(Length x, CalcValue<T> y) => FromLength(x) + y;
+    public static CalcValue<T> operator -(CalcValue<T> x, Length y) => x - FromLength(y);
+    public static CalcValue<T> operator -(Length x, CalcValue<T> y) => FromLength(x) - y;
+
+    // 与变量引用交叉运算（VarReference 侧同样提供对称重载，便于链式书写）。
+    public static CalcValue<T> operator +(CalcValue<T> x, VarReference y) => x + FromVar(y);
+    public static CalcValue<T> operator +(VarReference x, CalcValue<T> y) => FromVar(x) + y;
+    public static CalcValue<T> operator -(CalcValue<T> x, VarReference y) => x - FromVar(y);
+    public static CalcValue<T> operator -(VarReference x, CalcValue<T> y) => FromVar(x) - y;
+
+    public override string ToString() => "calc(...)";
+}
+
+/// <summary>
+/// calc 闭包的作用域句柄。作为 <c>Calc(s =&gt; ...)</c> lambda 的形参，提供与
+/// <see cref="Css.Var(string)"/> 等价的 <c>s.Var("--x")</c> 写法（返回同一个 <see cref="VarReference"/>，
+/// 因此 <c>s.Var(...)</c> 与自由函数 <c>Var(...)</c> 可互换）。它同时给 lambda 一个具体委托类型，
+/// 使 <c>Calc(s =&gt; ...)</c> 无需类型标注即可推断。
+/// </summary>
+public readonly struct CalcScope
+{
+    /// <summary>创建对自定义变量 <paramref name="name"/> 的引用（等价于 <see cref="Css.Var(string)"/>）。</summary>
+    public VarReference Var(string name) => new(name);
+
+    /// <summary>创建带回退值的变量引用（等价于 <see cref="Css.Var(string, VarValue)"/>）。</summary>
+    public VarReference Var(string name, VarValue fallback) => new(name, fallback);
+}

--- a/src/Miko/Styling/ComputedStyle.cs
+++ b/src/Miko/Styling/ComputedStyle.cs
@@ -164,6 +164,11 @@ public partial class ComputedStyle : Style
         if (property.TryGetValue(out value))
             return true;
 
+        // calc 表达式：对当前变量作用域求值；引用的变量未解析时返回 false（保留默认值，
+        // 与未解析的 Var(...) 行为一致）。
+        if (property.IsCalc)
+            return property.TryEvaluateCalc(Vars, out value);
+
         // 关键词但无“父属性值 + 是否可继承”上下文：无法就地消解，视为未解析。
         // （带上下文的重载会正确处理；此重载仅供不涉及关键词的调用点复用。）
         if (property.IsKeyword)
@@ -236,8 +241,14 @@ public partial class ComputedStyle : Style
     /// 父元素的计算样式。用于解析 CSS 全局关键词 <c>inherit</c> / <c>unset</c> 等
     /// （读取父属性值）。根元素为 null。
     /// </param>
+    /// <param name="viewport">
+    /// 视口尺寸。用于折算 font-size 中的 vw/vh 视窗单位（须先于其 em 解析）。
+    /// null 时 font-size 的视窗分量按 0 计（缺少视口上下文）。其余属性的 vw/vh 由
+    /// <see cref="ResolveViewport"/> 在样式计算阶段统一折算。
+    /// </param>
     public static ComputedStyle FromStyle(Style? style, float? parentFontSizePx = null,
-        Dictionary<string, VarValue>? varScope = null, ComputedStyle? parent = null)
+        Dictionary<string, VarValue>? varScope = null, ComputedStyle? parent = null,
+        ViewportInfo? viewport = null)
     {
         var computed = new ComputedStyle();
         // 先设作用域与父上下文：ApplyStylePropertiesGenerated 与下方特例都会经
@@ -254,6 +265,9 @@ public partial class ComputedStyle : Style
             if (style.FontSize is { } fontSizeProp &&
                 computed.TryResolveStyleProperty(fontSizeProp, parent?.FontSize ?? default, inheritable: true, out var fontSize))
             {
+                // vw/vh 相对视口解析，须先于 em（否则视窗分量会被 ToPixels 按 0 折算而丢失）。
+                if (viewport != null)
+                    fontSize = fontSize.ResolveViewport(viewport.Width, viewport.Height);
                 computed.FontSize = Length.Px(fontSize.ToPixels(0, parentFontSizePx));
             }
 
@@ -332,5 +346,64 @@ public partial class ComputedStyle : Style
         MaxWidth = MaxWidth.ResolveSafeArea(insets);
         MaxHeight = MaxHeight.ResolveSafeArea(insets);
         FlexBasis = FlexBasis.ResolveSafeArea(insets);
+    }
+
+    /// <summary>
+    /// 折算所有长度属性中的视窗单位（vw/vh）分量为像素。由布局引擎在样式计算阶段、
+    /// 已知视口尺寸时调用。仅影响显式使用了 vw/vh 的属性（其余长度原样返回），
+    /// 因此对未使用视窗单位的元素完全无副作用。
+    /// <para>
+    /// vw/vh 始终相对整个视口解析（1vw = 视口宽度的 1%、1vh = 视口高度的 1%），
+    /// 与包含块尺寸无关；因此可与 calc 复合长度共存（如 <c>calc(100vw - 240px)</c>）。
+    /// font-size 中的 vw/vh 由 <see cref="FromStyle"/> 单独折算（须先于其 em 解析），此处不再处理。
+    /// </para>
+    /// </summary>
+    public void ResolveViewport(ViewportInfo viewport)
+    {
+        float vw = viewport.Width;
+        float vh = viewport.Height;
+
+        PaddingTop = PaddingTop.ResolveViewport(vw, vh);
+        PaddingRight = PaddingRight.ResolveViewport(vw, vh);
+        PaddingBottom = PaddingBottom.ResolveViewport(vw, vh);
+        PaddingLeft = PaddingLeft.ResolveViewport(vw, vh);
+
+        MarginTop = MarginTop.ResolveViewport(vw, vh);
+        MarginRight = MarginRight.ResolveViewport(vw, vh);
+        MarginBottom = MarginBottom.ResolveViewport(vw, vh);
+        MarginLeft = MarginLeft.ResolveViewport(vw, vh);
+
+        Top = Top.ResolveViewport(vw, vh);
+        Right = Right.ResolveViewport(vw, vh);
+        Bottom = Bottom.ResolveViewport(vw, vh);
+        Left = Left.ResolveViewport(vw, vh);
+
+        Width = Width.ResolveViewport(vw, vh);
+        Height = Height.ResolveViewport(vw, vh);
+        MinWidth = MinWidth.ResolveViewport(vw, vh);
+        MinHeight = MinHeight.ResolveViewport(vw, vh);
+        MaxWidth = MaxWidth.ResolveViewport(vw, vh);
+        MaxHeight = MaxHeight.ResolveViewport(vw, vh);
+        FlexBasis = FlexBasis.ResolveViewport(vw, vh);
+
+        BorderTopWidth = BorderTopWidth.ResolveViewport(vw, vh);
+        BorderRightWidth = BorderRightWidth.ResolveViewport(vw, vh);
+        BorderBottomWidth = BorderBottomWidth.ResolveViewport(vw, vh);
+        BorderLeftWidth = BorderLeftWidth.ResolveViewport(vw, vh);
+
+        BorderTopLeftRadius = BorderTopLeftRadius.ResolveViewport(vw, vh);
+        BorderTopRightRadius = BorderTopRightRadius.ResolveViewport(vw, vh);
+        BorderBottomRightRadius = BorderBottomRightRadius.ResolveViewport(vw, vh);
+        BorderBottomLeftRadius = BorderBottomLeftRadius.ResolveViewport(vw, vh);
+
+        OutlineWidth = OutlineWidth.ResolveViewport(vw, vh);
+        OutlineOffset = OutlineOffset.ResolveViewport(vw, vh);
+
+        LineHeight = LineHeight.ResolveViewport(vw, vh);
+        LetterSpacing = LetterSpacing.ResolveViewport(vw, vh);
+
+        Gap = Gap.ResolveViewport(vw, vh);
+        RowGap = RowGap.ResolveViewport(vw, vh);
+        ColumnGap = ColumnGap.ResolveViewport(vw, vh);
     }
 }

--- a/src/Miko/Styling/StyleProperty.cs
+++ b/src/Miko/Styling/StyleProperty.cs
@@ -1,23 +1,26 @@
 namespace Miko.Styling;
 
 /// <summary>
-/// 样式属性的联合值，三选一：具体值 <typeparamref name="T"/>、变量引用
-/// <see cref="Styling.VarReference"/>（如 <c>Color = Var("--button-color")</c>），
-/// 或一个 CSS 全局关键词 <see cref="StyleKeyword"/>（如 <c>Color = Initial</c>）。
+/// 样式属性的联合值，四选一：具体值 <typeparamref name="T"/>、变量引用
+/// <see cref="Styling.VarReference"/>（如 <c>Color = Var("--button-color")</c>）、
+/// 一个 CSS 全局关键词 <see cref="StyleKeyword"/>（如 <c>Color = Initial</c>），
+/// 或一个延迟求值的 calc 表达式 <see cref="CalcValue{T}"/>（如 <c>MarginLeft = -1 * Var("--bs-border-width")</c>）。
 /// <para>
 /// 通过隐式转换，既有写法 <c>Color = Color.Red</c> / <c>Width = Length.Px(100)</c> 保持不变；
 /// 变量写法 <c>Color = Var("--x")</c> 经 <see cref="VarReference"/> 隐式转换成立；
-/// 关键词写法 <c>Color = Initial</c> 经 <see cref="StyleKeyword"/> 隐式转换成立。
+/// 关键词写法 <c>Color = Initial</c> 经 <see cref="StyleKeyword"/> 隐式转换成立；
+/// calc 写法 <c>MarginLeft = -1 * Var("--x")</c> / <c>Calc(s =&gt; ...)</c> 经 <see cref="CalcValue{T}"/> 隐式转换成立。
 /// </para>
 /// </summary>
 public readonly struct StyleProperty<T>
 {
     /// <summary>联合体判别式：当前 <see cref="StyleProperty{T}"/> 持有的是哪一路。</summary>
-    private enum Slot : byte { Value, Var, Keyword }
+    private enum Slot : byte { Value, Var, Keyword, Calc }
 
     private readonly T _value;
     private readonly VarReference _var;
     private readonly StyleKeyword _keyword;
+    private readonly CalcValue<T> _calc;
     private readonly Slot _slot;
 
     public StyleProperty(T value)
@@ -25,6 +28,7 @@ public readonly struct StyleProperty<T>
         _value = value;
         _var = default;
         _keyword = default;
+        _calc = default;
         _slot = Slot.Value;
     }
 
@@ -33,6 +37,7 @@ public readonly struct StyleProperty<T>
         _value = default!;
         _var = var;
         _keyword = default;
+        _calc = default;
         _slot = Slot.Var;
     }
 
@@ -41,7 +46,17 @@ public readonly struct StyleProperty<T>
         _value = default!;
         _var = default;
         _keyword = keyword;
+        _calc = default;
         _slot = Slot.Keyword;
+    }
+
+    public StyleProperty(CalcValue<T> calc)
+    {
+        _value = default!;
+        _var = default;
+        _keyword = default;
+        _calc = calc;
+        _slot = Slot.Calc;
     }
 
     /// <summary>是否为变量引用（而非具体值或关键词）。</summary>
@@ -50,11 +65,27 @@ public readonly struct StyleProperty<T>
     /// <summary>是否为 CSS 全局关键词（而非具体值或变量引用）。</summary>
     public bool IsKeyword => _slot == Slot.Keyword;
 
+    /// <summary>是否为延迟求值的 calc 表达式。</summary>
+    public bool IsCalc => _slot == Slot.Calc;
+
     /// <summary>变量引用（仅当 <see cref="IsVar"/> 为 true 时有意义）。</summary>
     public VarReference VarRef => _var;
 
     /// <summary>CSS 全局关键词（仅当 <see cref="IsKeyword"/> 为 true 时有意义）。</summary>
     public StyleKeyword Keyword => _keyword;
+
+    /// <summary>
+    /// 对 calc 表达式求值（仅当 <see cref="IsCalc"/> 为 true 时有意义）。
+    /// 引用的变量在 <paramref name="scope"/> 中未解析时返回 <c>false</c>（调用方保留默认值）。
+    /// </summary>
+    public bool TryEvaluateCalc(Dictionary<string, VarValue>? scope, out T value)
+    {
+        if (_slot == Slot.Calc)
+            return _calc.TryEvaluate(scope, out value);
+
+        value = default!;
+        return false;
+    }
 
     /// <summary>
     /// 尝试取出具体值。当持有变量引用或关键词时返回 <c>false</c>（此时需先经作用域/级联解析）。
@@ -75,11 +106,13 @@ public readonly struct StyleProperty<T>
     public static implicit operator StyleProperty<T>(T value) => new(value);
     public static implicit operator StyleProperty<T>(VarReference var) => new(var);
     public static implicit operator StyleProperty<T>(StyleKeyword keyword) => new(keyword);
+    public static implicit operator StyleProperty<T>(CalcValue<T> calc) => new(calc);
 
     public override string ToString() => _slot switch
     {
         Slot.Var => $"var({_var.Name})",
         Slot.Keyword => _keyword.ToString(),
+        Slot.Calc => _calc.ToString(),
         _ => _value?.ToString() ?? "",
     };
 }

--- a/src/Miko/Styling/StyleResolver.cs
+++ b/src/Miko/Styling/StyleResolver.cs
@@ -92,8 +92,8 @@ public class StyleResolver
         var varScope = BuildVarScope(parentVarScope, baseStyle.Vars);
 
         // 9. 转换为计算样式（传入父字体大小以正确解析 font-size 中的 em；传入变量作用域解析 Var 引用；
-        //    传入父计算样式以解析 inherit/unset 等全局关键词）
-        return ComputedStyle.FromStyle(baseStyle, parentFontSizePx, varScope, parentComputed);
+        //    传入父计算样式以解析 inherit/unset 等全局关键词；传入视口以折算 font-size 中的 vw/vh）
+        return ComputedStyle.FromStyle(baseStyle, parentFontSizePx, varScope, parentComputed, viewport);
     }
 
     /// <summary>

--- a/src/Miko/Styling/VarReference.cs
+++ b/src/Miko/Styling/VarReference.cs
@@ -41,16 +41,6 @@ public static class Css
     /// <summary>创建带回退值的变量引用；变量在作用域内未定义时使用 <paramref name="fallback"/>。</summary>
     public static VarReference Var(string name, VarValue fallback) => new(name, fallback);
 
-    // ---- 视窗单位 ----
-    // vw/vh 相对整个视口解析（1vw = 视口宽度的 1%、1vh = 视口高度的 1%），在样式计算阶段折算成 px。
-    // 参与 calc：如 Width = Vw(100) - Length.Px(240)（对应 CSS calc(100vw - 240px)）。
-
-    /// <summary>视窗宽度长度：<c>Vw(100)</c> 等价于 CSS <c>100vw</c>。</summary>
-    public static Length Vw(float value) => Length.Vw(value);
-
-    /// <summary>视窗高度长度：<c>Vh(100)</c> 等价于 CSS <c>100vh</c>。</summary>
-    public static Length Vh(float value) => Length.Vh(value);
-
     // ---- calc(...) ----
     // 含变量的算术（如 -1 * Var("--x")）本身即为 CalcValue<T>，可直接赋给样式属性
     // （经 StyleProperty<T> 的隐式转换）。Calc 为可读的 CSS 风格别名/包装：

--- a/src/Miko/Styling/VarReference.cs
+++ b/src/Miko/Styling/VarReference.cs
@@ -1,3 +1,5 @@
+using Miko.Common;
+
 namespace Miko.Styling;
 
 /// <summary>
@@ -5,7 +7,27 @@ namespace Miko.Styling;
 /// <paramref name="Name"/> 为变量名（约定以 <c>--</c> 开头），
 /// <paramref name="Fallback"/> 为变量在作用域内未定义时使用的回退值。
 /// </summary>
-public readonly record struct VarReference(string Name, VarValue? Fallback = null);
+public readonly record struct VarReference(string Name, VarValue? Fallback = null)
+{
+    // ---- calc 算术运算符 ----
+    // 对变量引用做算术（如 -1 * Var("--bs-border-width")）会构造成延迟求值的 CalcValue<Length>，
+    // 在样式计算阶段拿到作用域后才折算。变量在此按长度域解析（见 CalcValue 说明）。
+
+    public static CalcValue<Length> operator -(VarReference x) => -CalcValue<Length>.FromVar(x);
+
+    public static CalcValue<Length> operator *(float factor, VarReference x) => factor * CalcValue<Length>.FromVar(x);
+    public static CalcValue<Length> operator *(VarReference x, float factor) => factor * CalcValue<Length>.FromVar(x);
+
+    public static CalcValue<Length> operator /(VarReference x, float divisor) => CalcValue<Length>.FromVar(x) / divisor;
+
+    public static CalcValue<Length> operator +(VarReference x, VarReference y) => CalcValue<Length>.FromVar(x) + CalcValue<Length>.FromVar(y);
+    public static CalcValue<Length> operator -(VarReference x, VarReference y) => CalcValue<Length>.FromVar(x) - CalcValue<Length>.FromVar(y);
+
+    public static CalcValue<Length> operator +(VarReference x, Length y) => CalcValue<Length>.FromVar(x) + y;
+    public static CalcValue<Length> operator +(Length x, VarReference y) => x + CalcValue<Length>.FromVar(y);
+    public static CalcValue<Length> operator -(VarReference x, Length y) => CalcValue<Length>.FromVar(x) - y;
+    public static CalcValue<Length> operator -(Length x, VarReference y) => x - CalcValue<Length>.FromVar(y);
+}
 
 /// <summary>
 /// 样式辅助方法的静态入口。通过 <c>using static Miko.Styling.Css;</c> 即可直接书写
@@ -18,6 +40,35 @@ public static class Css
 
     /// <summary>创建带回退值的变量引用；变量在作用域内未定义时使用 <paramref name="fallback"/>。</summary>
     public static VarReference Var(string name, VarValue fallback) => new(name, fallback);
+
+    // ---- 视窗单位 ----
+    // vw/vh 相对整个视口解析（1vw = 视口宽度的 1%、1vh = 视口高度的 1%），在样式计算阶段折算成 px。
+    // 参与 calc：如 Width = Vw(100) - Length.Px(240)（对应 CSS calc(100vw - 240px)）。
+
+    /// <summary>视窗宽度长度：<c>Vw(100)</c> 等价于 CSS <c>100vw</c>。</summary>
+    public static Length Vw(float value) => Length.Vw(value);
+
+    /// <summary>视窗高度长度：<c>Vh(100)</c> 等价于 CSS <c>100vh</c>。</summary>
+    public static Length Vh(float value) => Length.Vh(value);
+
+    // ---- calc(...) ----
+    // 含变量的算术（如 -1 * Var("--x")）本身即为 CalcValue<T>，可直接赋给样式属性
+    // （经 StyleProperty<T> 的隐式转换）。Calc 为可读的 CSS 风格别名/包装：
+    //   直接：MarginLeft = -1 * Var("--x");
+    //   包装：MarginLeft = Calc(-1 * Var("--x"));
+    //   带作用域 lambda：MarginLeft = Calc(s => -1 * Var("--x"));  或  Calc(s => -1 * s.Var("--x"));
+    // lambda 形参 s（CalcScope）提供与自由函数 Var(...) 等价的 s.Var(...)，并让 lambda 具备
+    // 具体委托类型以便类型推断。
+
+    /// <summary>calc 表达式的透传别名（读作 CSS 的 <c>calc(...)</c>）。</summary>
+    public static CalcValue<T> Calc<T>(CalcValue<T> expr) => expr;
+
+    /// <summary>
+    /// 以作用域 lambda 构造 calc 表达式：<c>Calc(s =&gt; -1 * Var("--x"))</c> 或
+    /// <c>Calc(s =&gt; -1 * s.Var("--x"))</c>。<paramref name="factory"/> 立即执行以构建延迟闭包
+    /// （实际求值仍推迟到样式计算阶段）。
+    /// </summary>
+    public static CalcValue<T> Calc<T>(Func<CalcScope, CalcValue<T>> factory) => factory(new CalcScope());
 
     // CSS 全局关键词的全局静态引用。经 StyleProperty<T> 的隐式转换可直接赋给任意样式属性，
     // 例如 using static Miko.Styling.Css; 后书写 style.Color = Initial;

--- a/tests/Miko.Tests/Common/ViewportLengthTests.cs
+++ b/tests/Miko.Tests/Common/ViewportLengthTests.cs
@@ -1,0 +1,206 @@
+using Miko.Common;
+using Shouldly;
+
+namespace Miko.Tests.Common;
+
+/// <summary>
+/// 视窗单位 vw/vh 的 <see cref="Length"/> 层单元测试（ISSUE-091）。
+/// 覆盖：工厂方法、单位/数值兼容 API、ResolveViewport 折算（基础与 calc 复合）、
+/// 各类算术运算符保留视窗分量、ToString、与安全区分量共存、幂等。
+/// </summary>
+public class ViewportLengthTests
+{
+    [Fact]
+    public void Vw_ShouldCreateViewportWidthLength()
+    {
+        var length = Length.Vw(100);
+
+        length.Value.ShouldBe(100);
+        length.Unit.ShouldBe(LengthUnit.Vw);
+        length.IsAuto.ShouldBeFalse();
+        length.HasViewportComponent.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Vh_ShouldCreateViewportHeightLength()
+    {
+        var length = Length.Vh(50);
+
+        length.Value.ShouldBe(50);
+        length.Unit.ShouldBe(LengthUnit.Vh);
+        length.HasViewportComponent.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void PlainPx_HasNoViewportComponent()
+    {
+        Length.Px(10).HasViewportComponent.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void BeforeResolve_ToPixelsIsZero()
+    {
+        // 未折算的 vw/vh 缺少视口上下文，ToPixels 按 0 计（与 env() 语义一致）。
+        Length.Vw(100).ToPixels(500).ShouldBe(0);
+        Length.Vh(100).ToPixels(500).ShouldBe(0);
+    }
+
+    [Fact]
+    public void ResolveViewport_Vw_FoldsAgainstViewportWidth()
+    {
+        // 100vw 相对视口宽度：1000 宽 → 1000px（与传入的 containerSize 无关）。
+        Length.Vw(100).ResolveViewport(1000, 800).ToPixels(500).ShouldBe(1000);
+        Length.Vw(50).ResolveViewport(1000, 800).ToPixels(500).ShouldBe(500);
+    }
+
+    [Fact]
+    public void ResolveViewport_Vh_FoldsAgainstViewportHeight()
+    {
+        Length.Vh(100).ResolveViewport(1000, 800).ToPixels(500).ShouldBe(800);
+        Length.Vh(25).ResolveViewport(1000, 800).ToPixels(500).ShouldBe(200);
+    }
+
+    [Fact]
+    public void ResolveViewport_IndependentOfContainerSize()
+    {
+        // vw/vh 不随包含块尺寸变化：不同 containerSize 得到相同像素值。
+        var resolved = Length.Vw(10).ResolveViewport(1000, 800);
+        resolved.ToPixels(200).ShouldBe(100);
+        resolved.ToPixels(9999).ShouldBe(100);
+    }
+
+    [Fact]
+    public void ResolveViewport_IssueExample_CalcVwMinusPx()
+    {
+        // width: calc(100vw - 240px) 在 1280 宽视口下 → 1040px。
+        var len = Length.Vw(100) - Length.Px(240);
+        var resolved = len.ResolveViewport(1280, 720);
+
+        resolved.ToPixels(0).ShouldBe(1040);
+        resolved.HasViewportComponent.ShouldBeFalse(); // 折算后不再是符号性长度
+    }
+
+    [Fact]
+    public void ResolveViewport_MixedVwVh_FoldsBoth()
+    {
+        // calc(50vw + 50vh)：1000 宽 + 800 高 → 500 + 400 = 900。
+        var len = Length.Vw(50) + Length.Vh(50);
+        len.ResolveViewport(1000, 800).ToPixels(0).ShouldBe(900);
+    }
+
+    [Fact]
+    public void ResolveViewport_PreservesPercentComponent()
+    {
+        // 复合 calc(100vw - 10%)：vw 折算成 px，百分比一路保留到 ToPixels 按容器解析。
+        var len = Length.Vw(100) - Length.Percent(10);
+        var resolved = len.ResolveViewport(1000, 800);
+
+        // 1000 - 10% of 200 = 1000 - 20 = 980
+        resolved.ToPixels(200).ShouldBe(980);
+    }
+
+    [Fact]
+    public void ResolveViewport_Auto_StaysAuto()
+    {
+        Length.Auto.ResolveViewport(1000, 800).IsAuto.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ResolveViewport_NoViewportComponent_ReturnsUnchanged()
+    {
+        var len = Length.Px(42);
+        len.ResolveViewport(1000, 800).ToPixels(0).ShouldBe(42);
+    }
+
+    [Fact]
+    public void ResolveViewport_Idempotent()
+    {
+        var once = Length.Vw(100).ResolveViewport(1000, 800);
+        var twice = once.ResolveViewport(1000, 800);
+
+        // 折算后视窗系数已清零，重复折算不会重复计入。
+        twice.ToPixels(0).ShouldBe(1000);
+    }
+
+    // ---- 算术运算符保留视窗分量 ----
+
+    [Fact]
+    public void Add_VwAndVw_KeepsUnit()
+    {
+        var result = Length.Vw(30) + Length.Vw(20);
+
+        result.Value.ShouldBe(50);
+        result.Unit.ShouldBe(LengthUnit.Vw);
+    }
+
+    [Fact]
+    public void Subtract_VhAndVh_KeepsUnit()
+    {
+        var result = Length.Vh(80) - Length.Vh(30);
+
+        result.Value.ShouldBe(50);
+        result.Unit.ShouldBe(LengthUnit.Vh);
+    }
+
+    [Fact]
+    public void Negate_Vw_NegatesValue()
+    {
+        var result = -Length.Vw(25);
+
+        result.ResolveViewport(1000, 800).ToPixels(0).ShouldBe(-250);
+    }
+
+    [Fact]
+    public void Multiply_Vw_ScalesComponent()
+    {
+        (Length.Vw(10) * 3f).ResolveViewport(1000, 800).ToPixels(0).ShouldBe(300);
+        (2f * Length.Vh(10)).ResolveViewport(1000, 800).ToPixels(0).ShouldBe(160);
+    }
+
+    [Fact]
+    public void Divide_Vw_ScalesComponent()
+    {
+        (Length.Vw(100) / 4f).ResolveViewport(1000, 800).ToPixels(0).ShouldBe(250);
+    }
+
+    // ---- ToString ----
+
+    [Theory]
+    [InlineData(100f, LengthUnit.Vw, "100vw")]
+    [InlineData(50f, LengthUnit.Vh, "50vh")]
+    public void ToString_SingleUnit_FormatsCorrectly(float value, LengthUnit unit, string expected)
+    {
+        new Length(value, unit).ToString().ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ToString_Composite_ListsViewportComponent()
+    {
+        (Length.Vw(100) - Length.Px(240)).ToString().ShouldBe("-240px + 100vw");
+    }
+
+    // ---- 与安全区分量共存（ResolveSafeArea 不应吞掉 vw/vh，反之亦然）----
+
+    [Fact]
+    public void ResolveSafeArea_PreservesViewportComponent()
+    {
+        // calc(100vh - env(safe-area-inset-bottom))：先折算安全区，vw/vh 分量保留。
+        var len = Length.Vh(100) - Length.SafeAreaInsetBottom;
+        var afterSafe = len.ResolveSafeArea(new SafeAreaInsets(0, 0, 0, 24));
+
+        afterSafe.HasViewportComponent.ShouldBeTrue();
+        // 再折算视口：800 高 - 24 安全区 = 776。
+        afterSafe.ResolveViewport(1000, 800).ToPixels(0).ShouldBe(776);
+    }
+
+    [Fact]
+    public void ResolveViewport_PreservesSafeAreaComponent()
+    {
+        // 折算顺序无关：先折算视口，安全区分量仍应保留待后续折算。
+        var len = Length.Vh(100) - Length.SafeAreaInsetBottom;
+        var afterViewport = len.ResolveViewport(1000, 800);
+
+        afterViewport.HasSafeAreaComponent.ShouldBeTrue();
+        afterViewport.ResolveSafeArea(new SafeAreaInsets(0, 0, 0, 24)).ToPixels(0).ShouldBe(776);
+    }
+}

--- a/tests/Miko.Tests/Layout/ViewportUnitsLayoutTests.cs
+++ b/tests/Miko.Tests/Layout/ViewportUnitsLayoutTests.cs
@@ -4,7 +4,7 @@ using Miko.Layout;
 using Miko.Styling;
 using Miko.Styling.Selectors;
 using Shouldly;
-using static Miko.Styling.Css;
+using static Miko.Common.Length;
 
 namespace Miko.Tests.Layout;
 

--- a/tests/Miko.Tests/Layout/ViewportUnitsLayoutTests.cs
+++ b/tests/Miko.Tests/Layout/ViewportUnitsLayoutTests.cs
@@ -1,0 +1,175 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Miko.Styling.Selectors;
+using Shouldly;
+using static Miko.Styling.Css;
+
+namespace Miko.Tests.Layout;
+
+/// <summary>
+/// 视窗单位 vw/vh 在 <see cref="LayoutEngine.Layout"/> 中的端到端测试（ISSUE-091）。
+/// vw/vh 相对整个视口解析（1vw = 视口宽度的 1%、1vh = 视口高度的 1%），在样式计算阶段折算成 px，
+/// 因此可直接用于尺寸/间距，并参与 calc（如 <c>calc(100vw - 240px)</c>）。
+/// </summary>
+public class ViewportUnitsLayoutTests
+{
+    private const float ViewportW = 1280f;
+    private const float ViewportH = 720f;
+
+    private readonly LayoutEngine _layoutEngine = new();
+
+    private static LayoutBox? FindByClass(LayoutBox box, string cls)
+    {
+        if (box.Element.Class == cls) return box;
+        foreach (var child in box.Children)
+        {
+            var found = FindByClass(child, cls);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    private static StyleSheet Sheet(string cls, Style style) => new()
+    {
+        Rules = new List<StyleRule>
+        {
+            new() { Selector = new ClassSelector(cls), Style = style }
+        }
+    };
+
+    [Fact]
+    public void Width100Vw_Height100Vh_FillViewport()
+    {
+        // width: 100vw; height: 100vh;
+        var root = new DivElement { Class = "box" };
+        var sheet = Sheet("box", new Style
+        {
+            Display = Display.Block,
+            Width = Length.Vw(100),
+            Height = Length.Vh(100),
+        });
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, ViewportW, ViewportH);
+
+        layout.BoxModel.Content.Width.ShouldBe(ViewportW);
+        layout.BoxModel.Content.Height.ShouldBe(ViewportH);
+    }
+
+    [Fact]
+    public void HalfViewport_ResolvesAgainstEachAxis()
+    {
+        // width: 50vw; height: 25vh;
+        var root = new DivElement { Class = "box" };
+        var sheet = Sheet("box", new Style
+        {
+            Display = Display.Block,
+            Width = Length.Vw(50),
+            Height = Length.Vh(25),
+        });
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, ViewportW, ViewportH);
+
+        layout.BoxModel.Content.Width.ShouldBe(ViewportW * 0.5f);   // 640
+        layout.BoxModel.Content.Height.ShouldBe(ViewportH * 0.25f); // 180
+    }
+
+    [Fact]
+    public void CalcVwMinusPx_IssueExample()
+    {
+        // width: calc(100vw - 240px);  → 1280 - 240 = 1040
+        var root = new DivElement { Class = "box" };
+        var sheet = Sheet("box", new Style
+        {
+            Display = Display.Block,
+            Width = Length.Vw(100) - Length.Px(240),
+            Height = Length.Px(100),
+        });
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, ViewportW, ViewportH);
+
+        layout.BoxModel.Content.Width.ShouldBe(1040f);
+    }
+
+    [Fact]
+    public void VwWorksForPadding()
+    {
+        // padding-left: 10vw → 128px（相对视口宽度，与包含块无关）。
+        var root = new DivElement { Class = "box" };
+        var sheet = Sheet("box", new Style
+        {
+            Display = Display.Block,
+            BoxSizing = BoxSizing.BorderBox,
+            Width = Length.Px(400),
+            Height = Length.Px(100),
+            PaddingLeft = Length.Vw(10),
+        });
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, ViewportW, ViewportH);
+
+        // border-box 下内容左内边距 = 128，内容左边界随之右移。
+        layout.BoxModel.Content.Left.ShouldBe(128f);
+    }
+
+    [Fact]
+    public void VwCssHelper_EquivalentToLengthVw()
+    {
+        // 通过 Css.Vw(...) 辅助方法书写，等价于 Length.Vw(...)。
+        var root = new DivElement { Class = "box" };
+        var sheet = Sheet("box", new Style
+        {
+            Display = Display.Block,
+            Width = Vw(100) - Length.Px(240),
+            Height = Vh(50),
+        });
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, ViewportW, ViewportH);
+
+        layout.BoxModel.Content.Width.ShouldBe(1040f);
+        layout.BoxModel.Content.Height.ShouldBe(ViewportH * 0.5f); // 360
+    }
+
+    [Fact]
+    public void FontSizeVw_ResolvesAgainstViewportWidth()
+    {
+        // font-size: 5vw → 64px（1280 的 5%）。验证 font-size 的 vw 先于 em 折算。
+        var root = new DivElement { Class = "box" };
+        var sheet = Sheet("box", new Style
+        {
+            Display = Display.Block,
+            FontSize = Length.Vw(5),
+        });
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, ViewportW, ViewportH);
+
+        layout.ComputedStyle.FontSize.ToPixels(0).ShouldBe(64f);
+    }
+
+    [Fact]
+    public void EmResolvesAgainstVwFontSize()
+    {
+        // 父 font-size: 5vw (=64px)，子 width: 2em → 相对父字体大小 = 128px。
+        // 验证父 font-size 的 vw 已折算成 px，供子元素 em 正确解析。
+        var parent = new DivElement { Class = "parent" };
+        var child = new DivElement { Class = "child" };
+        parent.AddChild(child);
+
+        var sheet = new StyleSheet
+        {
+            Rules = new List<StyleRule>
+            {
+                new() { Selector = new ClassSelector("parent"),
+                        Style = new Style { Display = Display.Block, FontSize = Length.Vw(5) } },
+                new() { Selector = new ClassSelector("child"),
+                        Style = new Style { Display = Display.Block, Width = Length.Em(2) } },
+            }
+        };
+
+        var layout = _layoutEngine.Layout(parent, new List<StyleSheet> { sheet }, ViewportW, ViewportH);
+        var childBox = FindByClass(layout, "child");
+
+        childBox.ShouldNotBeNull();
+        childBox!.BoxModel.Content.Width.ShouldBe(128f); // 2 * 64
+    }
+}

--- a/tests/Miko.Tests/Styling/CalcTests.cs
+++ b/tests/Miko.Tests/Styling/CalcTests.cs
@@ -1,0 +1,278 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Styling;
+using Shouldly;
+using static Miko.Styling.Css;
+
+namespace Miko.Tests.Styling;
+
+/// <summary>
+/// calc() 表达式（含变量的延迟算术）的单元测试（ISSUE-090）。
+/// 覆盖：issue 原样例、直接/Calc 包装/作用域 lambda 三种写法、各类运算符、回退值、
+/// 未解析回退默认、类型不匹配、百分比等相对单位保留。
+/// </summary>
+public class CalcTests
+{
+    private static ComputedStyle Resolve(Element element, StyleSheet sheet)
+        => new StyleResolver().Resolve(element, [sheet]);
+
+    [Fact]
+    public void Calc_IssueExample_NegativeVarBorderWidth_Resolves()
+    {
+        // .page-item { margin-left: calc(-1 * var(--bs-border-width)); }
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".page-item"] = new()
+            {
+                MarginLeft = -1 * Var("--bs-border-width"),
+                Vars = new() { ["--bs-border-width"] = Length.Px(1) }
+            }
+        });
+
+        var element = new DivElement { Class = "page-item" };
+        Resolve(element, sheet).MarginLeft.ShouldBe(Length.Px(-1));
+    }
+
+    [Fact]
+    public void Calc_DirectExpression_NoLambda_Resolves()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                MarginLeft = -1 * Var("--w"),
+                Vars = new() { ["--w"] = Length.Px(4) }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).MarginLeft.ShouldBe(Length.Px(-4));
+    }
+
+    [Fact]
+    public void Calc_WrapperWithScopeLambda_FreeVar_Resolves()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                MarginLeft = Calc(s => -1 * Var("--w")),
+                Vars = new() { ["--w"] = Length.Px(4) }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).MarginLeft.ShouldBe(Length.Px(-4));
+    }
+
+    [Fact]
+    public void Calc_WrapperWithScopeLambda_ScopeVar_Resolves()
+    {
+        // s.Var(...) 与自由 Var(...) 等价。
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                MarginLeft = Calc(s => -1 * s.Var("--w")),
+                Vars = new() { ["--w"] = Length.Px(10) }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).MarginLeft.ShouldBe(Length.Px(-10));
+    }
+
+    [Fact]
+    public void Calc_WrapperPassthrough_Resolves()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                MarginLeft = Calc(-1 * Var("--w")),
+                Vars = new() { ["--w"] = Length.Px(3) }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).MarginLeft.ShouldBe(Length.Px(-3));
+    }
+
+    [Fact]
+    public void Calc_Addition_TwoVars_Resolves()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                Width = Calc(s => s.Var("--x") + s.Var("--y")),
+                Vars = new() { ["--x"] = Length.Px(4), ["--y"] = Length.Px(10) }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).Width.ShouldBe(Length.Px(14));
+    }
+
+    [Fact]
+    public void Calc_Division_Resolves()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                Width = Var("--x") / 2f,
+                Vars = new() { ["--x"] = Length.Px(8) }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).Width.ShouldBe(Length.Px(4));
+    }
+
+    [Fact]
+    public void Calc_Multiplication_VarTimesFloat_Resolves()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                Width = Var("--x") * 3f,
+                Vars = new() { ["--x"] = Length.Px(5) }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).Width.ShouldBe(Length.Px(15));
+    }
+
+    [Fact]
+    public void Calc_UnaryNegate_Resolves()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                MarginLeft = -Var("--x"),
+                Vars = new() { ["--x"] = Length.Px(6) }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).MarginLeft.ShouldBe(Length.Px(-6));
+    }
+
+    [Fact]
+    public void Calc_Subtraction_VarMinusVar_Resolves()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                Width = Var("--x") - Var("--y"),
+                Vars = new() { ["--x"] = Length.Px(10), ["--y"] = Length.Px(3) }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).Width.ShouldBe(Length.Px(7));
+    }
+
+    [Fact]
+    public void Calc_VarPlusLiteralLength_Resolves()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                Width = Var("--x") + Length.Px(2),
+                Vars = new() { ["--x"] = Length.Px(8) }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).Width.ShouldBe(Length.Px(10));
+    }
+
+    [Fact]
+    public void Calc_VarWithFallback_UsesFallbackWhenMissing()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                // --missing 未定义，calc 内变量走回退值 7px。
+                MarginLeft = -1 * Var("--missing", Length.Px(7))
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).MarginLeft.ShouldBe(Length.Px(-7));
+    }
+
+    [Fact]
+    public void Calc_MissingVar_NoFallback_KeepsDefault()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                MarginLeft = -1 * Var("--missing")
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        // 未解析 → 属性视为未设置 → 保留 ComputedStyle 的 MarginLeft 默认（0px）。
+        Resolve(element, sheet).MarginLeft.ShouldBe(Length.Px(0));
+    }
+
+    [Fact]
+    public void Calc_WrongTypeVar_KeepsDefault_NoCrash()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                // --c 是颜色，不能作为长度参与 calc → 未解析 → 保留默认（0px）。
+                MarginLeft = -1 * Var("--c"),
+                Vars = new() { ["--c"] = (Color)"#FF0000" }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).MarginLeft.ShouldBe(Length.Px(0));
+    }
+
+    [Fact]
+    public void Calc_PreservesPercentComponent()
+    {
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".box"] = new()
+            {
+                // 百分比在 calc 中不提前折算，一路保留到布局阶段。
+                Width = -1 * Var("--x"),
+                Vars = new() { ["--x"] = Length.Percent(50) }
+            }
+        });
+
+        var element = new DivElement { Class = "box" };
+        Resolve(element, sheet).Width.ShouldBe(Length.Percent(-50));
+    }
+}


### PR DESCRIPTION
## Overview

Implements ISSUE-091: add support for CSS viewport length units `vw`/`vh`, including usage within `calc()` expressions.

- `1vw` = 1% of viewport width, `1vh` = 1% of viewport height
- Supports basic usage (`width: 100vw`) and `calc()` composition (`width: calc(100vw - 240px)`)
- The resolution model mirrors `env()`/`ResolveSafeArea`, folding into concrete pixel values during style computation

## Key Changes

- **Length**: add vw/vh components, `Vw`/`Vh` factories, `ResolveViewport` folding, plus arithmetic/`ToString`/`Value`/`Unit` support so they compose in `calc()`
- **ComputedStyle**: `ResolveViewport` folds vw/vh across all length properties; font-size vw/vh is folded in `FromStyle` before em resolution
- **LayoutEngine**: wires `ResolveViewport` into the style computation flow (including pseudo-elements)
- **Css**: add `Css.Vw`/`Css.Vh` helpers, enabling `calc(100vw - 240px)`-style expressions
- Also includes the prior staged ISSUE-090 `calc()` groundwork

## Tests

- `ViewportLengthTests`: Length-level vw/vh coverage
- `ViewportUnitsLayoutTests`: end-to-end layout coverage
- `CalcTests`: calc() expression coverage

Fixes ISSUE-091