### PR TITLE
fix(layout): percent min/max-width should be a no-op against an indefinite containing block (ISSUE-094)

### DIFF
--- a/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs
@@ -91,15 +91,19 @@ public class BlockLayout
         // 应用 min/max 约束
         // border-box 下，min/max-width 约束的是 border-box 宽度，需先扣除水平 padding+border
         // 再与内容宽度比较（与上面 Width 的 border-box 处理保持一致）。
+        // 百分比 min/max-width 针对不确定宽度的包含块（如在 shrink-to-fit 路径下 containerWidth<=0）
+        // 应退化为"无约束"，而非折算为 0 把内容宽度夹取归零（见 ISSUE-094；与 ISSUE-077 的百分比宽度
+        // 退化处理一致）。
         bool isBorderBoxW = style.BoxSizing == BoxSizing.BorderBox;
+        bool widthCbIndefinite = constraints.IsInfiniteWidth || containerWidth <= 0;
         float horizontalExtra = box.BoxModel.Border.Horizontal + box.BoxModel.Padding.Horizontal;
-        if (!style.MinWidth.IsAuto)
+        if (!style.MinWidth.IsAuto && !(style.MinWidth.HasPercentComponent && widthCbIndefinite))
         {
             float min = style.MinWidth.ToPixels(containerWidth, fs);
             if (isBorderBoxW) min = Math.Max(0, min - horizontalExtra);
             contentWidth = Math.Max(contentWidth, min);
         }
-        if (!style.MaxWidth.IsAuto)
+        if (!style.MaxWidth.IsAuto && !(style.MaxWidth.HasPercentComponent && widthCbIndefinite))
         {
             float max = style.MaxWidth.ToPixels(containerWidth, fs);
             if (isBorderBoxW) max = Math.Max(0, max - horizontalExtra);

--- a/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs
@@ -157,7 +157,10 @@ public class FlexLayout
         // 未约束的容器宽度计算，导致子元素超出容器（见 ISSUE-081 IonCard 在 Flex 容器中宽度问题）。
         bool isBorderBoxW_Early = style.BoxSizing == BoxSizing.BorderBox;
         float horizontalExtra_Early = box.BoxModel.Border.Horizontal + box.BoxModel.Padding.Horizontal;
-        if (!style.MaxWidth.IsAuto)
+        // 百分比 max-width 针对不确定宽度的包含块应退化为"无约束"，而非折算为 0 把内容夹取归零
+        // （见 ISSUE-094；与 widthPercentAgainstIndefinite 的百分比宽度退化一致）。
+        bool widthCbIndefinite = constraints.IsInfiniteWidth || (constraints.AvailableWidth ?? 0) <= 0;
+        if (!style.MaxWidth.IsAuto && !(style.MaxWidth.HasPercentComponent && widthCbIndefinite))
         {
             float max = style.MaxWidth.ToPixels(constraints.AvailableWidth ?? 0, fs);
             if (isBorderBoxW_Early) max = Math.Max(0, max - horizontalExtra_Early);
@@ -300,15 +303,16 @@ public class FlexLayout
         }
 
         // 7. 应用 min-width/max-width 约束
+        // 百分比 min/max-width 针对不确定宽度的包含块退化为"无约束"（见 ISSUE-094）。
         bool isBorderBoxW = style.BoxSizing == BoxSizing.BorderBox;
         float horizontalExtra = box.BoxModel.Border.Horizontal + box.BoxModel.Padding.Horizontal;
-        if (!style.MinWidth.IsAuto)
+        if (!style.MinWidth.IsAuto && !(style.MinWidth.HasPercentComponent && widthCbIndefinite))
         {
             float min = style.MinWidth.ToPixels(constraints.AvailableWidth ?? 0, fs);
             if (isBorderBoxW) min = Math.Max(0, min - horizontalExtra);
             contentWidth = Math.Max(contentWidth, min);
         }
-        if (!style.MaxWidth.IsAuto)
+        if (!style.MaxWidth.IsAuto && !(style.MaxWidth.HasPercentComponent && widthCbIndefinite))
         {
             float max = style.MaxWidth.ToPixels(constraints.AvailableWidth ?? 0, fs);
             if (isBorderBoxW) max = Math.Max(0, max - horizontalExtra);

--- a/src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs
+++ b/src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs
@@ -135,13 +135,19 @@ public class InlineLayout
         float horizontalExtra = box.BoxModel.Border.Horizontal + box.BoxModel.Padding.Horizontal;
         float verticalExtra = box.BoxModel.Border.Vertical + box.BoxModel.Padding.Vertical;
 
-        if (!style.MinWidth.IsAuto)
+        // 百分比 min/max-width 针对不确定宽度的包含块退化为"无约束"，而非折算为 0 把内容夹取归零
+        // （见 ISSUE-094；与 widthPercentAgainstIndefinite 的百分比宽度退化一致）。
+        bool widthCbIndefinite = !constraints.AvailableWidth.HasValue || constraints.AvailableWidth.Value <= 0;
+        bool minWidthEffective = !style.MinWidth.IsAuto && !(style.MinWidth.HasPercentComponent && widthCbIndefinite);
+        bool maxWidthEffective = !style.MaxWidth.IsAuto && !(style.MaxWidth.HasPercentComponent && widthCbIndefinite);
+
+        if (minWidthEffective)
         {
             float min = style.MinWidth.ToPixels(containerWidth, fs);
             if (isBorderBox) min = Math.Max(0, min - horizontalExtra);
             contentWidth = Math.Max(contentWidth, min);
         }
-        if (!style.MaxWidth.IsAuto)
+        if (maxWidthEffective)
         {
             float max = style.MaxWidth.ToPixels(containerWidth, fs);
             if (isBorderBox) max = Math.Max(0, max - horizontalExtra);
@@ -152,7 +158,8 @@ public class InlineLayout
         // 重排在流子元素，使子元素的 width:100% 能解析到父内容宽度（浏览器行为）。
         // 高度传 null 保持不确定——min-height 撑起的高度不使百分比高度可解析（见 ISSUE-078）。
         // 注意：auto 宽度且无 min/max-width 时不重排，保持 shrink-to-fit 的内容尺寸（见 ISSUE-077）。
-        bool widthIsDefinite = !widthIsAuto || !style.MinWidth.IsAuto || !style.MaxWidth.IsAuto;
+        // 针对不确定包含块退化的百分比 min/max-width 不计入"确定宽度"（见 ISSUE-094）。
+        bool widthIsDefinite = !widthIsAuto || minWidthEffective || maxWidthEffective;
         if (widthIsDefinite && contentWidth > 0 && box.Children.Count > 0)
         {
             float childX = contentX;

--- a/tests/Miko.Tests/Layout/MaxWidthPercentShrinkToFitTests.cs
+++ b/tests/Miko.Tests/Layout/MaxWidthPercentShrinkToFitTests.cs
@@ -1,0 +1,164 @@
+using Miko.Common;
+using Miko.Core;
+using Miko.Core.DomElements;
+using Miko.Layout;
+using Miko.Styling;
+using Shouldly;
+using SkiaSharp;
+
+namespace Miko.Tests.Layout;
+
+/// <summary>
+/// 复现 ISSUE-094：当元素以 shrink-to-fit（auto 宽度、非 stretch 交叉轴）布局，
+/// 且设置了百分比 max-width 时，百分比针对不确定包含块解析不应折算为 0，
+/// 而应退化为“无约束”（与浏览器一致），使内容宽度保持为内容尺寸。
+/// </summary>
+public class MaxWidthPercentShrinkToFitTests
+{
+    [Fact]
+    public void Label_WithMaxWidthPercent_InCenteredFlexColumn_ShouldNotCollapseToZero()
+    {
+        // Arrange：还原 issue 中的 DOM 结构
+        // .root > .segment > .btn-native > .button-inner > .label("Default")
+        var root = new DivElement { Class = "root" };
+        var segment = new DivElement { Class = "segment" };
+        var btnNative = new DivElement { Class = "btn-native" };
+        var buttonInner = new DivElement { Class = "button-inner" };
+        var label = new DivElement { Class = "label", TextContent = "Default" };
+
+        buttonInner.AddChild(label);
+        btnNative.AddChild(buttonInner);
+        segment.AddChild(btnNative);
+        root.AddChild(segment);
+
+        var sheet = new StyleSheet();
+        sheet.Add(new CssObject
+        {
+            ["*"] = new()
+            {
+                BoxSizing = BoxSizing.BorderBox,
+            },
+            [".root"] = new()
+            {
+                Width = Length.Px(500),
+                Height = Length.Px(500),
+            },
+            [".segment"] = new()
+            {
+                Width = Length.Auto,
+                Height = Length.Auto,
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                JustifyContent = JustifyContent.FlexStart,
+                AlignItems = AlignItems.Stretch,
+                AlignContent = AlignContent.FlexStart,
+                MaxWidth = Length.Px(240),
+            },
+            [".btn-native"] = new()
+            {
+                Width = Length.Percent(100),
+                Height = Length.Auto,
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                JustifyContent = JustifyContent.Center,
+                AlignItems = AlignItems.Center,
+            },
+            [".button-inner"] = new()
+            {
+                Width = Length.Percent(100),
+                Height = Length.Auto,
+                Display = Display.Flex,
+                FlexDirection = FlexDirection.Column,
+                JustifyContent = JustifyContent.Center,
+                AlignItems = AlignItems.Center,
+            },
+            [".label"] = new()
+            {
+                MaxWidth = Length.Percent(100),
+                TextAlign = TextAlign.Center,
+                LineHeight = Length.Px(22),
+                FontSize = Length.Px(13),
+            }
+        });
+
+        using var surface = SKSurface.Create(new SKImageInfo(800, 800));
+        var canvas = surface.Canvas;
+
+        var engine = new MikoEngine();
+        engine.Initialize(root, new List<StyleSheet> { sheet }, canvas, 800, 800);
+
+        // Assert
+        var segmentBox = root.LayoutBox!.Children[0];
+        var btnNativeBox = segmentBox.Children[0];
+        var buttonInnerBox = btnNativeBox.Children[0];
+        var labelBox = buttonInnerBox.Children[0];
+
+        // label 设置了 max-width:100%，其包含块（button-inner）宽度不确定（交叉轴 auto、非 stretch），
+        // 百分比应退化为无约束，label 宽度应为内容宽度（约等于文本 "Default" 的宽度），而不是 0。
+        labelBox.BoxModel.Content.Width.ShouldBeGreaterThan(0f,
+            $"label width should be its content width, not collapsed to 0 (got {labelBox.BoxModel.Content.Width}px)");
+    }
+
+    [Fact]
+    public void Label_WithMaxWidthPercent_ShouldMatchWidthWithoutConstraint()
+    {
+        // max-width:100% 针对不确定包含块解析应为无操作（no-op），
+        // 因此与不设 max-width 的相同结构渲染出的宽度应完全一致（浏览器行为）。
+        float WidthOf(bool withMaxWidth)
+        {
+            var buttonInner = new DivElement { Class = "button-inner" };
+            var label = new DivElement { Class = "label", TextContent = "Default" };
+            buttonInner.AddChild(label);
+
+            var labelStyle = new CssObject
+            {
+                [".button-inner"] = new()
+                {
+                    Width = Length.Auto,
+                    Height = Length.Auto,
+                    Display = Display.Flex,
+                    FlexDirection = FlexDirection.Column,
+                    AlignItems = AlignItems.Center,
+                },
+                [".label"] = new()
+                {
+                    FontSize = Length.Px(13),
+                    LineHeight = Length.Px(22),
+                }
+            };
+            if (withMaxWidth)
+                labelStyle[".label"].MaxWidth = Length.Percent(100);
+
+            var sheet = new StyleSheet();
+            sheet.Add(labelStyle);
+
+            using var surface = SKSurface.Create(new SKImageInfo(800, 800));
+            var engine = new MikoEngine();
+            // button-inner 处于不确定宽度的父约束下（root width auto in a shrink-to-fit context）
+            var host = new DivElement { Class = "host" };
+            host.AddChild(buttonInner);
+            var hostSheet = new StyleSheet();
+            hostSheet.Add(new CssObject
+            {
+                [".host"] = new()
+                {
+                    Display = Display.Flex,
+                    FlexDirection = FlexDirection.Row,
+                    AlignItems = AlignItems.FlexStart,
+                    JustifyContent = JustifyContent.FlexStart,
+                }
+            });
+            hostSheet.Add(labelStyle);
+
+            engine.Initialize(host, new List<StyleSheet> { hostSheet }, surface.Canvas, 800, 800);
+            return host.LayoutBox!.Children[0].Children[0].BoxModel.Content.Width;
+        }
+
+        float withConstraint = WidthOf(withMaxWidth: true);
+        float withoutConstraint = WidthOf(withMaxWidth: false);
+
+        withoutConstraint.ShouldBeGreaterThan(0f);
+        withConstraint.ShouldBe(withoutConstraint, 0.5f,
+            "max-width:100% against an indefinite containing block must be a no-op");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes ISSUE-094: a `.label` with `max-width: 100%` inside a centered flex column rendered with width **0** instead of its content width (browsers render the content width).

## Root cause

When `.label` is laid out as a cross-axis `auto`, non-stretch flex item, it receives `AvailableWidth = null` (shrink-to-fit), so `containerWidth = 0` in the layout algorithms. `max-width: 100%` then resolves as `100% × 0 = 0` and clamps content width to zero.

Per CSS, a percentage min/max-width resolved against an **indefinite** containing block should degrade to "no constraint" (like `none`), not resolve to `0` — consistent with the existing percent-*width* degradation (ISSUE-077/078, via `Length.HasPercentComponent`).

## Changes

Guard the min/max-width application so a percentage constraint is skipped when the containing block width is indefinite (`IsInfiniteWidth || containerWidth <= 0`):

- `src/Miko/Layout/LayoutAlgorithms/BlockLayout.cs`
- `src/Miko/Layout/LayoutAlgorithms/FlexLayout.cs` — early (2c) pre-constraint + final step-7 constraint
- `src/Miko/Layout/LayoutAlgorithms/InlineLayout.cs` — clamp + `widthIsDefinite` check (so a degraded percent max-width no longer wrongly triggers child re-layout)

## Tests

Added `tests/Miko.Tests/Layout/MaxWidthPercentShrinkToFitTests.cs`:
- Reproduces the issue's exact DOM and asserts the label width no longer collapses to 0.
- Confirms setting vs. omitting `max-width: 100%` yields identical widths (proving it's a no-op against an indefinite containing block, matching the browser).

Verified failing before the fix (`got 0px`) and passing after. Full suites green: **1255** Miko tests + **716** Ionic tests.