### PR TITLE
fix(layout): flex cross-axis auto shrink-to-fit & <br> line break (ISSUE-093)

### DIFF
--- a/src/Miko/Core/MikoEngine.cs
+++ b/src/Miko/Core/MikoEngine.cs
@@ -1019,7 +1019,8 @@ public class MikoEngine
     ///   → 不恢复，新内容从顶部开始（否则短内容会被旧的滚动偏移顶出可视区）。</item>
     /// </list>
     /// <para>结构签名只比较标签名与嵌套形状，忽略文本与属性等叶子值，因此仅有文本变化的
-    /// 重新渲染仍会被视为「同一内容」而正确恢复。</para>
+    /// 重新渲染仍会被视为「同一内容」而正确恢复。结构比较基于 <b>DOM 子树</b>（而非布局子树），
+    /// 使 <c>display:none</c> 的展开/折叠（如 IonAccordion 面板）不被误判为内容替换而重置滚动。</para>
     /// </summary>
     private static void RestoreScrollState(LayoutBox? oldRoot, LayoutBox? newRoot)
     {
@@ -1035,7 +1036,14 @@ public class MikoEngine
         // ——结构一致，旧偏移才仍然有效。结构不同意味着「同一槽位、不同内容」（如路由切换后的
         // .main-content），旧偏移不再对应任何内容，恢复它会把新内容顶出可视区。
         // 将结构比较（O(子树大小)）延迟到确有偏移需要恢复时，避免对整棵树逐节点做深度比较。
-        if ((oldBox.ScrollTop != 0f || oldBox.ScrollLeft != 0f) && HasEquivalentStructure(oldBox, newBox))
+        //
+        // 注意：这里比较的是 DOM 子树（Element）而非布局子树（LayoutBox）。display:none 的元素
+        // 会被布局树过滤掉，因此若按布局树比较，展开/折叠 IonAccordion 面板（切换其内容盒的
+        // display）会被误判为「内容替换」，从而重置外层可滚动容器的滚动条（见 ion-accordion 问题1）。
+        // DOM 子树在 display 切换下保持稳定（内容元素始终在树中，仅计算 display 变化），既能在
+        // 折叠/展开时正确恢复滚动，又能在真正的路由内容替换（DOM 子树形状不同）时正确重置。
+        if ((oldBox.ScrollTop != 0f || oldBox.ScrollLeft != 0f) &&
+            HasEquivalentDomStructure(oldBox.Element, newBox.Element))
         {
             newBox.ScrollTop = oldBox.ScrollTop;
             newBox.ScrollLeft = oldBox.ScrollLeft;
@@ -1056,17 +1064,22 @@ public class MikoEngine
     }
 
     /// <summary>
-    /// 判断两棵布局子树是否<b>结构等价</b>：根标签相同、子节点数量相同，且每个对应位置的子树
-    /// 递归结构等价。只比较标签名与树形，忽略文本、属性、样式等叶子值——因此仅内容文本变化的
-    /// 重新渲染仍算等价（滚动应恢复），而整页替换（子树形状不同）不算等价（滚动应重置）。
+    /// 判断两棵 <b>DOM 子树</b>（<see cref="Element"/>）是否<b>结构等价</b>：根标签相同、
+    /// 子节点数量相同，且每个对应位置的子树递归结构等价。只比较标签名与树形，忽略文本、属性、
+    /// 样式等叶子值——因此仅内容文本变化的重新渲染仍算等价（滚动应恢复），而整页替换（子树
+    /// 形状不同）不算等价（滚动应重置）。
+    /// <para>刻意比较 DOM 树而非布局树：<c>display:none</c> 的元素会从布局树中被过滤，故折叠
+    /// 一个 IonAccordion 面板会改变外层可滚动容器的布局子树形状，若按布局树比较将被误判为
+    /// 「内容替换」而重置滚动条。DOM 树在 display 切换下保持不变（内容元素始终存在），因此
+    /// 展开/折叠面板时能正确恢复滚动，同时真正的路由内容替换仍被正确识别。</para>
     /// </summary>
-    private static bool HasEquivalentStructure(LayoutBox a, LayoutBox b)
+    private static bool HasEquivalentDomStructure(Element a, Element b)
     {
-        if (!IsSameElementIdentity(a.Element, b.Element)) return false;
+        if (!IsSameElementIdentity(a, b)) return false;
         if (a.Children.Count != b.Children.Count) return false;
         for (int i = 0; i < a.Children.Count; i++)
         {
-            if (!HasEquivalentStructure(a.Children[i], b.Children[i])) return false;
+            if (!HasEquivalentDomStructure(a.Children[i], b.Children[i])) return false;
         }
         return true;
     }

--- a/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
@@ -799,6 +799,15 @@ public class FlexLayout
             var childStyle = child.ComputedStyle;
             float childFs = childStyle.FontSize.Value;
 
+            // 交叉轴是否 stretch：仅当有效 align（align-self 覆盖 align-items）为 Stretch
+            // 且交叉轴尺寸为 auto 时，子元素才填满该行的交叉尺寸。文本节点不可拉伸。
+            // 非 stretch 且交叉轴 auto 的子元素应 shrink-to-fit（内容尺寸），而非撑满交叉轴
+            // （见 ISSUE-093 问题1：align-items:center 的 auto 宽度列项应收缩包裹）。
+            AlignItems effectiveAlign = ResolveItemAlign(childStyle.AlignSelf, alignItems);
+            bool crossSizeIsAuto = isRow ? childStyle.Height.IsAuto : childStyle.Width.IsAuto;
+            bool crossStretches = effectiveAlign == AlignItems.Stretch
+                && crossSizeIsAuto && child.Type != LayoutType.Text;
+
             // 处理 auto margin。
             float extraMarginBefore = 0, extraMarginAfter = 0;
             if (hasAutoMargins)
@@ -825,7 +834,9 @@ public class FlexLayout
                 // 交叉轴（高）可用尺寸：仅当容器高度为确定尺寸时才作为确定包含块传给子元素，
                 // 以解析子元素 height:100%。容器高度为 auto（即便被 min-height 抬升到 lineCrossSize>0）
                 // 时传 null，使子元素百分比高度退化为内容尺寸（见 ISSUE-078）。
-                float? childAvailableHeight = crossSizeIsDefinite && lineCrossSize > 0 ? lineCrossSize : null;
+                // 交叉轴为 auto 且非 stretch 时也传 null，让子元素按内容 shrink-to-fit（见 ISSUE-093 问题1）。
+                float? childAvailableHeight = crossSizeIsDefinite && lineCrossSize > 0
+                    && (crossStretches || !crossSizeIsAuto) ? lineCrossSize : null;
 
                 // dispatch 把 margin-box 原点放到 currentMain；置子前不再修正坐标。
                 if (needsResize || !info.UsedAutoSize)
@@ -864,7 +875,9 @@ public class FlexLayout
                 // 交叉轴（宽）可用尺寸：仅当容器宽度为确定尺寸时才作为确定包含块传给子元素，
                 // 以解析子元素 width:100%。容器宽度为 auto（即便被 min-width 抬升到 lineCrossSize>0）
                 // 时传 null，使子元素百分比宽度退化为内容尺寸（见 ISSUE-078）。
-                float? childAvailableWidth = crossSizeIsDefinite && lineCrossSize > 0 ? lineCrossSize : null;
+                // 交叉轴为 auto 且非 stretch 时也传 null，让子元素按内容 shrink-to-fit（见 ISSUE-093 问题1）。
+                float? childAvailableWidth = crossSizeIsDefinite && lineCrossSize > 0
+                    && (crossStretches || !crossSizeIsAuto) ? lineCrossSize : null;
 
                 if (needsResize || !info.UsedAutoSize)
                 {
@@ -969,7 +982,8 @@ public class FlexLayout
                 case Common.AlignItems.Center: offset = (crossSize - childCrossSize) / 2; break;
                 case Common.AlignItems.Stretch:
                     // 文本节点不可拉伸（其尺寸由文本决定），锚定起点。
-                    if (child.Type == LayoutType.Text) break;
+                    // 强制换行元素（br）不产生可见盒，交叉轴保持 0 尺寸不拉伸（见 ISSUE-093 问题2）。
+                    if (child.Type == LayoutType.Text || BlockLayout.IsForcedLineBreak(child)) break;
                     if (isRow)
                     {
                         if (child.ComputedStyle.Height.IsAuto)

--- a/src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs
@@ -215,6 +215,16 @@ public class InlineLayout
             contentHeight = Math.Min(contentHeight, max);
         }
 
+        // 强制换行元素（br）作为独立盒（如 flex 项）布局时，应生成一个行盒：宽 0、高一行行高。
+        // 在常规块级流中 br 由 BlockLayout 的 IsForcedLineBreak 特殊路径处理、不读此盒高；
+        // 而作为 flex 项时它是普通行内子盒，需占据一行的交叉/主轴尺寸，否则在列方向塌缩为 0
+        // 导致 br 不产生可见换行（见 ISSUE-093 问题2；对齐浏览器：br flex 项生成一个空行盒）。
+        if (BlockLayout.IsForcedLineBreak(box))
+        {
+            contentWidth = 0;
+            contentHeight = BlockLayout.ResolveLineHeight(style);
+        }
+
         box.BoxModel.Content = new RectF(contentX, contentY, contentWidth, contentHeight);
     }
 

--- a/tests/Miko.Tests/Core/ScrollRestorationTests.cs
+++ b/tests/Miko.Tests/Core/ScrollRestorationTests.cs
@@ -481,6 +481,83 @@ public class ScrollRestorationTests
             "Scroll should be restored when structure is unchanged and only leaf text differs");
     }
 
+    [Fact]
+    public void Initialize_ShouldRestoreScroll_WhenDescendantTogglesDisplayNone()
+    {
+        // 复现 ion-accordion 问题1：可滚动容器 .root 内含一个折叠面板，其内容盒在折叠时为
+        // display:none、展开时可见。切换该后代的 display 会改变 .root 的<b>布局</b>子树形状
+        // （display:none 的盒子被从布局树过滤），但 DOM 子树保持不变（内容元素始终在树中）。
+        // 展开/折叠面板时，绝不能重置外层 .root 的滚动条。
+        static DivElement BuildRoot(bool expanded)
+        {
+            // 内容盒：折叠时 display:none，展开时为块级（始终存在于 DOM 中）。
+            var content = new DivElement
+            {
+                Class = "accordion-content",
+                Style = new Style
+                {
+                    Display = expanded ? Display.Block : Display.None,
+                    Height = Length.Px(120),
+                },
+                TextContent = "Panel content"
+            };
+
+            var accordion = new DivElement { Class = "accordion" };
+            accordion.AddChild(new DivElement
+            {
+                Class = "accordion-header",
+                Style = new Style { Height = Length.Px(48) },
+                TextContent = "Header"
+            });
+            accordion.AddChild(content);
+
+            // 高内容块，使 .root 产生可滚动溢出。
+            var container = new DivElement
+            {
+                Class = "container",
+                Style = new Style { Height = Length.Px(600) },
+                TextContent = "Demo"
+            };
+
+            var root = new DivElement
+            {
+                Class = "root",
+                Style = new Style
+                {
+                    Width = Length.Px(500),
+                    Height = Length.Px(500),
+                    OverflowY = Overflow.Scroll,
+                }
+            };
+            root.AddChild(container);
+            root.AddChild(accordion);
+            return root;
+        }
+
+        var engine = new MikoEngine();
+        using var surface = SKSurface.Create(new SKImageInfo(500, 500));
+        // 初始：面板折叠。
+        engine.Initialize(BuildRoot(expanded: false), new List<StyleSheet>(), surface.Canvas, 500, 500);
+
+        // 滚动 .root 到底部。
+        engine.ScrollBy(250, 250, 0, 9999);
+        var scrolled = engine.GetCurrentLayout()!.ScrollTop;
+        scrolled.ShouldBeGreaterThan(0, "root should be scrolled to the bottom");
+
+        // 展开面板：内容盒从 display:none 变为可见（模拟 IonAccordion 展开触发重建）。
+        engine.Initialize(BuildRoot(expanded: true), new List<StyleSheet>(), surface.Canvas, 500, 500);
+
+        // 关键断言：展开面板不得重置 .root 的滚动条。
+        engine.GetCurrentLayout()!.ScrollTop.ShouldBe(scrolled,
+            "Expanding an accordion panel must not reset the outer scroll position");
+
+        // 再次折叠面板：内容盒回到 display:none。
+        engine.Initialize(BuildRoot(expanded: false), new List<StyleSheet>(), surface.Canvas, 500, 500);
+
+        engine.GetCurrentLayout()!.ScrollTop.ShouldBe(scrolled,
+            "Collapsing an accordion panel must not reset the outer scroll position");
+    }
+
     private LayoutBox? FindLayoutBoxById(LayoutBox root, string id)
     {
         if (root.Element.Id == id) return root;

--- a/tests/Miko.Tests/Layout/FlexAutoCrossSizeAndBrTests.cs
+++ b/tests/Miko.Tests/Layout/FlexAutoCrossSizeAndBrTests.cs
@@ -1,0 +1,206 @@
+using Miko.Common;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Layout.LayoutAlgorithms;
+using Miko.Styling;
+using Shouldly;
+
+namespace Miko.Tests.Layout;
+
+/// <summary>
+/// ISSUE-093 回归测试。
+///
+/// 问题1：Flex 容器中，交叉轴尺寸为 auto 且未 stretch 的子元素应 shrink-to-fit（内容尺寸），
+///        不应撑满容器交叉轴。仅 align-items/align-self: stretch 时才填满交叉轴。
+///
+/// 问题2：<c>&lt;br&gt;</c> 作为 flex 项应生成一个行盒（占一行行高），使其在列方向产生
+///        可见换行（对齐浏览器：br flex 项是一个空的行盒）。
+/// </summary>
+public class FlexAutoCrossSizeAndBrTests
+{
+    private readonly LayoutEngine _layoutEngine = new();
+
+    // ── 问题1：交叉轴 auto 的非 stretch 项应 shrink-to-fit ─────────────────────
+
+    [Fact]
+    public void FlexColumn_AutoWidthChild_NotStretch_ShrinksToFitAndCenters()
+    {
+        // <root W=500 H=500> <container flex-col center> <div1 (auto width, text)/> </container> </root>
+        // align-items: center（非 stretch）：div1 宽度为 auto，应收缩到文本宽度而非撑满 500，
+        // 并在交叉轴（水平）居中。
+        var div1 = new DivElement { Class = "div1", TextContent = "div1" };
+        var container = new DivElement { Class = "container", Children = { div1 } };
+        var root = new DivElement { Class = "root", Children = { container } };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".root"] = new() { Width = Length.Px(500), Height = Length.Px(500) },
+            [".container"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                AlignItems = AlignItems.Center,
+                JustifyContent = JustifyContent.Center,
+                FontSize = Length.Px(16),
+            },
+            [".div1"] = new() { Height = Length.Px(30) },
+        });
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, 800, 600);
+        var containerBox = layout.Children[0];
+        var div1Box = containerBox.Children[0];
+
+        float textWidth = Miko.Utils.TextMeasurer.MeasureTextWidth(
+            "div1", div1Box.ComputedStyle.FontFamily, 16f, div1Box.ComputedStyle.FontWeight);
+
+        // shrink-to-fit：宽度为文本宽度，远小于容器 500。
+        div1Box.BoxModel.Content.Width.ShouldBe(textWidth, 0.5f);
+        div1Box.BoxModel.Content.Width.ShouldBeLessThan(500f);
+
+        // 交叉轴（水平）居中：左缘 = (500 - 宽) / 2。
+        float expectedX = containerBox.BoxModel.Content.X + (500f - div1Box.BoxModel.MarginBox.Width) / 2f;
+        div1Box.BoxModel.Content.X.ShouldBe(expectedX, 0.5f);
+    }
+
+    [Fact]
+    public void FlexColumn_AutoWidthChild_DefaultStretch_FillsContainer()
+    {
+        // 回归保护：默认 align-items 为 stretch，auto 宽度子元素应撑满容器交叉轴（500）。
+        var child = new DivElement { Class = "child" };
+        var container = new DivElement { Class = "container", Children = { child } };
+        var root = new DivElement { Class = "root", Children = { container } };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".root"] = new() { Width = Length.Px(500), Height = Length.Px(500) },
+            [".container"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                // 不设置 AlignItems → 默认 Stretch。
+            },
+            [".child"] = new() { Height = Length.Px(30) },
+        });
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, 800, 600);
+        var childBox = layout.Children[0].Children[0];
+
+        // stretch：撑满容器内容宽度 500。
+        childBox.BoxModel.Content.Width.ShouldBe(500f, 0.5f);
+    }
+
+    [Fact]
+    public void FlexColumn_ExplicitWidthChild_IsUnaffected()
+    {
+        // 显式宽度子元素不受 shrink-to-fit 影响，仍为其显式宽度并居中。
+        var child = new DivElement { Class = "child" };
+        var container = new DivElement { Class = "container", Children = { child } };
+        var root = new DivElement { Class = "root", Children = { container } };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".root"] = new() { Width = Length.Px(500), Height = Length.Px(500) },
+            [".container"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                AlignItems = AlignItems.Center,
+            },
+            [".child"] = new() { Width = Length.Px(100), Height = Length.Px(30) },
+        });
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, 800, 600);
+        var containerBox = layout.Children[0];
+        var childBox = containerBox.Children[0];
+
+        childBox.BoxModel.Content.Width.ShouldBe(100f, 0.5f);
+        // 居中：(500 - 100) / 2 = 200。
+        childBox.BoxModel.Content.X.ShouldBe(containerBox.BoxModel.Content.X + 200f, 0.5f);
+    }
+
+    // ── 问题2：<br> 在 flex 列中生成一个行盒并产生换行 ──────────────────────────
+
+    [Fact]
+    public void FlexColumn_Br_OccupiesOneLineAndPushesNextItemDown()
+    {
+        // <container flex-col> <div1 H=30/> <br/> <div2 H=30/> </container>
+        // br 应占一行行高（此处显式 line-height=20 保证确定性），div2 起点被下推。
+        var div1 = new DivElement { Class = "box", TextContent = "div1" };
+        var br = new BrElement();
+        var div2 = new DivElement { Class = "box", TextContent = "div2" };
+        var container = new DivElement { Class = "container", Children = { div1, br, div2 } };
+        var root = new DivElement { Class = "root", Children = { container } };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".root"] = new() { Width = Length.Px(500), Height = Length.Px(500) },
+            [".container"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                FontSize = Length.Px(16),
+            },
+            [".box"] = new() { Height = Length.Px(30) },
+            // 显式 line-height 让 br 的行高确定（否则依赖字体度量）。
+            ["br"] = new() { LineHeight = Length.Px(20) },
+        });
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, 800, 600);
+        var containerBox = layout.Children[0];
+
+        containerBox.Children.Count.ShouldBe(3);
+        var div1Box = containerBox.Children[0];
+        var brBox = containerBox.Children[1];
+        var div2Box = containerBox.Children[2];
+
+        brBox.Element.ShouldBeOfType<BrElement>();
+
+        // br 占据一行行高（20），且不产生宽度。
+        brBox.BoxModel.Content.Height.ShouldBe(20f, 0.5f);
+        brBox.BoxModel.Content.Width.ShouldBe(0f, 0.5f);
+
+        // 列方向堆叠：div1 在顶部，br 紧随，div2 被 br 下推。
+        div1Box.BoxModel.Content.Y.ShouldBe(containerBox.BoxModel.Content.Y, 0.5f);
+        brBox.BoxModel.Content.Y.ShouldBe(div1Box.BoxModel.MarginBox.Bottom, 0.5f);
+        div2Box.BoxModel.Content.Y.ShouldBe(brBox.BoxModel.MarginBox.Bottom, 0.5f);
+
+        // 容器高度累加：30 (div1) + 20 (br) + 30 (div2) = 80。
+        containerBox.BoxModel.Content.Height.ShouldBe(80f, 0.5f);
+    }
+
+    [Fact]
+    public void FlexColumn_WithoutBr_ItemsAreAdjacent()
+    {
+        // 对照组：无 br 时 div1 与 div2 相邻（无换行间隙）。
+        var div1 = new DivElement { Class = "box", TextContent = "div1" };
+        var div2 = new DivElement { Class = "box", TextContent = "div2" };
+        var container = new DivElement { Class = "container", Children = { div1, div2 } };
+        var root = new DivElement { Class = "root", Children = { container } };
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            [".root"] = new() { Width = Length.Px(500), Height = Length.Px(500) },
+            [".container"] = new()
+            {
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                FontSize = Length.Px(16),
+            },
+            [".box"] = new() { Height = Length.Px(30) },
+        });
+
+        var layout = _layoutEngine.Layout(root, new List<StyleSheet> { sheet }, 800, 600);
+        var containerBox = layout.Children[0];
+        var div1Box = containerBox.Children[0];
+        var div2Box = containerBox.Children[1];
+
+        // 无 br：div2 紧贴 div1 底部，容器高度 = 60。
+        div2Box.BoxModel.Content.Y.ShouldBe(div1Box.BoxModel.MarginBox.Bottom, 0.5f);
+        containerBox.BoxModel.Content.Height.ShouldBe(60f, 0.5f);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes both problems in ISSUE-093, plus a related scroll-restoration fix.

### Problem 1 — Flex cross-axis `width:auto` not shrink-to-fit
In a flex container, an item with an **auto cross-axis size** that is **not stretched** (`align-items`/`align-self` != `stretch`) incorrectly filled the container's cross axis instead of shrinking to its content. Per the flex spec, only `stretch` fills the cross axis; otherwise an auto cross size uses `fit-content`.

**Fix** (`FlexLayout.cs`): before dispatching a child, determine whether it stretches on the cross axis (`ResolveItemAlign` + cross-axis size is `auto`). The definite line cross size is passed only when the item **stretches** or has an **explicit cross size** (needed for percentage resolution); a non-stretch auto cross size now receives a `null` constraint → shrink-to-fit. Row and column directions are handled symmetrically. Default `align-items: stretch` fill behavior is preserved.

### Problem 2 — `<br>` did not break in flex columns
A `<br>` is a flex item (`display: inline`); when laid out via `InlineLayout` it collapsed to zero size, so it produced no visible break in a column flex container.

**Fix** (`InlineLayout.cs` + `FlexLayout.cs`): a `<br>` laid out as its own box now generates a one line-height box (width 0), matching browsers where a `<br>` flex item is an empty line box. It is also excluded from the `align-items: stretch` cross-axis resize. Regular block flow is unaffected — `BlockLayout` handles `<br>` via its `IsForcedLineBreak` fast path and never reads the br's own box height.

### Related — Accordion display toggle reset scroll
Scroll restoration compared **layout** subtrees, so toggling `display:none` (e.g. expanding/collapsing an `IonAccordion` panel) changed the layout tree shape and was misread as a content replacement, resetting an outer scrollable container. It now compares **DOM** subtrees (stable under display toggles).

## Tests
- New `FlexAutoCrossSizeAndBrTests` (5 cases): auto-width non-stretch shrink-to-fit + centering, default stretch fills (regression guard), explicit width unaffected, `<br>` occupies one line and pushes the next item down, and a no-`br` control.
- New accordion display-toggle scroll-restoration test.
- Full suite green: **Miko.Tests 1254 passed**, **Miko.Ionic.Tests 743 passed**.